### PR TITLE
fix css selector for svg based sort icons | checkbox should use creat…

### DIFF
--- a/src/DataTable/Checkbox.js
+++ b/src/DataTable/Checkbox.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, createRef } from 'react';
 import PropTypes from 'prop-types';
 import { handleFunctionProps } from './util';
 
@@ -28,17 +28,24 @@ export default class Checkbox extends PureComponent {
     style: null,
   };
 
+  constructor(props) {
+    super(props);
+
+    this.checkbox = createRef();
+  }
+
+
   componentDidMount() {
     const { indeterminate } = this.props;
 
-    this.el.indeterminate = indeterminate;
+    this.checkbox.current.indeterminate = indeterminate;
   }
 
   componentDidUpdate(prevProps) {
     const { indeterminate } = this.props;
 
     if (prevProps.indeterminate !== indeterminate) {
-      this.el.indeterminate = indeterminate;
+      this.checkbox.current.indeterminate = indeterminate;
     }
   }
 
@@ -66,7 +73,7 @@ export default class Checkbox extends PureComponent {
         {...rest}
         {...resolvedComponentOptions}
         // allow this component to fully control these options
-        ref={el => { this.el = el; }}
+        ref={this.checkbox}
         style={baseStyle}
         onClick={this.handleClick}
         onChange={() => null} // prevent uncontrolled checkbox warnings -  we don't need onChange

--- a/src/DataTable/TableCol.js
+++ b/src/DataTable/TableCol.js
@@ -43,15 +43,18 @@ const SortIcon = styled.span`
   i,
   svg {
     font-size: 18px !important;
-    line-height: 24px;
+    height: 18px !important;
+    width: 18px !important;
     flex-grow: 0;
     flex-shrink: 0;
+    backface-visibility: hidden;
+    transform-style: preserve-3d;
     transition-duration: 0.1s;
     transition-property: transform;
   }
 
   &.desc i,
-  svg {
+  &.desc svg {
     transform: rotate(180deg);
   }
 `;


### PR DESCRIPTION
* svg sort icon was not being selected (would not rotate)
* minor refactor for checkbox to use createRef