### PR TITLE
fix-rows-per-page

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ Nothing new here - we are using an array of object literals and properties to de
 | pagination | bool | no | false | enable pagination with defaults. by default the total record set will be sliced depending on the page, rows per page. if you wish to use server side pagination then use the `paginationServer` property |
 | paginationServer | bool | no | false | changes the default pagination to work with server side pagination |
 | paginationTotalRows | number | no | 0 | allows you to provide the total row count for your table as represented by your API when performing server side pagination. if this property is not provided then react-data-table will use `data.length` |
-| paginationPerPage | number | no | 10 | rows per page |
+| paginationPerPage | number | no | 10 | the default rows per page to use when the table initially loads |
 | paginationRowsPerPageOptions | number | no | [10, 15, 20, 25, 30] | row page dropdown selection options |
-| onChangePage | func | no | null | callback when paged that returns the current page and total row count. e.g. onChangePage(page, totalRows) |
-| onChangeRowsPerPage | func | no | null | callback when rows per page is changed that returns the new rows rowsPerPage
+| onChangePage | func | no | null | callback when paged that returns `onChangePage(page, totalRows)` |
+| onChangeRowsPerPage | func | no | null | callback when rows per page is changed returns `onChangeRowsPerPage(currentRowsPerPage, currentPage)` |
 | paginationComponent | func | no | Pagination | a component that overrides the default paginator component |
 | paginationIconFirstPage |  | no | JSX | a component that overrides the first page icon for the pagination |
 | paginationIconLastPage |  | no | JSX | a component that overrides the last page icon for the pagination |

--- a/src/DataTable/Pagination.js
+++ b/src/DataTable/Pagination.js
@@ -62,14 +62,6 @@ export default class Pagination extends PureComponent {
     return Math.ceil(rowCount / rowsPerPage);
   }
 
-  // TODO: Future numbers implementation
-  // handlePage = e => {
-  //   const { onChangePage } = this.props;
-  //   const currentPage = Number(e.target.id);
-
-  //   onChangePage(currentPage);
-  // }
-
   handlePrevious = () => {
     const { onChangePage, currentPage } = this.props;
 
@@ -94,12 +86,10 @@ export default class Pagination extends PureComponent {
     onChangePage(this.getNumberOfPages());
   }
 
-  handleRowsPerPage = ({ target }) => {
-    const { onChangePage, onChangeRowsPerPage } = this.props;
+  handleRowsPerPage = currentPage => ({ target }) => {
+    const { onChangeRowsPerPage } = this.props;
 
-    onChangeRowsPerPage(Number(target.value));
-    // TODO: fix empty array on perRows change
-    onChangePage(1);
+    onChangeRowsPerPage(Number(target.value), currentPage);
   }
 
   render() {
@@ -115,10 +105,10 @@ export default class Pagination extends PureComponent {
 
     return (
       <DataTableConsumer>
-        {({ paginationPerPage, paginationRowsPerPageOptions, paginationIconLastPage, paginationIconFirstPage, paginationIconNext, paginationIconPrevious }) => (
+        {({ paginationRowsPerPageOptions, paginationIconLastPage, paginationIconFirstPage, paginationIconNext, paginationIconPrevious }) => (
           <React.Fragment>
             <Span>Rows per page:</Span>
-            <Select onChange={this.handleRowsPerPage} defaultValue={paginationPerPage}>
+            <Select onChange={this.handleRowsPerPage(currentPage)} defaultValue={rowsPerPage}>
               {paginationRowsPerPageOptions.map(num => (
                 <option
                   key={num}

--- a/src/DataTable/__tests__/DataTable.test.js
+++ b/src/DataTable/__tests__/DataTable.test.js
@@ -327,7 +327,7 @@ describe('Pagination', () => {
     );
 
     fireEvent.change(container.querySelector('select'), { target: { value: 20 } });
-    expect(onChangeRowsPerPageMock).toBeCalledWith(20);
+    expect(onChangeRowsPerPageMock).toBeCalledWith(20, 1);
   });
 });
 

--- a/src/DataTable/__tests__/Pagination.test.js
+++ b/src/DataTable/__tests__/Pagination.test.js
@@ -242,7 +242,6 @@ describe('when clicking the Previous Page button', () => {
     );
 
     fireEvent.change(container.querySelector('select'), { target: { value: 20 } });
-    expect(onChangeRowsPerPageMock).toBeCalledWith(20);
-    expect(onChangePageMock).toBeCalledWith(1);
+    expect(onChangeRowsPerPageMock).toBeCalledWith(20, 2);
   });
 });

--- a/stories/DataTable/ServerSide/AdvancedPaginationTable.stories.js
+++ b/stories/DataTable/ServerSide/AdvancedPaginationTable.stories.js
@@ -1,0 +1,98 @@
+
+import React, { Component } from 'react';
+import axios from 'axios';
+import { storiesOf } from '@storybook/react';
+import DataTable from '../../../src/DataTable/DataTable';
+
+const columns = [
+  {
+    name: 'First Name',
+    selector: 'first_name',
+    sortable: true,
+  },
+  {
+    name: 'Last Name',
+    selector: 'last_name',
+    sortable: true,
+  },
+  {
+    name: 'Email',
+    selector: 'email',
+    sortable: true,
+  },
+];
+
+class AdvancedPaginationTable extends Component {
+  state = {
+    data: [],
+    loading: false,
+    totalRows: 0,
+    perPage: 10,
+  };
+
+  async componentDidMount() {
+    const { perPage } = this.state;
+
+    this.setState({ loading: true });
+
+    const response = await axios.get(
+      `https://reqres.in/api/users?page=1&per_page=${perPage}`,
+    );
+
+    this.setState({
+      data: response.data.data,
+      totalRows: response.data.total,
+      loading: false,
+    });
+  }
+
+  handlePageChange = async page => {
+    const { perPage } = this.state;
+
+    this.setState({ loading: true });
+
+    const response = await axios.get(
+      `https://reqres.in/api/users?page=${page}&per_page=${perPage}`,
+    );
+
+    this.setState({
+      loading: false,
+      data: response.data.data,
+    });
+  }
+
+  handlePerRowsChange = async (perPage, page) => {
+    this.setState({ loading: true });
+
+    const response = await axios.get(
+      `https://reqres.in/api/users?page=${page}&per_page=${perPage}`,
+    );
+
+    this.setState({
+      loading: false,
+      data: response.data.data,
+      perPage,
+    });
+  }
+
+  render() {
+    const { loading, data, totalRows } = this.state;
+
+    return (
+      <DataTable
+        title="Users"
+        columns={columns}
+        data={data}
+        progressPending={loading}
+        pagination
+        paginationServer
+        paginationTotalRows={totalRows}
+        onChangeRowsPerPage={this.handlePerRowsChange}
+        onChangePage={this.handlePageChange}
+      />
+    );
+  }
+}
+
+storiesOf('Advanced', module)
+  .add('Server-Side Pagination', () => <AdvancedPaginationTable />);


### PR DESCRIPTION
* Switching the rows per page when on the last row and using client-side paging will now correctly navigate to the last page instead of page 1
* when using `paginationServer` page navigation will be bypassed
* server-side pagination storybook example
* closes #89 