### PR TITLE
[Feature] Disable expander in some rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Nothing new here - we are using an array of object literals and properties to de
 | selectableRowsComponent | func | no |  | Override the default checkbox component - must be passed as a function (e.g. `Checkbox` not `<Checkbox />`) |
 | selectableRowsComponentProps | object | no |  | Additional props you want to pass to `selectableRowsComponent`. See [Advanced Selectable Component Options](#advanced-selectable-component-options) to learn how you can override indeterminate state |
 | expandableRows | bool | no | false | Whether to make a row expandable, if true it requires an `expandableRowsComponent`. It is **highly recommended** your data set have a unique identifier defined as the `keyField` for row expansion to work properly.
-| expanderDisabledField | string | no | | React Data Table looks for this property for each item in your data to check if that item can be expanded or not. You must set a bool value in the `expanderDisabledField` of your data if you want to use this feature.
+| expandableDisabledField | string | no |  | React Data Table looks for this property for each item in your data to check if that item can be expanded or not. You must set a bool value in the `expandableDisabledField` of your data if you want to use this feature.
 | expandableRowsComponent | string or component | no |  | A custom component to display in the expanded row. It will have the `data` prop composed  so that you may access the row data |
 | noDataComponent | string or component | no |  | A custom component to display when there are no records to display
 | sortIcon | component | no |  | Override the default sort icon - the icon must be a font or svg icon and it should be a "downward" icon since animation will be handled by React Data Table  |
@@ -403,7 +403,7 @@ class MyComponent extends Component {
         sortIcon={<FontIcon>arrow_downward</FontIcon>}
         onTableUpdate={handleChange} 
         expandableRows
-        expanderDisabledField="expanderDisabled"
+        expandableDisabledField="expanderDisabled"
         expandableRowsComponent={<ExpanableComponent />}
       />
     )

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Nothing new here - we are using an array of object literals and properties to de
 | selectableRowsComponent | func | no |  | Override the default checkbox component - must be passed as a function (e.g. `Checkbox` not `<Checkbox />`) |
 | selectableRowsComponentProps | object | no |  | Additional props you want to pass to `selectableRowsComponent`. See [Advanced Selectable Component Options](#advanced-selectable-component-options) to learn how you can override indeterminate state |
 | expandableRows | bool | no | false | Whether to make a row expandable, if true it requires an `expandableRowsComponent`. It is **highly recommended** your data set have a unique identifier defined as the `keyField` for row expansion to work properly.
+| expanderDisabledField | string | no | | React Data Table looks for this property for each item in your data to check if that item can be expanded or not. You must set a bool value in the `expanderDisabledField` of your data if you want to use this feature.
 | expandableRowsComponent | string or component | no |  | A custom component to display in the expanded row. It will have the `data` prop composed  so that you may access the row data |
 | noDataComponent | string or component | no |  | A custom component to display when there are no records to display
 | sortIcon | component | no |  | Override the default sort icon - the icon must be a font or svg icon and it should be a "downward" icon since animation will be handled by React Data Table  |
@@ -358,6 +359,51 @@ class MyComponent extends Component {
         sortIcon={<FontIcon>arrow_downward</FontIcon>}
         onTableUpdate={handleChange} 
         expandableRows
+        expandableRowsComponent={<ExpanableComponent />}
+      />
+    )
+  }
+);
+```
+
+But in some cases we don't have more details to show:
+```js
+...
+
+const data = [{ id: 1, title: 'Conan the Barbarian', summary: 'Orphaned boy Conan is enslaved after his village is destroyed...',  year: '1982', expanderDisabled: true, image: 'http://conan.image.png' } ...];
+const columns = [
+  {
+    name: 'Title',
+    sortable: true,
+    cell: row => <div><div style={{ fontWeight: 700 }}>{row.title}</div>{row.summary}</div>,
+  },
+  {
+    name: 'Year',
+    selector: 'year',
+    sortable: true,
+    right: true,
+  },
+];
+
+...
+
+// The row data is composed into your custom expandable component via the data prop
+const ExpanableComponent = ({ data }) => <img src={data.image} />;
+
+class MyComponent extends Component {
+  render() { 
+    return (
+      <DataTable
+        title="Arnold Movies"
+        columns={columns}
+        data={data}
+        selectableRows
+        selectableRowsComponent={Checkbox}
+        selectableRowsComponentProps={{ inkDisabled: true }}
+        sortIcon={<FontIcon>arrow_downward</FontIcon>}
+        onTableUpdate={handleChange} 
+        expandableRows
+        expanderDisabledField="expanderDisabled"
         expandableRowsComponent={<ExpanableComponent />}
       />
     )

--- a/src/DataTable/ExpanderButton.js
+++ b/src/DataTable/ExpanderButton.js
@@ -18,7 +18,7 @@ const ButtonStyle = styled.button`
   }
 `;
 
-const ExpanderButton = ({ expanded, children, row, onToggled }) => {
+const ExpanderButton = ({ expanded, children, row, onToggled, disabled }) => {
   const handleToggle = e => onToggled && onToggled(row, e);
 
   return (
@@ -26,6 +26,7 @@ const ExpanderButton = ({ expanded, children, row, onToggled }) => {
       onClick={handleToggle}
       expanded={expanded}
       data-testid="expander-button"
+      disabled={disabled}
     >
       {children}
     </ButtonStyle>
@@ -40,12 +41,14 @@ ExpanderButton.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
+  disabled: PropTypes.bool,
 };
 
 ExpanderButton.defaultProps = {
   onToggled: null,
   children: null,
   expanded: false,
+  disabled: false,
 };
 
 export default ExpanderButton;

--- a/src/DataTable/TableCellExpander.js
+++ b/src/DataTable/TableCellExpander.js
@@ -22,6 +22,7 @@ const TableCellExpander = memo(({
   row,
   expanded,
   onExpandToggled,
+  disabled,
 }) => (
   <TableCellExpanderStyle
     column={column}
@@ -31,6 +32,7 @@ const TableCellExpander = memo(({
       onToggled={onExpandToggled}
       row={row}
       expanded={expanded}
+      disabled={disabled}
     />
   </TableCellExpanderStyle>
 ));
@@ -40,12 +42,14 @@ TableCellExpander.propTypes = {
   row: PropTypes.object,
   expanded: PropTypes.bool,
   onExpandToggled: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
 };
 
 TableCellExpander.defaultProps = {
   column: {},
   row: {},
   expanded: false,
+  disabled: false,
 };
 
 export default TableCellExpander;

--- a/src/DataTable/TableRow.js
+++ b/src/DataTable/TableRow.js
@@ -97,7 +97,7 @@ class TableRow extends PureComponent {
 
     return (
       <DataTableConsumer>
-        {({ keyField, columns, selectedRows, selectableRows, expandableRows, striped, highlightOnHover, pointerOnHover, expandableRowsComponent }) => (
+        {({ keyField, columns, selectedRows, selectableRows, expandableRows, striped, highlightOnHover, pointerOnHover, expandableRowsComponent, expanderDisabledField }) => (
           <React.Fragment>
             <TableRowStyle
               striped={striped}
@@ -119,6 +119,7 @@ class TableRow extends PureComponent {
                   expanded={expanded}
                   row={row}
                   onExpandToggled={this.toggleRowExpand}
+                  disabled={row[expanderDisabledField] || false}
                 />
               )}
 

--- a/src/DataTable/TableRow.js
+++ b/src/DataTable/TableRow.js
@@ -97,7 +97,7 @@ class TableRow extends PureComponent {
 
     return (
       <DataTableConsumer>
-        {({ keyField, columns, selectedRows, selectableRows, expandableRows, striped, highlightOnHover, pointerOnHover, expandableRowsComponent, expanderDisabledField }) => (
+        {({ keyField, columns, selectedRows, selectableRows, expandableRows, striped, highlightOnHover, pointerOnHover, expandableRowsComponent, expandableDisabledField }) => (
           <React.Fragment>
             <TableRowStyle
               striped={striped}
@@ -119,7 +119,7 @@ class TableRow extends PureComponent {
                   expanded={expanded}
                   row={row}
                   onExpandToggled={this.toggleRowExpand}
-                  disabled={row[expanderDisabledField] || false}
+                  disabled={row[expandableDisabledField] || false}
                 />
               )}
 

--- a/src/DataTable/propTypes.js
+++ b/src/DataTable/propTypes.js
@@ -13,7 +13,7 @@ export const propTypes = {
   ]),
   selectableRows: PropTypes.bool,
   expandableRows: PropTypes.bool,
-  expanderDisabledField: PropTypes.string,
+  expandableDisabledField: PropTypes.string,
   keyField: PropTypes.string,
   progressPending: PropTypes.bool,
   progressComponent: PropTypes.oneOfType([
@@ -98,7 +98,7 @@ export const defaultProps = {
   keyField: 'id',
   selectableRows: false,
   expandableRows: false,
-  expanderDisabledField: '',
+  expandableDisabledField: '',
   progressPending: false,
   progressComponent: <h2>Loading...</h2>,
   progressCentered: false,

--- a/src/DataTable/propTypes.js
+++ b/src/DataTable/propTypes.js
@@ -13,6 +13,7 @@ export const propTypes = {
   ]),
   selectableRows: PropTypes.bool,
   expandableRows: PropTypes.bool,
+  expanderDisabledField: PropTypes.string,
   keyField: PropTypes.string,
   progressPending: PropTypes.bool,
   progressComponent: PropTypes.oneOfType([
@@ -97,6 +98,7 @@ export const defaultProps = {
   keyField: 'id',
   selectableRows: false,
   expandableRows: false,
+  expanderDisabledField: '',
   progressPending: false,
   progressComponent: <h2>Loading...</h2>,
   progressCentered: false,

--- a/stories/DataTable/Basic/BasicExpandable.stories.js
+++ b/stories/DataTable/Basic/BasicExpandable.stories.js
@@ -46,11 +46,11 @@ const BasicTable = () => (
 
 const BasicTableExpanderDisabled = () => {
   const data = tableDataItems.map(item => {
-    let expandable = true;
-    if (Number(item.year) >= 2000) {
-      expandable = false;
+    let expanderDisabled = false;
+    if (Number(item.year) < 2000) {
+      expanderDisabled = true;
     }
-    return { ...item, expandable };
+    return { ...item, expanderDisabled };
   });
   return (
     <DataTable
@@ -58,7 +58,7 @@ const BasicTableExpanderDisabled = () => {
       columns={columns}
       data={data}
       expandableRows
-      expanderDisabledField="expandable"
+      expanderDisabledField="expanderDisabled"
       highlightOnHover
       defaultSortField="name"
       defaultSortDirection="desc"

--- a/stories/DataTable/Basic/BasicExpandable.stories.js
+++ b/stories/DataTable/Basic/BasicExpandable.stories.js
@@ -58,7 +58,7 @@ const BasicTableExpanderDisabled = () => {
       columns={columns}
       data={data}
       expandableRows
-      expanderDisabledField="expanderDisabled"
+      expandableDisabledField="expanderDisabled"
       highlightOnHover
       defaultSortField="name"
       defaultSortDirection="desc"

--- a/stories/DataTable/Basic/BasicExpandable.stories.js
+++ b/stories/DataTable/Basic/BasicExpandable.stories.js
@@ -44,6 +44,30 @@ const BasicTable = () => (
   />
 );
 
+const BasicTableExpanderDisabled = () => {
+  const data = tableDataItems.map((item, i) => {
+    let expandable = false;
+    if (i % 2 === 0) {
+      expandable = true;
+    }
+    return { ...item, expandable };
+  });
+  return (
+    <DataTable
+      title="Movie List"
+      columns={columns}
+      data={data}
+      expandableRows
+      expanderDisabledField="expandable"
+      highlightOnHover
+      defaultSortField="name"
+      defaultSortDirection="desc"
+      expandableRowsComponent={<ExpandedSection />}
+    />
+  );
+};
+
 
 storiesOf('Basic', module)
-  .add('Expandable', BasicTable);
+  .add('Expandable', BasicTable)
+  .add('Expander disabled in odd rows', BasicTableExpanderDisabled);

--- a/stories/DataTable/Basic/BasicExpandable.stories.js
+++ b/stories/DataTable/Basic/BasicExpandable.stories.js
@@ -45,16 +45,16 @@ const BasicTable = () => (
 );
 
 const BasicTableExpanderDisabled = () => {
-  const data = tableDataItems.map((item, i) => {
-    let expandable = false;
-    if (i % 2 === 0) {
-      expandable = true;
+  const data = tableDataItems.map(item => {
+    let expandable = true;
+    if (Number(item.year) >= 2000) {
+      expandable = false;
     }
     return { ...item, expandable };
   });
   return (
     <DataTable
-      title="Movie List"
+      title="Movie List - No additional info for old movies (Before 2000)"
       columns={columns}
       data={data}
       expandableRows
@@ -70,4 +70,4 @@ const BasicTableExpanderDisabled = () => {
 
 storiesOf('Basic', module)
   .add('Expandable', BasicTable)
-  .add('Expander disabled in odd rows', BasicTableExpanderDisabled);
+  .add('Expander disabled by row', BasicTableExpanderDisabled);


### PR DESCRIPTION
Add the feature to disable row expander only for a few rows. I asked you for this some days ago, and I got enough time to do some coding and make it works.

I did some stuff based on your [response](https://github.com/jbetancur/react-data-table-component/issues/112#issuecomment-503649660) to my question...
> As for disabling the expander for specific rows, this is not currently possible. I imagine this feature could just be a prop that you can set on your data that the table will look for and disable the expander.
> 
> ```
> const myData = [{ id: 1, name: 'disableMe', disabled: true, ... }]
> ```
> 
> ```
> expandable
> expanderDisabledProp="disabled"
> ```
> 
> Then you just manage that prop however you map your data set.
> 
> I don't have time to add this right now, but I'm open to PR requests ;)

Let me know if you have any recommendation.
Fixes #112 