### PR TITLE
properly align sort icons

### DIFF
--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -100,14 +100,14 @@ class DataTable extends Component {
     }
   }
 
-  handleSortChange = (column, e) => {
+  handleSortChange = column => {
     const { onSort } = this.props;
 
     this.setState(state => {
       const newState = handleSort(column.selector, column.sortable, state);
 
       if (column.sortable && onSort) {
-        onSort(column, newState.sortDirection, e);
+        onSort(column, newState.sortDirection);
       }
 
       return newState;

--- a/src/DataTable/__tests__/DataTable.test.js
+++ b/src/DataTable/__tests__/DataTable.test.js
@@ -14,7 +14,7 @@ jest.mock('shortid', () => {
 const dataMock = colProps => {
   return {
     columns: [{ name: 'Test', selector: 'some.name', ...colProps }],
-    data: [{ id: 1, some: { name: 'Henry the 8th' } }, { id: 2, some: { name: 'Henry the 9th' } }],
+    data: [{ id: 1, some: { name: 'Apple' } }, { id: 2, some: { name: 'Zuchinni' } }],
   };
 };
 
@@ -332,18 +332,81 @@ describe('DataTable::sorting', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('should render correctly when a column is sorted', () => {
+  test('should render correctly when a column is sorted in default asc', () => {
+    const mock = dataMock({ sortable: true });
+    const { container } = render(
+      <DataTable
+        data={mock.data}
+        columns={mock.columns}
+        expandableRows
+      />,
+    );
+
+    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('should render correctly when a column is sorted from asc to desc', () => {
+    const mock = dataMock({ sortable: true });
+    const { container } = render(
+      <DataTable
+        data={mock.data}
+        columns={mock.columns}
+        expandableRows
+      />,
+    );
+
+    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('should call onSort with the correct params', () => {
+    const onSortMock = jest.fn();
+    const mock = dataMock({ sortable: true });
+    const { container } = render(
+      <DataTable
+        data={mock.data}
+        columns={mock.columns}
+        onSort={onSortMock}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+
+    expect(onSortMock).toBeCalledWith({ id: 1, ...mock.columns[0] }, 'asc');
+  });
+
+  test('should call onSort with the correct params if the sort is clicked twice', () => {
+    const onSortMock = jest.fn();
+    const mock = dataMock({ sortable: true });
+    const { container } = render(
+      <DataTable
+        data={mock.data}
+        columns={mock.columns}
+        onSort={onSortMock}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    expect(onSortMock).toBeCalledWith({ id: 1, ...mock.columns[0] }, 'asc');
+
+    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    expect(onSortMock).toBeCalledWith({ id: 1, ...mock.columns[0] }, 'desc');
+  });
+
+  test('should render correctly with a custom sortIcon', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
       <DataTable
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
-        expandableRows
+        sortIcon={<div>ASC</div>}
       />,
     );
-
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
 
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -356,37 +419,6 @@ describe('DataTable::sorting', () => {
         columns={mock.columns}
         defaultSortField="some.name"
         defaultSortAsc={false}
-      />,
-    );
-
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
-  test('should call with the correct params onSort if a column is sortable and onSort is set', () => {
-    const onSortMock = jest.fn();
-    const mock = dataMock({ sortable: true });
-    const { container } = render(
-      <DataTable
-        data={mock.data}
-        columns={mock.columns}
-        defaultSortField="some.name"
-        onSort={onSortMock}
-      />,
-    );
-
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
-
-    expect(onSortMock).toBeCalled();
-  });
-
-  test('should render correctly with a custom sortIcon', () => {
-    const mock = dataMock({ sortable: true });
-    const { container } = render(
-      <DataTable
-        data={mock.data}
-        columns={mock.columns}
-        defaultSortField="some.name"
-        sortIcon={<div>ASC</div>}
       />,
     );
 

--- a/src/DataTable/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/DataTable/__tests__/__snapshots__/DataTable.test.js.snap
@@ -130,15 +130,15 @@ exports[`DataTable::Header actions should render correctly 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -149,13 +149,20 @@ exports[`DataTable::Header actions should render correctly 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -331,12 +338,14 @@ exports[`DataTable::Header actions should render correctly 1`] = `
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -358,7 +367,7 @@ exports[`DataTable::Header actions should render correctly 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -375,7 +384,7 @@ exports[`DataTable::Header actions should render correctly 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -535,28 +544,35 @@ exports[`DataTable::Header context menu should render correctly when selectableR
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -771,12 +787,14 @@ exports[`DataTable::Header context menu should render correctly when selectableR
           </div>
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -808,7 +826,7 @@ exports[`DataTable::Header context menu should render correctly when selectableR
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -835,7 +853,7 @@ exports[`DataTable::Header context menu should render correctly when selectableR
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -975,15 +993,15 @@ exports[`DataTable::Header contextTitle should render correctly 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -994,13 +1012,20 @@ exports[`DataTable::Header contextTitle should render correctly 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1168,12 +1193,14 @@ exports[`DataTable::Header contextTitle should render correctly 1`] = `
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -1195,7 +1222,7 @@ exports[`DataTable::Header contextTitle should render correctly 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -1212,7 +1239,7 @@ exports[`DataTable::Header contextTitle should render correctly 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -1352,15 +1379,15 @@ exports[`DataTable::Header should render without a header if noHeader is true 1`
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c5:first-child {
@@ -1371,13 +1398,20 @@ exports[`DataTable::Header should render without a header if noHeader is true 1`
   padding-right: calc(48px / 2);
 }
 
-.c5::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c6 {
+.c6 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1428,12 +1462,14 @@ exports[`DataTable::Header should render without a header if noHeader is true 1`
         >
           <div
             class="rdt_TableCol c5"
-            id="column-some.name"
           >
             <div
               class="c6"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -1455,7 +1491,7 @@ exports[`DataTable::Header should render without a header if noHeader is true 1`
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -1472,7 +1508,7 @@ exports[`DataTable::Header should render without a header if noHeader is true 1`
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -1612,15 +1648,15 @@ exports[`DataTable::Header title should render correctly 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -1631,13 +1667,20 @@ exports[`DataTable::Header title should render correctly 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1805,12 +1848,14 @@ exports[`DataTable::Header title should render correctly 1`] = `
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -1832,7 +1877,7 @@ exports[`DataTable::Header title should render correctly 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -1849,7 +1894,7 @@ exports[`DataTable::Header title should render correctly 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -2013,15 +2058,15 @@ exports[`DataTable::Pagination should render correctly if pagination is enabled 
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -2032,13 +2077,20 @@ exports[`DataTable::Pagination should render correctly if pagination is enabled 
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2317,12 +2369,14 @@ exports[`DataTable::Pagination should render correctly if pagination is enabled 
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -2344,7 +2398,7 @@ exports[`DataTable::Pagination should render correctly if pagination is enabled 
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -2361,7 +2415,7 @@ exports[`DataTable::Pagination should render correctly if pagination is enabled 
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -2671,15 +2725,15 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -2690,13 +2744,20 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2975,12 +3036,14 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -3002,7 +3065,7 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -3019,7 +3082,7 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -3370,28 +3433,35 @@ exports[`DataTable::Theming should render correctly when rows spaced 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -3560,12 +3630,14 @@ exports[`DataTable::Theming should render correctly when rows spaced 1`] = `
           />
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -3611,7 +3683,7 @@ exports[`DataTable::Theming should render correctly when rows spaced 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -3652,7 +3724,7 @@ exports[`DataTable::Theming should render correctly when rows spaced 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -3858,28 +3930,35 @@ exports[`DataTable::Theming should render correctly when rows spaced with spacin
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -4048,12 +4127,14 @@ exports[`DataTable::Theming should render correctly when rows spaced with spacin
           />
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -4099,7 +4180,7 @@ exports[`DataTable::Theming should render correctly when rows spaced with spacin
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -4140,7 +4221,7 @@ exports[`DataTable::Theming should render correctly when rows spaced with spacin
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -4288,15 +4369,15 @@ exports[`DataTable::columns should render correctly if column.center 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -4307,13 +4388,20 @@ exports[`DataTable::columns should render correctly if column.center 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -4479,12 +4567,14 @@ exports[`DataTable::columns should render correctly if column.center 1`] = `
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -4506,7 +4596,7 @@ exports[`DataTable::columns should render correctly if column.center 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -4523,7 +4613,7 @@ exports[`DataTable::columns should render correctly if column.center 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -4663,15 +4753,15 @@ exports[`DataTable::columns should render correctly if column.maxWidth 1`] = `
   flex-basis: 0;
   max-width: 600px;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -4682,13 +4772,20 @@ exports[`DataTable::columns should render correctly if column.maxWidth 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -4854,12 +4951,14 @@ exports[`DataTable::columns should render correctly if column.maxWidth 1`] = `
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -4881,7 +4980,7 @@ exports[`DataTable::columns should render correctly if column.maxWidth 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -4898,7 +4997,7 @@ exports[`DataTable::columns should render correctly if column.maxWidth 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -5038,15 +5137,15 @@ exports[`DataTable::columns should render correctly if column.minWidth 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 200px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -5057,13 +5156,20 @@ exports[`DataTable::columns should render correctly if column.minWidth 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -5229,12 +5335,14 @@ exports[`DataTable::columns should render correctly if column.minWidth 1`] = `
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -5256,7 +5364,7 @@ exports[`DataTable::columns should render correctly if column.minWidth 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -5273,7 +5381,7 @@ exports[`DataTable::columns should render correctly if column.minWidth 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -5421,15 +5529,15 @@ exports[`DataTable::columns should render correctly if column.right 1`] = `
   -webkit-justify-content: flex-end;
   -ms-flex-pack: end;
   justify-content: flex-end;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -5440,13 +5548,20 @@ exports[`DataTable::columns should render correctly if column.right 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -5612,12 +5727,14 @@ exports[`DataTable::columns should render correctly if column.right 1`] = `
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -5639,7 +5756,7 @@ exports[`DataTable::columns should render correctly if column.right 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -5656,7 +5773,7 @@ exports[`DataTable::columns should render correctly if column.right 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -5800,15 +5917,15 @@ exports[`DataTable::columns should render correctly if column.width 1`] = `
   min-width: 100px;
   min-width: 200px;
   max-width: 200px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -5819,13 +5936,20 @@ exports[`DataTable::columns should render correctly if column.width 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -5991,12 +6115,14 @@ exports[`DataTable::columns should render correctly if column.width 1`] = `
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -6018,7 +6144,7 @@ exports[`DataTable::columns should render correctly if column.width 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -6035,7 +6161,7 @@ exports[`DataTable::columns should render correctly if column.width 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -6175,15 +6301,15 @@ exports[`DataTable::columns should render correctly when column.allowOverflow = 
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -6194,13 +6320,20 @@ exports[`DataTable::columns should render correctly when column.allowOverflow = 
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -6366,12 +6499,14 @@ exports[`DataTable::columns should render correctly when column.allowOverflow = 
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -6393,7 +6528,7 @@ exports[`DataTable::columns should render correctly when column.allowOverflow = 
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -6410,7 +6545,7 @@ exports[`DataTable::columns should render correctly when column.allowOverflow = 
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -6558,15 +6693,15 @@ exports[`DataTable::columns should render correctly when column.button = true 1`
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -6577,13 +6712,20 @@ exports[`DataTable::columns should render correctly when column.button = true 1`
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -6749,12 +6891,14 @@ exports[`DataTable::columns should render correctly when column.button = true 1`
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -6776,7 +6920,7 @@ exports[`DataTable::columns should render correctly when column.button = true 1`
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -6793,7 +6937,7 @@ exports[`DataTable::columns should render correctly when column.button = true 1`
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -6933,15 +7077,15 @@ exports[`DataTable::columns should render correctly when column.cell is set to a
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -6952,13 +7096,20 @@ exports[`DataTable::columns should render correctly when column.cell is set to a
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -7124,12 +7275,14 @@ exports[`DataTable::columns should render correctly when column.cell is set to a
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -7152,7 +7305,7 @@ exports[`DataTable::columns should render correctly when column.cell is set to a
               class="react-data-table--cell-content"
             >
               <div>
-                Henry the 8th
+                Apple
               </div>
             </div>
           </div>
@@ -7171,7 +7324,7 @@ exports[`DataTable::columns should render correctly when column.cell is set to a
               class="react-data-table--cell-content"
             >
               <div>
-                Henry the 9th
+                Zuchinni
               </div>
             </div>
           </div>
@@ -7314,15 +7467,15 @@ exports[`DataTable::columns should render correctly when column.compact = true 1
   max-width: 100%;
   min-width: 100px;
   padding: calc(48px / 12);
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -7333,13 +7486,20 @@ exports[`DataTable::columns should render correctly when column.compact = true 1
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -7505,12 +7665,14 @@ exports[`DataTable::columns should render correctly when column.compact = true 1
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -7532,7 +7694,7 @@ exports[`DataTable::columns should render correctly when column.compact = true 1
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -7549,7 +7711,7 @@ exports[`DataTable::columns should render correctly when column.compact = true 1
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -7689,15 +7851,15 @@ exports[`DataTable::columns should render correctly when column.wrap = true 1`] 
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -7708,13 +7870,20 @@ exports[`DataTable::columns should render correctly when column.wrap = true 1`] 
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -7880,12 +8049,14 @@ exports[`DataTable::columns should render correctly when column.wrap = true 1`] 
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -7907,7 +8078,7 @@ exports[`DataTable::columns should render correctly when column.wrap = true 1`] 
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -7924,7 +8095,7 @@ exports[`DataTable::columns should render correctly when column.wrap = true 1`] 
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -8064,15 +8235,15 @@ exports[`DataTable::columns should render correctly with columns/data 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -8083,13 +8254,20 @@ exports[`DataTable::columns should render correctly with columns/data 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -8255,12 +8433,14 @@ exports[`DataTable::columns should render correctly with columns/data 1`] = `
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -8282,7 +8462,7 @@ exports[`DataTable::columns should render correctly with columns/data 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -8299,7 +8479,7 @@ exports[`DataTable::columns should render correctly with columns/data 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -8501,28 +8681,35 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -8691,12 +8878,14 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
           />
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -8742,7 +8931,7 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -8783,7 +8972,7 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -8992,28 +9181,35 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -9182,12 +9378,14 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
           />
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -9233,7 +9431,7 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -9283,7 +9481,7 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -9423,15 +9621,15 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -9442,13 +9640,20 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -9616,12 +9821,14 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader 1`] = `
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -9643,7 +9850,7 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -9660,7 +9867,7 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -9800,15 +10007,15 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader and fix
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -9819,13 +10026,20 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader and fix
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -9993,12 +10207,14 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader and fix
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -10020,7 +10236,7 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader and fix
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -10037,7 +10253,7 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader and fix
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -10177,15 +10393,15 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -10196,13 +10412,20 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -10372,12 +10595,14 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -10399,7 +10624,7 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -10416,7 +10641,7 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -10556,15 +10781,15 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -10575,13 +10800,20 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -10751,12 +10983,14 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -10778,7 +11012,7 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -10795,7 +11029,7 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -10944,15 +11178,15 @@ exports[`DataTable::highlightOnHover should render correctly when highlightOnHov
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -10963,13 +11197,20 @@ exports[`DataTable::highlightOnHover should render correctly when highlightOnHov
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -11135,12 +11376,14 @@ exports[`DataTable::highlightOnHover should render correctly when highlightOnHov
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -11162,7 +11405,7 @@ exports[`DataTable::highlightOnHover should render correctly when highlightOnHov
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -11179,7 +11422,7 @@ exports[`DataTable::highlightOnHover should render correctly when highlightOnHov
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -11323,15 +11566,15 @@ exports[`DataTable::pointerOnHover should render correctly when pointerOnHover 1
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -11342,13 +11585,20 @@ exports[`DataTable::pointerOnHover should render correctly when pointerOnHover 1
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -11514,12 +11764,14 @@ exports[`DataTable::pointerOnHover should render correctly when pointerOnHover 1
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -11541,7 +11793,7 @@ exports[`DataTable::pointerOnHover should render correctly when pointerOnHover 1
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -11558,7 +11810,7 @@ exports[`DataTable::pointerOnHover should render correctly when pointerOnHover 1
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -11698,15 +11950,15 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:first-child {
@@ -11717,13 +11969,20 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -11911,12 +12170,14 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
         >
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -11938,7 +12199,7 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -11955,7 +12216,7 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -12095,15 +12356,15 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:first-child {
@@ -12114,13 +12375,20 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -12312,12 +12580,14 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
         >
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -12339,7 +12609,7 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -12356,7 +12626,7 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -12496,15 +12766,15 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:first-child {
@@ -12515,13 +12785,20 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -12707,12 +12984,14 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
         >
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -12734,7 +13013,7 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -12751,7 +13030,7 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -13053,15 +13332,15 @@ exports[`DataTable::progress/nodata should render correctly when progressPending
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:first-child {
@@ -13072,13 +13351,20 @@ exports[`DataTable::progress/nodata should render correctly when progressPending
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -13266,12 +13552,14 @@ exports[`DataTable::progress/nodata should render correctly when progressPending
         >
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -13293,7 +13581,7 @@ exports[`DataTable::progress/nodata should render correctly when progressPending
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -13310,7 +13598,7 @@ exports[`DataTable::progress/nodata should render correctly when progressPending
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -13450,15 +13738,15 @@ exports[`DataTable::responsive should not apply overFlowY without an overflowYOf
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -13469,13 +13757,20 @@ exports[`DataTable::responsive should not apply overFlowY without an overflowYOf
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -13643,12 +13938,14 @@ exports[`DataTable::responsive should not apply overFlowY without an overflowYOf
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -13670,7 +13967,7 @@ exports[`DataTable::responsive should not apply overFlowY without an overflowYOf
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -13687,7 +13984,7 @@ exports[`DataTable::responsive should not apply overFlowY without an overflowYOf
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -13827,15 +14124,15 @@ exports[`DataTable::responsive should render correctly responsive by default 1`]
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -13846,13 +14143,20 @@ exports[`DataTable::responsive should render correctly responsive by default 1`]
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -14018,12 +14322,14 @@ exports[`DataTable::responsive should render correctly responsive by default 1`]
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -14045,7 +14351,7 @@ exports[`DataTable::responsive should render correctly responsive by default 1`]
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -14062,7 +14368,7 @@ exports[`DataTable::responsive should render correctly responsive by default 1`]
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -14202,15 +14508,15 @@ exports[`DataTable::responsive should render correctly when responsive=false 1`]
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -14221,13 +14527,20 @@ exports[`DataTable::responsive should render correctly when responsive=false 1`]
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -14392,12 +14705,14 @@ exports[`DataTable::responsive should render correctly when responsive=false 1`]
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -14419,7 +14734,7 @@ exports[`DataTable::responsive should render correctly when responsive=false 1`]
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -14436,7 +14751,7 @@ exports[`DataTable::responsive should render correctly when responsive=false 1`]
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -14596,28 +14911,35 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -14822,12 +15144,14 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
           </div>
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -14859,7 +15183,7 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -14886,7 +15210,7 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -15046,28 +15370,35 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -15272,12 +15603,14 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
           </div>
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -15309,7 +15642,7 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -15336,7 +15669,7 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -15496,28 +15829,35 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -15724,12 +16064,14 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
           </div>
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -15761,7 +16103,7 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -15788,7 +16130,7 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -15798,7 +16140,7 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
 </div>
 `;
 
-exports[`DataTable::sorting should render correctly when a column is sorted 1`] = `
+exports[`DataTable::sorting should render correctly when a column is sorted from asc to desc 1`] = `
 .c7 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -15990,30 +16332,19 @@ exports[`DataTable::sorting should render correctly when a column is sorted 1`] 
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
-  cursor: pointer;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:last-child {
   padding-right: calc(48px / 2);
-}
-
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
-}
-
-.c11::before {
-  content: '\\25BC';
 }
 
 .c12 {
@@ -16025,7 +16356,30 @@ exports[`DataTable::sorting should render correctly when a column is sorted 1`] 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  font-weight: 800;
+  height: 100%;
+}
+
+.c12 span {
+  line-height: 1;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 600;
+  color: rgba(0,0,0,.87);
+}
+
+.c12 span:hover {
+  cursor: pointer;
+}
+
+.c12 span::after {
+  padding-left: 2px;
+  content: '\\25BC';
 }
 
 .c5 {
@@ -16186,12 +16540,14 @@ exports[`DataTable::sorting should render correctly when a column is sorted 1`] 
           />
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -16237,7 +16593,7 @@ exports[`DataTable::sorting should render correctly when a column is sorted 1`] 
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -16278,7 +16634,511 @@ exports[`DataTable::sorting should render correctly when a column is sorted 1`] 
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataTable::sorting should render correctly when a column is sorted in default asc 1`] = `
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  text-align: left;
+  background-color: transparent;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+
+.c10 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+}
+
+.c17 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+  font-size: 13px;
+  font-weight: 400;
+  white-space: nowrap;
+  min-height: 48px;
+}
+
+.c17:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c17 .react-data-table--cell-content {
+  color: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c18 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.c16 {
+  outline: none;
+  border: none;
+  display: block;
+  width: 40px;
+  height: 40px;
+  background-color: transparent;
+  color: rgba(0,0,0,.54);
+}
+
+.c16:disabled {
+  color: rgba(0,0,0,.12);
+}
+
+.c16:hover:enabled {
+  cursor: pointer;
+}
+
+.c15 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+  -webkit-flex: 0 0 56px;
+  -ms-flex: 0 0 56px;
+  flex: 0 0 56px;
+  white-space: nowrap;
+  font-weight: 400;
+  font-size: 13px;
+  color: rgba(0,0,0,.87);
+  min-height: 48px;
+}
+
+.c15:not(:first-child) {
+  padding-left: 0;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 48px;
+  border-top-style: solid;
+  border-top-width: 1px;
+  border-top-color: rgba(0,0,0,.12);
+  background-color: transparent;
+  color: rgba(0,0,0,.87);
+}
+
+.c11 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  min-height: 48px;
+  color: rgba(0,0,0,.54);
+}
+
+.c11:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.c12 span {
+  line-height: 1;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 600;
+  color: rgba(0,0,0,.87);
+}
+
+.c12 span:hover {
+  cursor: pointer;
+}
+
+.c12 span::after {
+  padding-left: 2px;
+  content: '\\25B2';
+}
+
+.c5 {
+  color: rgba(0,0,0,.87);
+  font-size: 18px;
+  font-weight: 400;
+}
+
+.c4 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #e3f2fd;
+  z-index: 1;
+  -webkit-transform: translate3d(0,-100%,0);
+  -ms-transform: translate3d(0,-100%,0);
+  transform: translate3d(0,-100%,0);
+  -webkit-transition-duration: 225ms;
+  transition-duration: 225ms;
+  -webkit-transition-timing-function: cubic-bezier(0,0,0.2,1);
+  transition-timing-function: cubic-bezier(0,0,0.2,1);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+  will-change: transform;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 16px 16px 16px 24px;
+}
+
+.c1 {
+  position: relative;
+  overflow: visible;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 4px 16px 4px 24px;
+  min-height: 56px;
+  width: 100%;
+  background-color: transparent;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.c2 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  color: rgba(0,0,0,.87);
+  font-size: 22px;
+  font-weight: 400;
+}
+
+.c3 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c3 > * {
+  margin-left: 5px;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  overflow-x: auto;
+}
+
+.c6 {
+  position: relative;
+  display: table;
+  width: 100%;
+  height: 100%;
+}
+
+<div
+  class="c0"
+>
+  <header
+    class="rdt_TableHeader c1"
+  >
+    <div
+      class="c2"
+    />
+    <div
+      class="c3"
+    />
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      />
+      <div />
+    </div>
+  </header>
+  <div
+    class="c6"
+  >
+    <div
+      class="rdt_Table c7"
+    >
+      <div
+        class="rdt_TableHead c8"
+      >
+        <div
+          class="rdt_TableHeadRow c9"
+        >
+          <div
+            class="c10"
+          />
+          <div
+            class="rdt_TableCol c11"
+          >
+            <div
+              class="c12"
+              id="column-some.name"
+            >
+              <span>
+                Test
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="rdt_TableBody c13"
+        offset="250px"
+      >
+        <div
+          class="rdt_TableRow c14"
+        >
+          <div
+            class="c15"
+          >
+            <button
+              class="c16"
+              data-testid="expander-button-1"
+            >
+              <svg
+                fill="currentColor"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"
+                />
+                <path
+                  d="M0-.25h24v24H0z"
+                  fill="none"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="rdt_TableCell c17"
+          >
+            <div
+              class="c18"
+              data-tag="___react-data-table--click-clip___"
+            />
+            <div
+              class="react-data-table--cell-content"
+            >
+              Apple
+            </div>
+          </div>
+        </div>
+        <div
+          class="rdt_TableRow c14"
+        >
+          <div
+            class="c15"
+          >
+            <button
+              class="c16"
+              data-testid="expander-button-2"
+            >
+              <svg
+                fill="currentColor"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"
+                />
+                <path
+                  d="M0-.25h24v24H0z"
+                  fill="none"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="rdt_TableCell c17"
+          >
+            <div
+              class="c18"
+              data-tag="___react-data-table--click-clip___"
+            />
+            <div
+              class="react-data-table--cell-content"
+            >
+              Zuchinni
             </div>
           </div>
         </div>
@@ -16418,16 +17278,15 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
-  cursor: pointer;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -16436,12 +17295,6 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
 
 .c10:last-child {
   padding-right: calc(48px / 2);
-}
-
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
 }
 
 .c11 {
@@ -16453,15 +17306,38 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  font-weight: 800;
+  height: 100%;
+}
+
+.c11 span {
+  line-height: 1;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 600;
+  color: rgba(0,0,0,.87);
+}
+
+.c11 span:hover {
+  cursor: pointer;
 }
 
 .c12 {
   line-height: 1;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c12 i,
 .c12 svg {
+  color: inherit;
   font-size: 18px !important;
   height: 18px !important;
   width: 18px !important;
@@ -16477,8 +17353,8 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
   -webkit-transform-style: preserve-3d;
   -ms-transform-style: preserve-3d;
   transform-style: preserve-3d;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
   -webkit-transition-property: -webkit-transform;
   -webkit-transition-property: transform;
   transition-property: transform;
@@ -16486,6 +17362,7 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
 
 .c12.asc i,
 .c12.asc svg {
+  padding-right: 4px;
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
@@ -16646,11 +17523,14 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
+              <span>
+                Test
+              </span>
               <span
                 class="asc c12"
               >
@@ -16658,7 +17538,6 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
                   ASC
                 </div>
               </span>
-              Test
             </div>
           </div>
         </div>
@@ -16680,7 +17559,7 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -16697,7 +17576,7 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -16837,16 +17716,15 @@ exports[`DataTable::sorting should render correctly with a default sort field 1`
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
-  cursor: pointer;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -16855,16 +17733,6 @@ exports[`DataTable::sorting should render correctly with a default sort field 1`
 
 .c10:last-child {
   padding-right: calc(48px / 2);
-}
-
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
-}
-
-.c10::before {
-  content: '\\25B2';
 }
 
 .c11 {
@@ -16876,7 +17744,30 @@ exports[`DataTable::sorting should render correctly with a default sort field 1`
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  font-weight: 800;
+  height: 100%;
+}
+
+.c11 span {
+  line-height: 1;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 600;
+  color: rgba(0,0,0,.87);
+}
+
+.c11 span:hover {
+  cursor: pointer;
+}
+
+.c11 span::after {
+  padding-left: 2px;
+  content: '\\25B2';
 }
 
 .c5 {
@@ -17034,12 +17925,14 @@ exports[`DataTable::sorting should render correctly with a default sort field 1`
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -17061,7 +17954,7 @@ exports[`DataTable::sorting should render correctly with a default sort field 1`
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -17078,7 +17971,7 @@ exports[`DataTable::sorting should render correctly with a default sort field 1`
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -17218,16 +18111,15 @@ exports[`DataTable::sorting should render correctly with a defaultSortAsc = fals
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
-  cursor: pointer;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -17236,16 +18128,6 @@ exports[`DataTable::sorting should render correctly with a defaultSortAsc = fals
 
 .c10:last-child {
   padding-right: calc(48px / 2);
-}
-
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
-}
-
-.c10::before {
-  content: '\\25BC';
 }
 
 .c11 {
@@ -17257,7 +18139,30 @@ exports[`DataTable::sorting should render correctly with a defaultSortAsc = fals
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  font-weight: 800;
+  height: 100%;
+}
+
+.c11 span {
+  line-height: 1;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 600;
+  color: rgba(0,0,0,.87);
+}
+
+.c11 span:hover {
+  cursor: pointer;
+}
+
+.c11 span::after {
+  padding-left: 2px;
+  content: '\\25BC';
 }
 
 .c5 {
@@ -17415,12 +18320,14 @@ exports[`DataTable::sorting should render correctly with a defaultSortAsc = fals
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -17442,7 +18349,7 @@ exports[`DataTable::sorting should render correctly with a defaultSortAsc = fals
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -17459,7 +18366,7 @@ exports[`DataTable::sorting should render correctly with a defaultSortAsc = fals
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -17603,15 +18510,15 @@ exports[`DataTable::striped should render correctly when striped 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -17622,13 +18529,20 @@ exports[`DataTable::striped should render correctly when striped 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -17794,12 +18708,14 @@ exports[`DataTable::striped should render correctly when striped 1`] = `
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -17821,7 +18737,7 @@ exports[`DataTable::striped should render correctly when striped 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -17838,7 +18754,7 @@ exports[`DataTable::striped should render correctly when striped 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -17978,15 +18894,15 @@ exports[`DataTablke::subHeader should render correctly when a subheader is enabl
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:first-child {
@@ -17997,13 +18913,20 @@ exports[`DataTablke::subHeader should render correctly when a subheader is enabl
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -18199,12 +19122,14 @@ exports[`DataTablke::subHeader should render correctly when a subheader is enabl
         >
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -18226,7 +19151,7 @@ exports[`DataTablke::subHeader should render correctly when a subheader is enabl
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -18243,7 +19168,7 @@ exports[`DataTablke::subHeader should render correctly when a subheader is enabl
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -18383,15 +19308,15 @@ exports[`DataTablke::subHeader should render correctly with center align 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:first-child {
@@ -18402,13 +19327,20 @@ exports[`DataTablke::subHeader should render correctly with center align 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -18604,12 +19536,14 @@ exports[`DataTablke::subHeader should render correctly with center align 1`] = `
         >
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -18631,7 +19565,7 @@ exports[`DataTablke::subHeader should render correctly with center align 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -18648,7 +19582,7 @@ exports[`DataTablke::subHeader should render correctly with center align 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -18788,15 +19722,15 @@ exports[`DataTablke::subHeader should render correctly with left align 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:first-child {
@@ -18807,13 +19741,20 @@ exports[`DataTablke::subHeader should render correctly with left align 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -19009,12 +19950,14 @@ exports[`DataTablke::subHeader should render correctly with left align 1`] = `
         >
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -19036,7 +19979,7 @@ exports[`DataTablke::subHeader should render correctly with left align 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -19053,7 +19996,7 @@ exports[`DataTablke::subHeader should render correctly with left align 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -19193,15 +20136,15 @@ exports[`DataTablke::subHeader should render correctly with right align 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:first-child {
@@ -19212,13 +20155,20 @@ exports[`DataTablke::subHeader should render correctly with right align 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -19414,12 +20364,14 @@ exports[`DataTablke::subHeader should render correctly with right align 1`] = `
         >
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -19441,7 +20393,7 @@ exports[`DataTablke::subHeader should render correctly with right align 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -19458,7 +20410,7 @@ exports[`DataTablke::subHeader should render correctly with right align 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -19598,15 +20550,15 @@ exports[`DataTablke::subHeader should render when subHeaderWrap is false 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c11:first-child {
@@ -19617,13 +20569,20 @@ exports[`DataTablke::subHeader should render when subHeaderWrap is false 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c11::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c12 {
+.c12 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -19819,12 +20778,14 @@ exports[`DataTablke::subHeader should render when subHeaderWrap is false 1`] = `
         >
           <div
             class="rdt_TableCol c11"
-            id="column-some.name"
           >
             <div
               class="c12"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -19846,7 +20807,7 @@ exports[`DataTablke::subHeader should render when subHeaderWrap is false 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -19863,7 +20824,7 @@ exports[`DataTablke::subHeader should render when subHeaderWrap is false 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>
@@ -20003,15 +20964,15 @@ exports[`data prop changes should update state if the data prop changes 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -20022,13 +20983,20 @@ exports[`data prop changes should update state if the data prop changes 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -20194,12 +21162,14 @@ exports[`data prop changes should update state if the data prop changes 1`] = `
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -20523,15 +21493,15 @@ exports[`should render correctly if the keyField is overriden 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -20542,13 +21512,20 @@ exports[`should render correctly if the keyField is overriden 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -20714,12 +21691,14 @@ exports[`should render correctly if the keyField is overriden 1`] = `
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -20883,15 +21862,15 @@ exports[`should render correctly when disabled 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  color: rgba(0,0,0,.54);
   min-height: 48px;
+  color: rgba(0,0,0,.54);
 }
 
 .c10:first-child {
@@ -20902,13 +21881,20 @@ exports[`should render correctly when disabled 1`] = `
   padding-right: calc(48px / 2);
 }
 
-.c10::before {
-  margin-bottom: 1px;
-  font-size: 12px;
-  padding-right: 4px;
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
 }
 
-.c11 {
+.c11 span {
+  line-height: 1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -21075,12 +22061,14 @@ exports[`should render correctly when disabled 1`] = `
         >
           <div
             class="rdt_TableCol c10"
-            id="column-some.name"
           >
             <div
               class="c11"
+              id="column-some.name"
             >
-              Test
+              <span>
+                Test
+              </span>
             </div>
           </div>
         </div>
@@ -21102,7 +22090,7 @@ exports[`should render correctly when disabled 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 8th
+              Apple
             </div>
           </div>
         </div>
@@ -21119,7 +22107,7 @@ exports[`should render correctly when disabled 1`] = `
             <div
               class="react-data-table--cell-content"
             >
-              Henry the 9th
+              Zuchinni
             </div>
           </div>
         </div>

--- a/src/DataTable/statemgmt.js
+++ b/src/DataTable/statemgmt.js
@@ -28,10 +28,16 @@ export const handleRowSelected = (rows, row, selectedRows) => {
 
 export const handleSort = (selector, sortable, state) => {
   if (sortable) {
-    const { sortDirection } = state;
-    const direction = sortDirection === 'asc'
-      ? 'desc'
-      : 'asc';
+    const { sortDirection, sortColumn } = state;
+    let direction = sortDirection;
+
+    // change sort direction only if sortColumn (currently selected column) is === the newly clicked column
+    // otherwise, retain sort direction if the column is swiched
+    if (sortColumn === selector) {
+      direction = sortDirection === 'asc'
+        ? 'desc'
+        : 'asc';
+    }
 
     return {
       sortColumn: selector,

--- a/src/themes/default.js
+++ b/src/themes/default.js
@@ -8,6 +8,7 @@ export default () => ({
   header: {
     fontSize: '12px',
     fontColor: 'rgba(0,0,0,.54)',
+    fontColorActive: 'rgba(0,0,0,.87)',
     backgroundColor: 'transparent',
     height: '48px',
   },


### PR DESCRIPTION
This PR includes several fixes for sorting icon alignment as well as sorting behavior when selected a new sort column. The expectation on the later is that the sort direction should only change if the currently select column is clicked again
* may break `rdt_TableCol` customizations
* Closes #139 