### PR TITLE
prevent cells from unnecessary re-rendering

### DIFF
--- a/src/DataTable/Cell.js
+++ b/src/DataTable/Cell.js
@@ -39,11 +39,10 @@ export const Cell = styled(CellBase)`
   ${props => props.column.right && 'justify-content: flex-end'};
   ${props => (props.column.center || props.column.button) && 'justify-content: center'};
   ${props => props.column.compact && `padding: calc(${props.theme.cells.cellPadding} / 12)`};
-  ${props => !props.internalCell && css`
-    &:first-child {
-      padding-left: calc(${props.theme.cells.cellPadding} / 2);
-    }
-  `};
+
+  &:first-child {
+    padding-left: calc(${props => props.theme.cells.cellPadding} / 2);
+  }
 
   /* calculate left/right edge paddings */
   ${props => (props.column.button ? lastCellPaddingWhenButton : lastCellPadding)};

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -92,6 +92,12 @@ class DataTable extends Component {
     this.setState(state => handleRowSelected(data, row, state.selectedRows));
   }
 
+  checkIfRowSeleted = row => {
+    const { selectedRows } = this.state;
+
+    return selectedRows.some(srow => srow === row);
+  }
+
   handleRowClicked = (row, e) => {
     const { onRowClicked } = this.props;
 
@@ -174,12 +180,15 @@ class DataTable extends Component {
   }
 
   renderColumns() {
+    const { sortIcon } = this.props;
+
     return (
       this.columns.map(column => (
         <TableCol
           key={column.id}
           column={column}
           onColumnClick={this.handleSortChange}
+          sortIcon={sortIcon}
         />
       ))
     );
@@ -189,6 +198,13 @@ class DataTable extends Component {
     const {
       keyField,
       defaultExpandedField,
+      selectableRows,
+      expandableRows,
+      striped,
+      highlightOnHover,
+      pointerOnHover,
+      expandableRowsComponent,
+      expandableDisabledField,
     } = this.props;
 
     return (
@@ -196,9 +212,19 @@ class DataTable extends Component {
         <TableRow
           key={row[keyField] || i}
           row={row}
+          columns={this.columns}
+          keyField={keyField}
+          selectableRows={selectableRows}
+          expandableRows={expandableRows}
+          striped={striped}
+          highlightOnHover={highlightOnHover}
+          pointerOnHover={pointerOnHover}
+          expandableRowsComponent={expandableRowsComponent}
+          expandableDisabledField={expandableDisabledField}
           defaultExpanded={row[defaultExpandedField] || false}
           onRowClicked={this.handleRowClicked}
           onRowSelected={this.handleRowSelected}
+          isRowSelected={this.checkIfRowSeleted}
         />
       ))
     );
@@ -224,7 +250,17 @@ class DataTable extends Component {
   render() {
     const {
       data,
+      keyField,
+      selectableRowsComponent,
+      selectableRowsComponentProps,
+      expandableIcon,
       paginationTotalRows,
+      paginationRowsPerPageOptions,
+      paginationIconLastPage,
+      paginationIconFirstPage,
+      paginationIconNext,
+      paginationIconPrevious,
+      paginationComponentOptions,
       title,
       customTheme,
       actions,
@@ -242,8 +278,6 @@ class DataTable extends Component {
       fixedHeader,
       fixedHeaderScrollHeight,
       pagination,
-      selectableRows,
-      expandableRows,
       subHeader,
       subHeaderAlign,
       subHeaderWrap,
@@ -253,15 +287,31 @@ class DataTable extends Component {
     const {
       rowsPerPage,
       currentPage,
+      selectedRows,
+      allSelected,
+      selectedCount,
+      sortColumn,
+      sortDirection,
     } = this.state;
 
     const theme = this.mergeTheme(getDefaultTheme(), customTheme);
     const enabledPagination = pagination && !progressPending && data.length > 0;
     const init = {
-      ...this.props,
-      ...this.state,
-      ...{ columns: this.columns },
-      ...{ internalCell: selectableRows || expandableRows },
+      allSelected,
+      selectedCount,
+      sortColumn,
+      sortDirection,
+      keyField,
+      selectableRowsComponent,
+      selectableRowsComponentProps,
+      expandableIcon,
+      paginationRowsPerPageOptions,
+      paginationIconLastPage,
+      paginationIconFirstPage,
+      paginationIconNext,
+      paginationIconPrevious,
+      paginationComponentOptions,
+      indeterminate: selectedRows.length > 0 && !allSelected,
     };
 
     return (

--- a/src/DataTable/DataTableContext.js
+++ b/src/DataTable/DataTableContext.js
@@ -2,11 +2,34 @@ import React, { PureComponent, createContext } from 'react';
 import PropTypes from 'prop-types';
 import { defaultProps } from './propTypes';
 
+const {
+  keyField,
+  selectableRowsComponent,
+  selectableRowsComponentProps,
+  expandableIcon,
+  paginationTotalRows,
+  paginationRowsPerPageOptions,
+  paginationIconLastPage,
+  paginationIconFirstPage,
+  paginationIconNext,
+  paginationIconPrevious,
+  paginationComponentOptions,
+} = defaultProps;
+
 export const defaultState = {
-  columns: [],
   selectedRows: [],
-  internalCell: false,
-  ...defaultProps,
+  indeterminate: false,
+  keyField,
+  selectableRowsComponent,
+  selectableRowsComponentProps,
+  expandableIcon,
+  paginationTotalRows,
+  paginationRowsPerPageOptions,
+  paginationIconLastPage,
+  paginationIconFirstPage,
+  paginationIconNext,
+  paginationIconPrevious,
+  paginationComponentOptions,
 };
 
 export const DataTableContext = createContext(defaultState);

--- a/src/DataTable/TableCell.js
+++ b/src/DataTable/TableCell.js
@@ -1,7 +1,6 @@
-import React, { memo, useContext } from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { DataTableContext } from './DataTableContext';
 import { Cell } from './Cell';
 import { getProperty } from './util';
 
@@ -26,29 +25,17 @@ const ClickClip = styled.div`
   height: 100%;
 `;
 
-const TableCell = memo(({
-  column,
-  row,
-  rowClickable,
-}) => {
-  const { internalCell } = useContext(DataTableContext);
+const TableCell = memo(({ column, row, rowClickable }) => (
+  <TableCellStyle column={column} className="rdt_TableCell">
+    {!column.ignoreRowClick && rowClickable && (
+      <ClickClip data-tag="___react-data-table--click-clip___" />
+    )}
 
-  return (
-    <TableCellStyle
-      column={column}
-      internalCell={internalCell}
-      className="rdt_TableCell"
-    >
-      {!column.ignoreRowClick && rowClickable && (
-        <ClickClip data-tag="___react-data-table--click-clip___" />
-      )}
-
-      <div className="react-data-table--cell-content">
-        {column.cell ? column.cell(row) : getProperty(row, column.selector, column.format)}
-      </div>
-    </TableCellStyle>
-  );
-});
+    <div className="react-data-table--cell-content">
+      {column.cell ? column.cell(row) : getProperty(row, column.selector, column.format)}
+    </div>
+  </TableCellStyle>
+));
 
 TableCell.propTypes = {
   column: PropTypes.object,

--- a/src/DataTable/TableCol.js
+++ b/src/DataTable/TableCol.js
@@ -60,6 +60,10 @@ class TableCol extends PureComponent {
   static propTypes = {
     onColumnClick: PropTypes.func.isRequired,
     column: PropTypes.object.isRequired,
+    sortIcon: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.object,
+    ]).isRequired,
   };
 
   static contextType = DataTableContext;
@@ -76,12 +80,17 @@ class TableCol extends PureComponent {
     const { sortDirection } = this.context;
 
     return (
-      <NativeSortIcon column={column} sortActive={sortActive} sortDirection={sortDirection} />
+      <NativeSortIcon
+        column={column}
+        sortActive={sortActive}
+        sortDirection={sortDirection}
+      />
     );
   }
 
   renderCustomSortIcon() {
-    const { sortIcon, sortDirection } = this.context;
+    const { sortIcon } = this.props;
+    const { sortDirection } = this.context;
 
     return (
       <span className={[sortDirection, '__rdt_custom_sort_icon__'].join(' ')}>
@@ -91,8 +100,8 @@ class TableCol extends PureComponent {
   }
 
   render() {
-    const { column } = this.props;
-    const { sortIcon, sortColumn, internalCell } = this.context;
+    const { column, sortIcon } = this.props;
+    const { sortColumn } = this.context;
     const sortActive = column.sortable && sortColumn === column.selector;
     const nativeSortIconLeft = !sortIcon && !column.right;
     const nativeSortIconRight = !sortIcon && column.right;
@@ -103,7 +112,6 @@ class TableCol extends PureComponent {
       <TableColStyle
         className="rdt_TableCol"
         column={column} // required by Cell.js
-        internalCell={internalCell} // required by Cell.js
       >
         {column.name && (
           <ColumnSortable

--- a/src/DataTable/TableColCheckbox.js
+++ b/src/DataTable/TableColCheckbox.js
@@ -14,10 +14,8 @@ const TableColStyle = styled(CellBase)`
   min-height: ${props => props.theme.header.height};
 `;
 
-const TableCol = memo(({
-  onClick,
-}) => {
-  const { selectableRowsComponent, selectableRowsComponentProps, selectedRows, allSelected } = useContext(DataTableContext);
+const TableCol = memo(({ onClick }) => {
+  const { selectableRowsComponent, selectableRowsComponentProps, allSelected, indeterminate } = useContext(DataTableContext);
 
   return (
     <TableColStyle className="rdt_TableCol">
@@ -27,7 +25,7 @@ const TableCol = memo(({
         componentOptions={selectableRowsComponentProps}
         onClick={onClick}
         checked={allSelected}
-        indeterminate={selectedRows.length > 0 && !allSelected}
+        indeterminate={indeterminate}
       />
     </TableColStyle>
   );

--- a/src/DataTable/TableRow.js
+++ b/src/DataTable/TableRow.js
@@ -59,15 +59,25 @@ const TableRowStyle = styled.div`
 
 class TableRow extends PureComponent {
   static propTypes = {
+    keyField: PropTypes.string.isRequired,
+    columns: PropTypes.array.isRequired,
     row: PropTypes.object.isRequired,
     onRowClicked: PropTypes.func.isRequired,
+    defaultExpanded: PropTypes.bool.isRequired,
+    selectableRows: PropTypes.bool.isRequired,
+    expandableRows: PropTypes.bool.isRequired,
+    striped: PropTypes.bool.isRequired,
+    highlightOnHover: PropTypes.bool.isRequired,
+    pointerOnHover: PropTypes.bool.isRequired,
+    expandableRowsComponent: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node,
+      PropTypes.func,
+    ]).isRequired,
+    expandableDisabledField: PropTypes.string.isRequired,
     onRowSelected: PropTypes.func.isRequired,
-    defaultExpanded: PropTypes.bool,
+    isRowSelected: PropTypes.func.isRequired,
   };
-
-  static defaultProps = {
-    defaultExpanded: false,
-  }
 
   static contextType = DataTableContext;
 
@@ -79,12 +89,6 @@ class TableRow extends PureComponent {
     };
   }
 
-  handleRowSelected = row => {
-    const { onRowSelected } = this.props;
-
-    onRowSelected(row);
-  }
-
   handleRowClick = e => {
     // use event delegation allow events to propogate only when the element with data-tag __react-data-table--click-clip___ is present
     if (e.target && e.target.getAttribute('data-tag') === '___react-data-table--click-clip___') {
@@ -94,20 +98,27 @@ class TableRow extends PureComponent {
     }
   };
 
-  isChecked = (row, selectedRows) => selectedRows.some(srow => srow === row);
-
   toggleRowExpand = () => {
     this.setState(state => ({ expanded: !state.expanded }));
   }
 
   render() {
     const {
+      keyField,
+      columns,
       row,
       onRowClicked,
+      selectableRows,
+      expandableRows,
+      striped,
+      highlightOnHover,
+      pointerOnHover,
+      expandableRowsComponent,
+      expandableDisabledField,
+      onRowSelected,
+      isRowSelected,
     } = this.props;
-
     const { expanded } = this.state;
-    const { keyField, columns, selectedRows, selectableRows, expandableRows, striped, highlightOnHover, pointerOnHover, expandableRowsComponent, expandableDisabledField } = this.context;
 
     return (
       <React.Fragment>
@@ -120,8 +131,8 @@ class TableRow extends PureComponent {
         >
           {selectableRows && (
             <TableCellCheckbox
-              checked={this.isChecked(row, selectedRows)}
-              onClick={this.handleRowSelected}
+              checked={isRowSelected(row)}
+              onClick={onRowSelected}
               row={row}
             />
           )}
@@ -137,7 +148,6 @@ class TableRow extends PureComponent {
 
           {columns.map(column => (
             <TableCell
-              type="cell"
               key={`cell-${column.id}-${row[keyField]}`}
               column={column}
               row={row}
@@ -146,7 +156,7 @@ class TableRow extends PureComponent {
           ))}
         </TableRowStyle>
 
-        {expanded && (
+        {expandableRows && expanded && (
           <ExpanderRow
             key={`expander--${row[keyField]}`}
             data={row}

--- a/src/DataTable/__tests__/DataTable.test.js
+++ b/src/DataTable/__tests__/DataTable.test.js
@@ -197,6 +197,54 @@ describe('DataTable::columns', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('should render correctly if column.hide sm', () => {
+    const mock = dataMock({ hide: 'sm' });
+    const { container } = render(
+      <DataTable
+        data={mock.data}
+        columns={mock.columns}
+      />,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('should render correctly if column.hide md', () => {
+    const mock = dataMock({ hide: 'md' });
+    const { container } = render(
+      <DataTable
+        data={mock.data}
+        columns={mock.columns}
+      />,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('should render correctly if column.hide lg', () => {
+    const mock = dataMock({ hide: 'lg' });
+    const { container } = render(
+      <DataTable
+        data={mock.data}
+        columns={mock.columns}
+      />,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('should render correctly if column.hide is an integer', () => {
+    const mock = dataMock({ hide: 300 });
+    const { container } = render(
+      <DataTable
+        data={mock.data}
+        columns={mock.columns}
+      />,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });
 
 describe('DataTable::progress/nodata', () => {
@@ -338,7 +386,6 @@ describe('DataTable::sorting', () => {
       <DataTable
         data={mock.data}
         columns={mock.columns}
-        expandableRows
       />,
     );
 
@@ -353,7 +400,6 @@ describe('DataTable::sorting', () => {
       <DataTable
         data={mock.data}
         columns={mock.columns}
-        expandableRows
       />,
     );
 
@@ -434,8 +480,21 @@ describe('DataTable::expandableRows', () => {
       <DataTable
         data={mock.data}
         columns={mock.columns}
-        defaultSortField="some.name"
         expandableRows
+      />,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('should not render expandableRows expandableRows is missing', () => {
+    const mock = dataMock();
+    mock.data[0].defaultExpanded = true;
+    const { container } = render(
+      <DataTable
+        data={mock.data}
+        columns={mock.columns}
+        defaultExpandedField="defaultExpanded"
       />,
     );
 
@@ -448,7 +507,6 @@ describe('DataTable::expandableRows', () => {
       <DataTable
         data={mock.data}
         columns={mock.columns}
-        defaultSortField="some.name"
         expandableRows
       />,
     );
@@ -481,7 +539,6 @@ describe('DataTable::selectableRows', () => {
       <DataTable
         data={mock.data}
         columns={mock.columns}
-        defaultSortField="some.name"
         selectableRows
       />,
     );
@@ -495,7 +552,6 @@ describe('DataTable::selectableRows', () => {
       <DataTable
         data={mock.data}
         columns={mock.columns}
-        defaultSortField="some.name"
         selectableRows
       />,
     );
@@ -511,7 +567,6 @@ describe('DataTable::selectableRows', () => {
       <DataTable
         data={mock.data}
         columns={mock.columns}
-        defaultSortField="some.name"
         selectableRows
       />,
     );
@@ -527,7 +582,6 @@ describe('DataTable::selectableRows', () => {
       <DataTable
         data={mock.data}
         columns={mock.columns}
-        defaultSortField="some.name"
         selectableRows
       />,
     );
@@ -543,7 +597,6 @@ describe('DataTable::selectableRows', () => {
       <DataTable
         data={mock.data}
         columns={mock.columns}
-        defaultSortField="some.name"
         selectableRows
       />,
     );
@@ -554,7 +607,6 @@ describe('DataTable::selectableRows', () => {
       <DataTable
         data={mock.data}
         columns={mock.columns}
-        defaultSortField="some.name"
         selectableRows
         clearSelectedRows
       />,
@@ -570,7 +622,6 @@ describe('DataTable::selectableRows', () => {
       <DataTable
         data={mock.data}
         columns={mock.columns}
-        defaultSortField="some.name"
         selectableRows
         onRowClicked={rowClickedMock}
       />,

--- a/src/DataTable/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/DataTable/__tests__/__snapshots__/DataTable.test.js.snap
@@ -492,6 +492,10 @@ exports[`DataTable::Header context menu should render correctly when selectableR
   min-height: 48px;
 }
 
+.c17:first-child {
+  padding-left: calc(48px / 2);
+}
+
 .c17:last-child {
   padding-right: calc(48px / 2);
 }
@@ -591,6 +595,10 @@ exports[`DataTable::Header context menu should render correctly when selectableR
   max-width: 100%;
   min-width: 100px;
   min-height: 48px;
+}
+
+.c11:first-child {
+  padding-left: calc(48px / 2);
 }
 
 .c11:last-child {
@@ -3552,6 +3560,10 @@ exports[`DataTable::Theming should render correctly when rows spaced 1`] = `
   min-height: 48px;
 }
 
+.c18:first-child {
+  padding-left: calc(48px / 2);
+}
+
 .c18:last-child {
   padding-right: calc(48px / 2);
 }
@@ -3678,6 +3690,10 @@ exports[`DataTable::Theming should render correctly when rows spaced 1`] = `
   max-width: 100%;
   min-width: 100px;
   min-height: 48px;
+}
+
+.c11:first-child {
+  padding-left: calc(48px / 2);
 }
 
 .c11:last-child {
@@ -4081,6 +4097,10 @@ exports[`DataTable::Theming should render correctly when rows spaced with spacin
   min-height: 48px;
 }
 
+.c18:first-child {
+  padding-left: calc(48px / 2);
+}
+
 .c18:last-child {
   padding-right: calc(48px / 2);
 }
@@ -4208,6 +4228,10 @@ exports[`DataTable::Theming should render correctly when rows spaced with spacin
   max-width: 100%;
   min-width: 100px;
   min-height: 48px;
+}
+
+.c11:first-child {
+  padding-left: calc(48px / 2);
 }
 
 .c11:last-child {
@@ -4854,6 +4878,1722 @@ exports[`DataTable::columns should render correctly if column.center 1`] = `
   display: table;
   width: 100%;
   height: 100%;
+}
+
+<div
+  class="c0"
+>
+  <header
+    class="rdt_TableHeader c1"
+  >
+    <div
+      class="c2"
+    />
+    <div
+      class="c3"
+    />
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      />
+      <div />
+    </div>
+  </header>
+  <div
+    class="c6"
+  >
+    <div
+      class="rdt_Table c7"
+    >
+      <div
+        class="rdt_TableHead c8"
+      >
+        <div
+          class="rdt_TableHeadRow c9"
+        >
+          <div
+            class="rdt_TableCol c10"
+          >
+            <div
+              class="rdt_TableCol_Sortable c11"
+              id="column-some.name"
+              role="button"
+            >
+              <div>
+                Test
+              </div>
+              <span
+                class="c12"
+              >
+                ▲
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="rdt_TableBody c13"
+        offset="250px"
+      >
+        <div
+          class="rdt_TableRow c14"
+        >
+          <div
+            class="rdt_TableCell c15"
+          >
+            <div
+              class="c16"
+              data-tag="___react-data-table--click-clip___"
+            />
+            <div
+              class="react-data-table--cell-content"
+            >
+              Apple
+            </div>
+          </div>
+        </div>
+        <div
+          class="rdt_TableRow c14"
+        >
+          <div
+            class="rdt_TableCell c15"
+          >
+            <div
+              class="c16"
+              data-tag="___react-data-table--click-clip___"
+            />
+            <div
+              class="react-data-table--cell-content"
+            >
+              Zuchinni
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataTable::columns should render correctly if column.hide is an integer 1`] = `
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  text-align: left;
+  background-color: transparent;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+
+.c15 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+  font-size: 13px;
+  font-weight: 400;
+  white-space: nowrap;
+  min-height: 48px;
+}
+
+.c15:first-child {
+  padding-left: calc(48px / 2);
+}
+
+.c15:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c15 .react-data-table--cell-content {
+  color: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c16 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 48px;
+  border-top-style: solid;
+  border-top-width: 1px;
+  border-top-color: rgba(0,0,0,.12);
+  background-color: transparent;
+  color: rgba(0,0,0,.87);
+}
+
+.c12 {
+  padding: 2px;
+  color: inherit;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  opacity: 0;
+}
+
+.c10 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+  min-height: 48px;
+}
+
+.c10:first-child {
+  padding-left: calc(48px / 2);
+}
+
+.c10:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c11 {
+  color: rgba(0,0,0,.54);
+  font-size: 12px;
+  font-weight: 500;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  line-height: 1;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c11 span.__rdt_custom_sort_icon__ i,
+.c11 span.__rdt_custom_sort_icon__ svg {
+  opacity: 0;
+  color: inherit;
+  font-size: 18px !important;
+  height: 18px !important;
+  width: 18px !important;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  -webkit-transform-style: preserve-3d;
+  -ms-transform-style: preserve-3d;
+  transform-style: preserve-3d;
+  -webkit-transition-duration: 125ms;
+  transition-duration: 125ms;
+  -webkit-transition-property: -webkit-transform;
+  -webkit-transition-property: transform;
+  transition-property: transform;
+}
+
+.c11 span.__rdt_custom_sort_icon__.asc i,
+.c11 span.__rdt_custom_sort_icon__.asc svg {
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.c5 {
+  color: rgba(0,0,0,.87);
+  font-size: 18px;
+  font-weight: 400;
+}
+
+.c4 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #e3f2fd;
+  z-index: 1;
+  -webkit-transform: translate3d(0,-100%,0);
+  -ms-transform: translate3d(0,-100%,0);
+  transform: translate3d(0,-100%,0);
+  -webkit-transition-duration: 225ms;
+  transition-duration: 225ms;
+  -webkit-transition-timing-function: cubic-bezier(0,0,0.2,1);
+  transition-timing-function: cubic-bezier(0,0,0.2,1);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+  will-change: transform;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 16px 16px 16px 24px;
+}
+
+.c1 {
+  position: relative;
+  overflow: visible;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 4px 16px 4px 24px;
+  min-height: 56px;
+  width: 100%;
+  background-color: transparent;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.c2 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  color: rgba(0,0,0,.87);
+  font-size: 22px;
+  font-weight: 400;
+}
+
+.c3 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c3 > * {
+  margin-left: 5px;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  overflow-x: auto;
+}
+
+.c6 {
+  position: relative;
+  display: table;
+  width: 100%;
+  height: 100%;
+}
+
+@media screen and (max-width:300px) {
+  .c15 {
+    display: none;
+  }
+}
+
+@media screen and (max-width:300px) {
+  .c10 {
+    display: none;
+  }
+}
+
+<div
+  class="c0"
+>
+  <header
+    class="rdt_TableHeader c1"
+  >
+    <div
+      class="c2"
+    />
+    <div
+      class="c3"
+    />
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      />
+      <div />
+    </div>
+  </header>
+  <div
+    class="c6"
+  >
+    <div
+      class="rdt_Table c7"
+    >
+      <div
+        class="rdt_TableHead c8"
+      >
+        <div
+          class="rdt_TableHeadRow c9"
+        >
+          <div
+            class="rdt_TableCol c10"
+          >
+            <div
+              class="rdt_TableCol_Sortable c11"
+              id="column-some.name"
+              role="button"
+            >
+              <div>
+                Test
+              </div>
+              <span
+                class="c12"
+              >
+                ▲
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="rdt_TableBody c13"
+        offset="250px"
+      >
+        <div
+          class="rdt_TableRow c14"
+        >
+          <div
+            class="rdt_TableCell c15"
+          >
+            <div
+              class="c16"
+              data-tag="___react-data-table--click-clip___"
+            />
+            <div
+              class="react-data-table--cell-content"
+            >
+              Apple
+            </div>
+          </div>
+        </div>
+        <div
+          class="rdt_TableRow c14"
+        >
+          <div
+            class="rdt_TableCell c15"
+          >
+            <div
+              class="c16"
+              data-tag="___react-data-table--click-clip___"
+            />
+            <div
+              class="react-data-table--cell-content"
+            >
+              Zuchinni
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataTable::columns should render correctly if column.hide lg 1`] = `
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  text-align: left;
+  background-color: transparent;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+
+.c15 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+  font-size: 13px;
+  font-weight: 400;
+  white-space: nowrap;
+  min-height: 48px;
+}
+
+.c15:first-child {
+  padding-left: calc(48px / 2);
+}
+
+.c15:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c15 .react-data-table--cell-content {
+  color: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c16 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 48px;
+  border-top-style: solid;
+  border-top-width: 1px;
+  border-top-color: rgba(0,0,0,.12);
+  background-color: transparent;
+  color: rgba(0,0,0,.87);
+}
+
+.c12 {
+  padding: 2px;
+  color: inherit;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  opacity: 0;
+}
+
+.c10 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+  min-height: 48px;
+}
+
+.c10:first-child {
+  padding-left: calc(48px / 2);
+}
+
+.c10:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c11 {
+  color: rgba(0,0,0,.54);
+  font-size: 12px;
+  font-weight: 500;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  line-height: 1;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c11 span.__rdt_custom_sort_icon__ i,
+.c11 span.__rdt_custom_sort_icon__ svg {
+  opacity: 0;
+  color: inherit;
+  font-size: 18px !important;
+  height: 18px !important;
+  width: 18px !important;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  -webkit-transform-style: preserve-3d;
+  -ms-transform-style: preserve-3d;
+  transform-style: preserve-3d;
+  -webkit-transition-duration: 125ms;
+  transition-duration: 125ms;
+  -webkit-transition-property: -webkit-transform;
+  -webkit-transition-property: transform;
+  transition-property: transform;
+}
+
+.c11 span.__rdt_custom_sort_icon__.asc i,
+.c11 span.__rdt_custom_sort_icon__.asc svg {
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.c5 {
+  color: rgba(0,0,0,.87);
+  font-size: 18px;
+  font-weight: 400;
+}
+
+.c4 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #e3f2fd;
+  z-index: 1;
+  -webkit-transform: translate3d(0,-100%,0);
+  -ms-transform: translate3d(0,-100%,0);
+  transform: translate3d(0,-100%,0);
+  -webkit-transition-duration: 225ms;
+  transition-duration: 225ms;
+  -webkit-transition-timing-function: cubic-bezier(0,0,0.2,1);
+  transition-timing-function: cubic-bezier(0,0,0.2,1);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+  will-change: transform;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 16px 16px 16px 24px;
+}
+
+.c1 {
+  position: relative;
+  overflow: visible;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 4px 16px 4px 24px;
+  min-height: 56px;
+  width: 100%;
+  background-color: transparent;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.c2 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  color: rgba(0,0,0,.87);
+  font-size: 22px;
+  font-weight: 400;
+}
+
+.c3 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c3 > * {
+  margin-left: 5px;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  overflow-x: auto;
+}
+
+.c6 {
+  position: relative;
+  display: table;
+  width: 100%;
+  height: 100%;
+}
+
+@media screen and (max-width:1280px) {
+  .c15 {
+    display: none;
+  }
+}
+
+@media screen and (max-width:1280px) {
+  .c10 {
+    display: none;
+  }
+}
+
+<div
+  class="c0"
+>
+  <header
+    class="rdt_TableHeader c1"
+  >
+    <div
+      class="c2"
+    />
+    <div
+      class="c3"
+    />
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      />
+      <div />
+    </div>
+  </header>
+  <div
+    class="c6"
+  >
+    <div
+      class="rdt_Table c7"
+    >
+      <div
+        class="rdt_TableHead c8"
+      >
+        <div
+          class="rdt_TableHeadRow c9"
+        >
+          <div
+            class="rdt_TableCol c10"
+          >
+            <div
+              class="rdt_TableCol_Sortable c11"
+              id="column-some.name"
+              role="button"
+            >
+              <div>
+                Test
+              </div>
+              <span
+                class="c12"
+              >
+                ▲
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="rdt_TableBody c13"
+        offset="250px"
+      >
+        <div
+          class="rdt_TableRow c14"
+        >
+          <div
+            class="rdt_TableCell c15"
+          >
+            <div
+              class="c16"
+              data-tag="___react-data-table--click-clip___"
+            />
+            <div
+              class="react-data-table--cell-content"
+            >
+              Apple
+            </div>
+          </div>
+        </div>
+        <div
+          class="rdt_TableRow c14"
+        >
+          <div
+            class="rdt_TableCell c15"
+          >
+            <div
+              class="c16"
+              data-tag="___react-data-table--click-clip___"
+            />
+            <div
+              class="react-data-table--cell-content"
+            >
+              Zuchinni
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataTable::columns should render correctly if column.hide md 1`] = `
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  text-align: left;
+  background-color: transparent;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+
+.c15 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+  font-size: 13px;
+  font-weight: 400;
+  white-space: nowrap;
+  min-height: 48px;
+}
+
+.c15:first-child {
+  padding-left: calc(48px / 2);
+}
+
+.c15:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c15 .react-data-table--cell-content {
+  color: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c16 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 48px;
+  border-top-style: solid;
+  border-top-width: 1px;
+  border-top-color: rgba(0,0,0,.12);
+  background-color: transparent;
+  color: rgba(0,0,0,.87);
+}
+
+.c12 {
+  padding: 2px;
+  color: inherit;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  opacity: 0;
+}
+
+.c10 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+  min-height: 48px;
+}
+
+.c10:first-child {
+  padding-left: calc(48px / 2);
+}
+
+.c10:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c11 {
+  color: rgba(0,0,0,.54);
+  font-size: 12px;
+  font-weight: 500;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  line-height: 1;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c11 span.__rdt_custom_sort_icon__ i,
+.c11 span.__rdt_custom_sort_icon__ svg {
+  opacity: 0;
+  color: inherit;
+  font-size: 18px !important;
+  height: 18px !important;
+  width: 18px !important;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  -webkit-transform-style: preserve-3d;
+  -ms-transform-style: preserve-3d;
+  transform-style: preserve-3d;
+  -webkit-transition-duration: 125ms;
+  transition-duration: 125ms;
+  -webkit-transition-property: -webkit-transform;
+  -webkit-transition-property: transform;
+  transition-property: transform;
+}
+
+.c11 span.__rdt_custom_sort_icon__.asc i,
+.c11 span.__rdt_custom_sort_icon__.asc svg {
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.c5 {
+  color: rgba(0,0,0,.87);
+  font-size: 18px;
+  font-weight: 400;
+}
+
+.c4 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #e3f2fd;
+  z-index: 1;
+  -webkit-transform: translate3d(0,-100%,0);
+  -ms-transform: translate3d(0,-100%,0);
+  transform: translate3d(0,-100%,0);
+  -webkit-transition-duration: 225ms;
+  transition-duration: 225ms;
+  -webkit-transition-timing-function: cubic-bezier(0,0,0.2,1);
+  transition-timing-function: cubic-bezier(0,0,0.2,1);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+  will-change: transform;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 16px 16px 16px 24px;
+}
+
+.c1 {
+  position: relative;
+  overflow: visible;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 4px 16px 4px 24px;
+  min-height: 56px;
+  width: 100%;
+  background-color: transparent;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.c2 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  color: rgba(0,0,0,.87);
+  font-size: 22px;
+  font-weight: 400;
+}
+
+.c3 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c3 > * {
+  margin-left: 5px;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  overflow-x: auto;
+}
+
+.c6 {
+  position: relative;
+  display: table;
+  width: 100%;
+  height: 100%;
+}
+
+@media screen and (max-width:959px) {
+  .c15 {
+    display: none;
+  }
+}
+
+@media screen and (max-width:959px) {
+  .c10 {
+    display: none;
+  }
+}
+
+<div
+  class="c0"
+>
+  <header
+    class="rdt_TableHeader c1"
+  >
+    <div
+      class="c2"
+    />
+    <div
+      class="c3"
+    />
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      />
+      <div />
+    </div>
+  </header>
+  <div
+    class="c6"
+  >
+    <div
+      class="rdt_Table c7"
+    >
+      <div
+        class="rdt_TableHead c8"
+      >
+        <div
+          class="rdt_TableHeadRow c9"
+        >
+          <div
+            class="rdt_TableCol c10"
+          >
+            <div
+              class="rdt_TableCol_Sortable c11"
+              id="column-some.name"
+              role="button"
+            >
+              <div>
+                Test
+              </div>
+              <span
+                class="c12"
+              >
+                ▲
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="rdt_TableBody c13"
+        offset="250px"
+      >
+        <div
+          class="rdt_TableRow c14"
+        >
+          <div
+            class="rdt_TableCell c15"
+          >
+            <div
+              class="c16"
+              data-tag="___react-data-table--click-clip___"
+            />
+            <div
+              class="react-data-table--cell-content"
+            >
+              Apple
+            </div>
+          </div>
+        </div>
+        <div
+          class="rdt_TableRow c14"
+        >
+          <div
+            class="rdt_TableCell c15"
+          >
+            <div
+              class="c16"
+              data-tag="___react-data-table--click-clip___"
+            />
+            <div
+              class="react-data-table--cell-content"
+            >
+              Zuchinni
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataTable::columns should render correctly if column.hide sm 1`] = `
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  text-align: left;
+  background-color: transparent;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+
+.c15 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+  font-size: 13px;
+  font-weight: 400;
+  white-space: nowrap;
+  min-height: 48px;
+}
+
+.c15:first-child {
+  padding-left: calc(48px / 2);
+}
+
+.c15:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c15 .react-data-table--cell-content {
+  color: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c16 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 48px;
+  border-top-style: solid;
+  border-top-width: 1px;
+  border-top-color: rgba(0,0,0,.12);
+  background-color: transparent;
+  color: rgba(0,0,0,.87);
+}
+
+.c12 {
+  padding: 2px;
+  color: inherit;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  opacity: 0;
+}
+
+.c10 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+  min-height: 48px;
+}
+
+.c10:first-child {
+  padding-left: calc(48px / 2);
+}
+
+.c10:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c11 {
+  color: rgba(0,0,0,.54);
+  font-size: 12px;
+  font-weight: 500;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  line-height: 1;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c11 span.__rdt_custom_sort_icon__ i,
+.c11 span.__rdt_custom_sort_icon__ svg {
+  opacity: 0;
+  color: inherit;
+  font-size: 18px !important;
+  height: 18px !important;
+  width: 18px !important;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  -webkit-transform-style: preserve-3d;
+  -ms-transform-style: preserve-3d;
+  transform-style: preserve-3d;
+  -webkit-transition-duration: 125ms;
+  transition-duration: 125ms;
+  -webkit-transition-property: -webkit-transform;
+  -webkit-transition-property: transform;
+  transition-property: transform;
+}
+
+.c11 span.__rdt_custom_sort_icon__.asc i,
+.c11 span.__rdt_custom_sort_icon__.asc svg {
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.c5 {
+  color: rgba(0,0,0,.87);
+  font-size: 18px;
+  font-weight: 400;
+}
+
+.c4 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #e3f2fd;
+  z-index: 1;
+  -webkit-transform: translate3d(0,-100%,0);
+  -ms-transform: translate3d(0,-100%,0);
+  transform: translate3d(0,-100%,0);
+  -webkit-transition-duration: 225ms;
+  transition-duration: 225ms;
+  -webkit-transition-timing-function: cubic-bezier(0,0,0.2,1);
+  transition-timing-function: cubic-bezier(0,0,0.2,1);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+  will-change: transform;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 16px 16px 16px 24px;
+}
+
+.c1 {
+  position: relative;
+  overflow: visible;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 4px 16px 4px 24px;
+  min-height: 56px;
+  width: 100%;
+  background-color: transparent;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.c2 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  color: rgba(0,0,0,.87);
+  font-size: 22px;
+  font-weight: 400;
+}
+
+.c3 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c3 > * {
+  margin-left: 5px;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  overflow-x: auto;
+}
+
+.c6 {
+  position: relative;
+  display: table;
+  width: 100%;
+  height: 100%;
+}
+
+@media screen and (max-width:599px) {
+  .c15 {
+    display: none;
+  }
+}
+
+@media screen and (max-width:599px) {
+  .c10 {
+    display: none;
+  }
 }
 
 <div
@@ -9149,6 +10889,423 @@ exports[`DataTable::columns should render correctly with columns/data 1`] = `
 </div>
 `;
 
+exports[`DataTable::expandableRows should not render expandableRows expandableRows is missing 1`] = `
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  text-align: left;
+  background-color: transparent;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+
+.c15 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+  font-size: 13px;
+  font-weight: 400;
+  white-space: nowrap;
+  min-height: 48px;
+}
+
+.c15:first-child {
+  padding-left: calc(48px / 2);
+}
+
+.c15:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c15 .react-data-table--cell-content {
+  color: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c16 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 48px;
+  border-top-style: solid;
+  border-top-width: 1px;
+  border-top-color: rgba(0,0,0,.12);
+  background-color: transparent;
+  color: rgba(0,0,0,.87);
+}
+
+.c12 {
+  padding: 2px;
+  color: inherit;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  opacity: 0;
+}
+
+.c10 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+  min-height: 48px;
+}
+
+.c10:first-child {
+  padding-left: calc(48px / 2);
+}
+
+.c10:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c11 {
+  color: rgba(0,0,0,.54);
+  font-size: 12px;
+  font-weight: 500;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  line-height: 1;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c11 span.__rdt_custom_sort_icon__ i,
+.c11 span.__rdt_custom_sort_icon__ svg {
+  opacity: 0;
+  color: inherit;
+  font-size: 18px !important;
+  height: 18px !important;
+  width: 18px !important;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  -webkit-transform-style: preserve-3d;
+  -ms-transform-style: preserve-3d;
+  transform-style: preserve-3d;
+  -webkit-transition-duration: 125ms;
+  transition-duration: 125ms;
+  -webkit-transition-property: -webkit-transform;
+  -webkit-transition-property: transform;
+  transition-property: transform;
+}
+
+.c11 span.__rdt_custom_sort_icon__.asc i,
+.c11 span.__rdt_custom_sort_icon__.asc svg {
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.c5 {
+  color: rgba(0,0,0,.87);
+  font-size: 18px;
+  font-weight: 400;
+}
+
+.c4 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #e3f2fd;
+  z-index: 1;
+  -webkit-transform: translate3d(0,-100%,0);
+  -ms-transform: translate3d(0,-100%,0);
+  transform: translate3d(0,-100%,0);
+  -webkit-transition-duration: 225ms;
+  transition-duration: 225ms;
+  -webkit-transition-timing-function: cubic-bezier(0,0,0.2,1);
+  transition-timing-function: cubic-bezier(0,0,0.2,1);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+  will-change: transform;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 16px 16px 16px 24px;
+}
+
+.c1 {
+  position: relative;
+  overflow: visible;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 4px 16px 4px 24px;
+  min-height: 56px;
+  width: 100%;
+  background-color: transparent;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.c2 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  color: rgba(0,0,0,.87);
+  font-size: 22px;
+  font-weight: 400;
+}
+
+.c3 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c3 > * {
+  margin-left: 5px;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  overflow-x: auto;
+}
+
+.c6 {
+  position: relative;
+  display: table;
+  width: 100%;
+  height: 100%;
+}
+
+<div
+  class="c0"
+>
+  <header
+    class="rdt_TableHeader c1"
+  >
+    <div
+      class="c2"
+    />
+    <div
+      class="c3"
+    />
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      />
+      <div />
+    </div>
+  </header>
+  <div
+    class="c6"
+  >
+    <div
+      class="rdt_Table c7"
+    >
+      <div
+        class="rdt_TableHead c8"
+      >
+        <div
+          class="rdt_TableHeadRow c9"
+        >
+          <div
+            class="rdt_TableCol c10"
+          >
+            <div
+              class="rdt_TableCol_Sortable c11"
+              id="column-some.name"
+              role="button"
+            >
+              <div>
+                Test
+              </div>
+              <span
+                class="c12"
+              >
+                ▲
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="rdt_TableBody c13"
+        offset="250px"
+      >
+        <div
+          class="rdt_TableRow c14"
+        >
+          <div
+            class="rdt_TableCell c15"
+          >
+            <div
+              class="c16"
+              data-tag="___react-data-table--click-clip___"
+            />
+            <div
+              class="react-data-table--cell-content"
+            >
+              Apple
+            </div>
+          </div>
+        </div>
+        <div
+          class="rdt_TableRow c14"
+        >
+          <div
+            class="rdt_TableCell c15"
+          >
+            <div
+              class="c16"
+              data-tag="___react-data-table--click-clip___"
+            />
+            <div
+              class="react-data-table--cell-content"
+            >
+              Zuchinni
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DataTable::expandableRows should render correctly when defaultExpandedField is true 1`] = `
 .c7 {
   display: -webkit-box;
@@ -9230,6 +11387,10 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
   font-weight: 400;
   white-space: nowrap;
   min-height: 48px;
+}
+
+.c18:first-child {
+  padding-left: calc(48px / 2);
 }
 
 .c18:last-child {
@@ -9362,6 +11523,10 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
   max-width: 100%;
   min-width: 100px;
   min-height: 48px;
+}
+
+.c11:first-child {
+  padding-left: calc(48px / 2);
 }
 
 .c11:last-child {
@@ -9774,6 +11939,10 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   min-height: 48px;
 }
 
+.c18:first-child {
+  padding-left: calc(48px / 2);
+}
+
 .c18:last-child {
   padding-right: calc(48px / 2);
 }
@@ -9897,6 +12066,10 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   max-width: 100%;
   min-width: 100px;
   min-height: 48px;
+}
+
+.c11:first-child {
+  padding-left: calc(48px / 2);
 }
 
 .c11:last-child {
@@ -10300,6 +12473,10 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   min-height: 48px;
 }
 
+.c18:first-child {
+  padding-left: calc(48px / 2);
+}
+
 .c18:last-child {
   padding-right: calc(48px / 2);
 }
@@ -10430,6 +12607,10 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   max-width: 100%;
   min-width: 100px;
   min-height: 48px;
+}
+
+.c11:first-child {
+  padding-left: calc(48px / 2);
 }
 
 .c11:last-child {
@@ -16523,6 +18704,10 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
   min-height: 48px;
 }
 
+.c17:first-child {
+  padding-left: calc(48px / 2);
+}
+
 .c17:last-child {
   padding-right: calc(48px / 2);
 }
@@ -16622,6 +18807,10 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
   max-width: 100%;
   min-width: 100px;
   min-height: 48px;
+}
+
+.c11:first-child {
+  padding-left: calc(48px / 2);
 }
 
 .c11:last-child {
@@ -17015,6 +19204,10 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
   min-height: 48px;
 }
 
+.c17:first-child {
+  padding-left: calc(48px / 2);
+}
+
 .c17:last-child {
   padding-right: calc(48px / 2);
 }
@@ -17114,6 +19307,10 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
   max-width: 100%;
   min-width: 100px;
   min-height: 48px;
+}
+
+.c11:first-child {
+  padding-left: calc(48px / 2);
 }
 
 .c11:last-child {
@@ -17507,6 +19704,10 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
   min-height: 48px;
 }
 
+.c17:first-child {
+  padding-left: calc(48px / 2);
+}
+
 .c17:last-child {
   padding-right: calc(48px / 2);
 }
@@ -17606,6 +19807,10 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
   max-width: 100%;
   min-width: 100px;
   min-height: 48px;
+}
+
+.c11:first-child {
+  padding-left: calc(48px / 2);
 }
 
 .c11:last-child {
@@ -17967,6 +20172,93 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
   width: 100%;
 }
 
+.c15 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+  font-size: 13px;
+  font-weight: 400;
+  white-space: nowrap;
+  min-height: 48px;
+}
+
+.c15:first-child {
+  padding-left: calc(48px / 2);
+}
+
+.c15:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c15 .react-data-table--cell-content {
+  color: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c16 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 48px;
+  border-top-style: solid;
+  border-top-width: 1px;
+  border-top-color: rgba(0,0,0,.12);
+  background-color: transparent;
+  color: rgba(0,0,0,.87);
+}
+
+.c12 {
+  padding: 2px;
+  color: inherit;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  opacity: 1;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
 .c10 {
   position: relative;
   display: -webkit-box;
@@ -17983,24 +20275,6 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
   padding-right: calc(48px / 6);
   padding-top: calc(48px / 12);
   padding-bottom: calc(48px / 12);
-}
-
-.c18 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  box-sizing: border-box;
-  line-height: normal;
-  padding-left: calc(48px / 6);
-  padding-right: calc(48px / 6);
-  padding-top: calc(48px / 12);
-  padding-bottom: calc(48px / 12);
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -18013,145 +20287,18 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 13px;
-  font-weight: 400;
-  white-space: nowrap;
   min-height: 48px;
 }
 
-.c18:last-child {
+.c10:first-child {
+  padding-left: calc(48px / 2);
+}
+
+.c10:last-child {
   padding-right: calc(48px / 2);
-}
-
-.c18 .react-data-table--cell-content {
-  color: inherit;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.c19 {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.c17 {
-  outline: none;
-  border: none;
-  display: block;
-  width: 40px;
-  height: 40px;
-  background-color: transparent;
-  color: rgba(0,0,0,.54);
-}
-
-.c17:disabled {
-  color: rgba(0,0,0,.12);
-}
-
-.c17:hover:enabled {
-  cursor: pointer;
-}
-
-.c16 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  box-sizing: border-box;
-  line-height: normal;
-  padding-left: calc(48px / 6);
-  padding-right: calc(48px / 6);
-  padding-top: calc(48px / 12);
-  padding-bottom: calc(48px / 12);
-  -webkit-flex: 0 0 56px;
-  -ms-flex: 0 0 56px;
-  flex: 0 0 56px;
-  white-space: nowrap;
-  font-weight: 400;
-  font-size: 13px;
-  color: rgba(0,0,0,.87);
-  min-height: 48px;
-}
-
-.c16:not(:first-child) {
-  padding-left: 0;
-}
-
-.c15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
-  box-sizing: border-box;
-  min-height: 48px;
-  border-top-style: solid;
-  border-top-width: 1px;
-  border-top-color: rgba(0,0,0,.12);
-  background-color: transparent;
-  color: rgba(0,0,0,.87);
-}
-
-.c13 {
-  padding: 2px;
-  color: inherit;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  opacity: 1;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
 }
 
 .c11 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  box-sizing: border-box;
-  line-height: normal;
-  padding-left: calc(48px / 6);
-  padding-right: calc(48px / 6);
-  padding-top: calc(48px / 12);
-  padding-bottom: calc(48px / 12);
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  max-width: 100%;
-  min-width: 100px;
-  min-height: 48px;
-}
-
-.c11:last-child {
-  padding-right: calc(48px / 2);
-}
-
-.c12 {
   color: rgba(0,0,0,.54);
   font-size: 12px;
   font-weight: 500;
@@ -18172,8 +20319,8 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
   color: rgba(0,0,0,.87);
 }
 
-.c12 span.__rdt_custom_sort_icon__ i,
-.c12 span.__rdt_custom_sort_icon__ svg {
+.c11 span.__rdt_custom_sort_icon__ i,
+.c11 span.__rdt_custom_sort_icon__ svg {
   opacity: 1;
   color: inherit;
   font-size: 18px !important;
@@ -18191,14 +20338,14 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
   transition-property: transform;
 }
 
-.c12 span.__rdt_custom_sort_icon__.asc i,
-.c12 span.__rdt_custom_sort_icon__.asc svg {
+.c11 span.__rdt_custom_sort_icon__.asc i,
+.c11 span.__rdt_custom_sort_icon__.asc svg {
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
 }
 
-.c12:hover {
+.c11:hover {
   cursor: pointer;
   color: rgba(0,0,0,.87);
 }
@@ -18300,7 +20447,7 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
   margin-left: 5px;
 }
 
-.c14 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -18357,13 +20504,10 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
           class="rdt_TableHeadRow c9"
         >
           <div
-            class="c10"
-          />
-          <div
-            class="rdt_TableCol c11"
+            class="rdt_TableCol c10"
           >
             <div
-              class="rdt_TableCol_Sortable c12"
+              class="rdt_TableCol_Sortable c11"
               id="column-some.name"
               role="button"
             >
@@ -18371,7 +20515,7 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
                 Test
               </div>
               <span
-                class="c13"
+                class="c12"
               >
                 ▲
               </span>
@@ -18380,41 +20524,17 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
         </div>
       </div>
       <div
-        class="rdt_TableBody c14"
+        class="rdt_TableBody c13"
         offset="250px"
       >
         <div
-          class="rdt_TableRow c15"
+          class="rdt_TableRow c14"
         >
           <div
-            class="c16"
-          >
-            <button
-              class="c17"
-              data-testid="expander-button-2"
-            >
-              <svg
-                fill="currentColor"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"
-                />
-                <path
-                  d="M0-.25h24v24H0z"
-                  fill="none"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="rdt_TableCell c18"
+            class="rdt_TableCell c15"
           >
             <div
-              class="c19"
+              class="c16"
               data-tag="___react-data-table--click-clip___"
             />
             <div
@@ -18425,37 +20545,13 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
           </div>
         </div>
         <div
-          class="rdt_TableRow c15"
+          class="rdt_TableRow c14"
         >
           <div
-            class="c16"
-          >
-            <button
-              class="c17"
-              data-testid="expander-button-1"
-            >
-              <svg
-                fill="currentColor"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"
-                />
-                <path
-                  d="M0-.25h24v24H0z"
-                  fill="none"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="rdt_TableCell c18"
+            class="rdt_TableCell c15"
           >
             <div
-              class="c19"
+              class="c16"
               data-tag="___react-data-table--click-clip___"
             />
             <div
@@ -18502,6 +20598,90 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
   width: 100%;
 }
 
+.c15 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  padding-top: calc(48px / 12);
+  padding-bottom: calc(48px / 12);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+  font-size: 13px;
+  font-weight: 400;
+  white-space: nowrap;
+  min-height: 48px;
+}
+
+.c15:first-child {
+  padding-left: calc(48px / 2);
+}
+
+.c15:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c15 .react-data-table--cell-content {
+  color: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c16 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 48px;
+  border-top-style: solid;
+  border-top-width: 1px;
+  border-top-color: rgba(0,0,0,.12);
+  background-color: transparent;
+  color: rgba(0,0,0,.87);
+}
+
+.c12 {
+  padding: 2px;
+  color: inherit;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  opacity: 1;
+}
+
 .c10 {
   position: relative;
   display: -webkit-box;
@@ -18518,24 +20698,6 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
   padding-right: calc(48px / 6);
   padding-top: calc(48px / 12);
   padding-bottom: calc(48px / 12);
-}
-
-.c18 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  box-sizing: border-box;
-  line-height: normal;
-  padding-left: calc(48px / 6);
-  padding-right: calc(48px / 6);
-  padding-top: calc(48px / 12);
-  padding-bottom: calc(48px / 12);
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -18548,142 +20710,18 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-  font-size: 13px;
-  font-weight: 400;
-  white-space: nowrap;
   min-height: 48px;
 }
 
-.c18:last-child {
+.c10:first-child {
+  padding-left: calc(48px / 2);
+}
+
+.c10:last-child {
   padding-right: calc(48px / 2);
-}
-
-.c18 .react-data-table--cell-content {
-  color: inherit;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.c19 {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.c17 {
-  outline: none;
-  border: none;
-  display: block;
-  width: 40px;
-  height: 40px;
-  background-color: transparent;
-  color: rgba(0,0,0,.54);
-}
-
-.c17:disabled {
-  color: rgba(0,0,0,.12);
-}
-
-.c17:hover:enabled {
-  cursor: pointer;
-}
-
-.c16 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  box-sizing: border-box;
-  line-height: normal;
-  padding-left: calc(48px / 6);
-  padding-right: calc(48px / 6);
-  padding-top: calc(48px / 12);
-  padding-bottom: calc(48px / 12);
-  -webkit-flex: 0 0 56px;
-  -ms-flex: 0 0 56px;
-  flex: 0 0 56px;
-  white-space: nowrap;
-  font-weight: 400;
-  font-size: 13px;
-  color: rgba(0,0,0,.87);
-  min-height: 48px;
-}
-
-.c16:not(:first-child) {
-  padding-left: 0;
-}
-
-.c15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
-  box-sizing: border-box;
-  min-height: 48px;
-  border-top-style: solid;
-  border-top-width: 1px;
-  border-top-color: rgba(0,0,0,.12);
-  background-color: transparent;
-  color: rgba(0,0,0,.87);
-}
-
-.c13 {
-  padding: 2px;
-  color: inherit;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  opacity: 1;
 }
 
 .c11 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  box-sizing: border-box;
-  line-height: normal;
-  padding-left: calc(48px / 6);
-  padding-right: calc(48px / 6);
-  padding-top: calc(48px / 12);
-  padding-bottom: calc(48px / 12);
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  max-width: 100%;
-  min-width: 100px;
-  min-height: 48px;
-}
-
-.c11:last-child {
-  padding-right: calc(48px / 2);
-}
-
-.c12 {
   color: rgba(0,0,0,.54);
   font-size: 12px;
   font-weight: 500;
@@ -18704,8 +20742,8 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
   color: rgba(0,0,0,.87);
 }
 
-.c12 span.__rdt_custom_sort_icon__ i,
-.c12 span.__rdt_custom_sort_icon__ svg {
+.c11 span.__rdt_custom_sort_icon__ i,
+.c11 span.__rdt_custom_sort_icon__ svg {
   opacity: 1;
   color: inherit;
   font-size: 18px !important;
@@ -18723,14 +20761,14 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
   transition-property: transform;
 }
 
-.c12 span.__rdt_custom_sort_icon__.asc i,
-.c12 span.__rdt_custom_sort_icon__.asc svg {
+.c11 span.__rdt_custom_sort_icon__.asc i,
+.c11 span.__rdt_custom_sort_icon__.asc svg {
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
 }
 
-.c12:hover {
+.c11:hover {
   cursor: pointer;
   color: rgba(0,0,0,.87);
 }
@@ -18832,7 +20870,7 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
   margin-left: 5px;
 }
 
-.c14 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -18889,13 +20927,10 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
           class="rdt_TableHeadRow c9"
         >
           <div
-            class="c10"
-          />
-          <div
-            class="rdt_TableCol c11"
+            class="rdt_TableCol c10"
           >
             <div
-              class="rdt_TableCol_Sortable c12"
+              class="rdt_TableCol_Sortable c11"
               id="column-some.name"
               role="button"
             >
@@ -18903,7 +20938,7 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
                 Test
               </div>
               <span
-                class="c13"
+                class="c12"
               >
                 ▲
               </span>
@@ -18912,41 +20947,17 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
         </div>
       </div>
       <div
-        class="rdt_TableBody c14"
+        class="rdt_TableBody c13"
         offset="250px"
       >
         <div
-          class="rdt_TableRow c15"
+          class="rdt_TableRow c14"
         >
           <div
-            class="c16"
-          >
-            <button
-              class="c17"
-              data-testid="expander-button-1"
-            >
-              <svg
-                fill="currentColor"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"
-                />
-                <path
-                  d="M0-.25h24v24H0z"
-                  fill="none"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="rdt_TableCell c18"
+            class="rdt_TableCell c15"
           >
             <div
-              class="c19"
+              class="c16"
               data-tag="___react-data-table--click-clip___"
             />
             <div
@@ -18957,37 +20968,13 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
           </div>
         </div>
         <div
-          class="rdt_TableRow c15"
+          class="rdt_TableRow c14"
         >
           <div
-            class="c16"
-          >
-            <button
-              class="c17"
-              data-testid="expander-button-2"
-            >
-              <svg
-                fill="currentColor"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"
-                />
-                <path
-                  d="M0-.25h24v24H0z"
-                  fill="none"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="rdt_TableCell c18"
+            class="rdt_TableCell c15"
           >
             <div
-              class="c19"
+              class="c16"
               data-tag="___react-data-table--click-clip___"
             />
             <div


### PR DESCRIPTION
* Fix a performance issue where TableCell was constantly re-rendering. This was resolved by removing TableCell from context.  
* Moved props out of context that did not need to be there (this will be a gradual process and will be completed in a release 3.0 since it will involve converting some components to use hooks)
* adds tests for column.hide