### PR TITLE
pass rowIndex argument to cell function

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Nothing new here - we are using an array of object literals and properties to de
 | selector | string | yes      | the propery in the data set e.g.  `property1.nested1.nested2`.                                                |
 | sortable | bool   | no       | if the column is sortable                                                                                     |
 | format   | func   | no       | format the selector e.g. `row => moment(row.timestamp).format('lll')`                                         |
-| cell     | func   | no       | for ultimate control use `cell` to render your own custom component! e.g `row => <h2>{row.title}</h2>`  **Negates  `format`** |
+| cell     | func   | no       | for ultimate control use `cell` to render your own custom component! e.g `(row,rowIndex) => <h2>{row.title}</h2>`  **Negates  `format`** |
 | grow     | number | no       | [flex-grow](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow) of the column.  the is useful if you want a column to take up more width than its relatives (without having to set widths explicitly).  this will be affected by other columns where you have explicitly set widths |
 | width    | string | no       | give the column a fixed width                                                                                 |
 | minWidth | string | no       | give the column a minWidth                                                                                    |

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -225,6 +225,7 @@ class DataTable extends Component {
           onRowClicked={this.handleRowClicked}
           onRowSelected={this.handleRowSelected}
           isRowSelected={this.checkIfRowSeleted}
+          rowIndex={i}
         />
       ))
     );

--- a/src/DataTable/TableCell.js
+++ b/src/DataTable/TableCell.js
@@ -41,12 +41,14 @@ TableCell.propTypes = {
   column: PropTypes.object,
   row: PropTypes.object,
   rowClickable: PropTypes.bool,
+  rowIndex: PropTypes.number,
 };
 
 TableCell.defaultProps = {
   column: {},
   row: {},
   rowClickable: false,
+  rowIndex: 0,
 };
 
 export default TableCell;

--- a/src/DataTable/TableCell.js
+++ b/src/DataTable/TableCell.js
@@ -25,14 +25,14 @@ const ClickClip = styled.div`
   height: 100%;
 `;
 
-const TableCell = memo(({ column, row, rowClickable }) => (
+const TableCell = memo(({ column, row, rowClickable, rowIndex }) => (
   <TableCellStyle column={column} className="rdt_TableCell">
     {!column.ignoreRowClick && rowClickable && (
       <ClickClip data-tag="___react-data-table--click-clip___" />
     )}
 
     <div className="react-data-table--cell-content">
-      {column.cell ? column.cell(row) : getProperty(row, column.selector, column.format)}
+      {column.cell ? column.cell(row, rowIndex) : getProperty(row, column.selector, column.format)}
     </div>
   </TableCellStyle>
 ));

--- a/src/DataTable/TableRow.js
+++ b/src/DataTable/TableRow.js
@@ -117,6 +117,7 @@ class TableRow extends PureComponent {
       expandableDisabledField,
       onRowSelected,
       isRowSelected,
+      rowIndex
     } = this.props;
     const { expanded } = this.state;
 
@@ -152,6 +153,7 @@ class TableRow extends PureComponent {
               column={column}
               row={row}
               rowClickable={!!onRowClicked || column.button}
+              rowIndex={rowIndex}
             />
           ))}
         </TableRowStyle>

--- a/src/DataTable/TableRow.js
+++ b/src/DataTable/TableRow.js
@@ -77,6 +77,11 @@ class TableRow extends PureComponent {
     expandableDisabledField: PropTypes.string.isRequired,
     onRowSelected: PropTypes.func.isRequired,
     isRowSelected: PropTypes.func.isRequired,
+    rowIndex: PropTypes.number,
+  };
+
+  static defaultProps = {
+    rowIndex: 0,
   };
 
   static contextType = DataTableContext;
@@ -117,7 +122,7 @@ class TableRow extends PureComponent {
       expandableDisabledField,
       onRowSelected,
       isRowSelected,
-      rowIndex
+      rowIndex,
     } = this.props;
     const { expanded } = this.state;
 


### PR DESCRIPTION
It would be nice if we had access to the index of the row being rendered in the `cell` function. 

### API Change
`cell` function can now accept an additional argument, which indicates the index of the row.
`cell: row,rowIndex=>{ //doSomething }`

### Intended Use Case
For example, if we want to display the serial number column of each item in the `data` array
```
{
    name: 'Serial No',
    cell: (row,rowIndex) => rowIndex,
}
```

Please let me know if any changes are needed ?