### PR TITLE
Reset pagination on new column sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,7 +676,15 @@ If you would like to customize the layout components of React Data Table using s
 # Development
 
 ## Setup
-Install the latest [Node JS LTS](https://nodejs.org/) and [Yarn](https://yarnpkg.com) and simply run `yarn` or `yarn install` command in the root and stories directory.
+
+Make sure your local Node version is set to `10.15.0` using [nvm](https://github.com/nvm-sh/nvm) or [n](https://github.com/tj/n).  This specific version is required, as Node v12+ and potentially other versions have some broken dependencies with Storybook.
+
+```bash
+$ node --version
+# v10.15.0
+$ yarn install
+$ yarn storybook # Local hotreloading example component available at http://localhost:6006
+```
 
 > It is advised to run the script whenever NPM packages are installed.
 

--- a/src/DataTable/TableCol.js
+++ b/src/DataTable/TableCol.js
@@ -71,6 +71,12 @@ const TableCol = memo(({
         direction = sortDirection === 'asc' ? 'desc' : 'asc';
       }
 
+      // Reset to the first page whenever a new sort is triggered
+      // Imagine viewing items 21-30 of 100 in pagination
+      // triggering a sort from a column resets to items 1-10 of 100
+      // It doesn't make sense to have the new sort reorder the items while the pagination remains set to items 21 - 30,
+      // since triggering the sort generally indicates the user wants a fresh ordered list
+      dispatch({ type: 'CHANGE_PAGE', page: 1 });
       dispatch({ type: 'SORT_CHANGE', sortDirection: direction, sortColumn: column.selector });
       onSort(column, direction);
     }


### PR DESCRIPTION
Updated so that column sorts reset Pagination to first page.  I am happy to make this an optional prop, but I don't see a need, this is the default behaviour a user will always expect anyway (it doesn't really make sense to bounce between page 2 and 9, or 3 and 7 when doing alternating 'asc'/'desc' sorts, rather if the user sorts by a given column then they clearly intend to be back at page 1 of the data set with that new sort applied).

Bonus: Updated documentation to make contribution setup a little clearer particularly the required Node version.