### PR TITLE
Search box

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ When the breakpoint is reached the column will be hidden. These are the built-in
 | onSort | func | no |  | callback to access the sort state when a column is clicked. returns ([column](https://github.com/jbetancur/react-data-table-component#columns), sortDirection, event) |
 | sortFunction | func | no |  | pass in your own custom sort function e.g. `(rows, field, direction) => {...yourSortLogicHere}. you must return an array |
 
+#### Searching
+| Property | Type | Required | Default | Description |
+|--------------------------|---------------------|----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| searchEnabled | boolean | no | false | Setting to true displays a Search box below the table header. Search only checks for matches in values that the table displays (i.e. additional properties in data rows that are not displayed by the columns prop will not be matched). Search is case insensitive ('A' matches 'Apple' and 'aardvark'). |
+
 #### Pagination
 | Property | Type | Required | Default | Description |
 |--------------------------|---------------------|----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -33,6 +33,7 @@ const DataTable = memo(({
   striped,
   highlightOnHover,
   pointerOnHover,
+  searchEnabled,
   selectableRowsComponent,
   selectableRowsComponentProps,
   expandableIcon,
@@ -93,6 +94,7 @@ const DataTable = memo(({
     selectedColumn: {},
     sortDirection: getSortDirection(defaultSortAsc),
     selectedRowsFlag: false,
+    searchText: '',
     currentPage: paginationDefaultPage,
     rowsPerPage: paginationPerPage,
     data,
@@ -100,6 +102,7 @@ const DataTable = memo(({
 
   const [{
     rowsPerPage,
+    searchText,
     currentPage,
     selectedRows,
     allSelected,
@@ -229,6 +232,15 @@ const DataTable = memo(({
 
             {!data.length > 0 && !progressPending &&
               <NoData component={noDataComponent} />}
+
+            {searchEnabled && (
+              <input
+                type="text"
+                placeholder='Search...'
+                value={searchText}
+                onChange={(e) => { dispatch({ type: 'UPDATE_SEARCH_TEXT', text: e.target.value }) }}
+              />
+            )}
 
             {data.length > 0 && !progressPending && (
               <Table disabled={disabled} className="rdt_Table">

--- a/src/DataTable/tableReducer.js
+++ b/src/DataTable/tableReducer.js
@@ -22,6 +22,7 @@ export function tableReducer(state, action) {
         sortColumn,
         selectedColumn,
         sortDirection,
+        currentPage: 1,
       };
     }
 

--- a/src/DataTable/tableReducer.js
+++ b/src/DataTable/tableReducer.js
@@ -47,6 +47,13 @@ export function tableReducer(state, action) {
       };
     }
 
+    case 'UPDATE_SEARCH_TEXT': {
+      return {
+        ...state,
+        searchText: action.text,
+      };
+    }
+
     case 'CHANGE_PAGE': {
       return {
         ...state,

--- a/stories/DataTable/Basic/Basic.CustomSort.stories.js
+++ b/stories/DataTable/Basic/Basic.CustomSort.stories.js
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import orderBy from 'lodash/orderBy';

--- a/stories/DataTable/Basic/Basic.stories.js
+++ b/stories/DataTable/Basic/Basic.stories.js
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import data from '../constants/sampleMovieData';

--- a/stories/DataTable/Basic/BasicCustomCell.stories.js
+++ b/stories/DataTable/Basic/BasicCustomCell.stories.js
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import data from '../constants/sampleMovieData';

--- a/stories/DataTable/Basic/BasicExpandable.stories.js
+++ b/stories/DataTable/Basic/BasicExpandable.stories.js
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import tableDataItems from '../constants/sampleMovieData';

--- a/stories/DataTable/Basic/BasicFixedHeader.stories.js
+++ b/stories/DataTable/Basic/BasicFixedHeader.stories.js
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import data from '../constants/sampleMovieData';

--- a/stories/DataTable/Basic/BasicMedia.stories.js
+++ b/stories/DataTable/Basic/BasicMedia.stories.js
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import data from '../constants/sampleDeserts';

--- a/stories/DataTable/Basic/BasicOptimizedClass.stories.js
+++ b/stories/DataTable/Basic/BasicOptimizedClass.stories.js
@@ -1,4 +1,3 @@
-
 import React, { PureComponent } from 'react';
 import { storiesOf } from '@storybook/react';
 import tableDataItems from '../constants/sampleDeserts';

--- a/stories/DataTable/Basic/BasicOptimizedHook.stories.js
+++ b/stories/DataTable/Basic/BasicOptimizedHook.stories.js
@@ -1,4 +1,3 @@
-
 import React, { useMemo, useState, useCallback, useEffect } from 'react';
 import { storiesOf } from '@storybook/react';
 import tableDataItems from '../constants/sampleDeserts';

--- a/stories/DataTable/Basic/BasicPagination.stories.js
+++ b/stories/DataTable/Basic/BasicPagination.stories.js
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import data from '../constants/sampleMovieData';

--- a/stories/DataTable/Basic/BasicSearch.stories.js
+++ b/stories/DataTable/Basic/BasicSearch.stories.js
@@ -5,7 +5,7 @@ import DataTable from '../../../src/DataTable/DataTable';
 
 const columns = [
   {
-    name: 'Título',
+    name: 'Title',
     selector: 'title',
     sortable: true,
   },
@@ -15,24 +15,21 @@ const columns = [
     sortable: true,
   },
   {
-    name: 'Año',
+    name: 'Year',
     selector: 'year',
     sortable: true,
   },
 ];
 
-const paginationOptions = { rowsPerPageText: 'Filas por página', rangeSeparatorText: 'de' };
-
-const BasicTable = () => (
+const BasicSearchTable = () => (
   <DataTable
-    title="Lista de Peliculas"
+    title="Movie List"
     columns={columns}
     data={data}
-    pagination
-    paginationComponentOptions={paginationOptions}
+    searchEnabled
   />
 );
 
 
 storiesOf('Basic', module)
-  .add('Pagination: Options', BasicTable);
+  .add('Search', BasicSearchTable);

--- a/stories/DataTable/Basic/BasicSelect.stories.js
+++ b/stories/DataTable/Basic/BasicSelect.stories.js
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import data from '../constants/sampleMovieData';

--- a/stories/DataTable/Basic/BasicToolbar.stories.js
+++ b/stories/DataTable/Basic/BasicToolbar.stories.js
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import styled from 'styled-components';
 import { storiesOf } from '@storybook/react';

--- a/stories/DataTable/Basic/PaginationServerSide.stories.js
+++ b/stories/DataTable/Basic/PaginationServerSide.stories.js
@@ -1,4 +1,3 @@
-
 import React, { Component } from 'react';
 import axios from 'axios';
 import { storiesOf } from '@storybook/react';


### PR DESCRIPTION
Added an optional search box (set with boolean prop) to filter table data by standard string input.

Comes with documentation, a new Story, and the intelligence to only check against values actually displayed in the table rather than any that match the data set.  Doesn't have tests (although I can add them later if required) and I'm expecting some need for an extra useMemo in feedback because that seems to be a performance optimization (?) used on all the other data in this component but I haven't read up on that hook yet.  It might be able to use a bit of CSS as well to look a bit nicer.