### PR TITLE
Add a pixel unit to the select arrow's top value

### DIFF
--- a/src/DataTable/Select.js
+++ b/src/DataTable/Select.js
@@ -36,7 +36,7 @@ const SelectWrapper = styled.div`
   color: ${props => props.theme.pagination.fontColor};
 
   svg {
-    top: 1;
+    top: 1px;
     right: 0;
     color: ${props => props.theme.pagination.fontColor};
     position: absolute;


### PR DESCRIPTION
This PR fixes a CSS bug where the pagination's select arrow is not aligning because the top value was missing a unit of measurement.

