### PR TITLE
prevent re-render when passing "on" callback handlers

### DIFF
--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -129,20 +129,20 @@ const DataTable = memo(({
 
     useDidUpdateEffect(() => {
       onTableUpdate({ allSelected, selectedCount, selectedRows, sortColumn, sortDirection });
-    }, [allSelected, onTableUpdate, selectedCount, selectedRows, sortColumn, sortDirection]);
+    }, [allSelected, selectedCount, selectedRows, sortColumn, sortDirection]);
   }
 
   useDidUpdateEffect(() => {
     onRowSelected({ allSelected, selectedCount, selectedRows });
-  }, [allSelected, onTableUpdate, selectedCount, selectedRows]);
+  }, [allSelected, selectedCount, selectedRows]);
 
   useDidUpdateEffect(() => {
     onChangePage(currentPage, paginationTotalRows || data.length);
-  }, [currentPage, onChangePage]);
+  }, [currentPage]);
 
   useDidUpdateEffect(() => {
     onChangeRowsPerPage(rowsPerPage, currentPage);
-  }, [rowsPerPage, onChangeRowsPerPage]);
+  }, [rowsPerPage]);
 
   useDidUpdateEffect(() => {
     onSort(selectedColumn, sortDirection);


### PR DESCRIPTION
* Fixes #195 
* Prevent re-render when passing in a non-memoized handler for all "on" callbacks