### PR TITLE
allow hiding rowsPerPage dropdown in pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ When the breakpoint is reached the column will be hidden. These are the built-in
 | onChangePage | func | no | null | callback when paged that returns `onChangePage(page, totalRows)` |
 | onChangeRowsPerPage | func | no | null | callback when rows per page is changed returns `onChangeRowsPerPage(currentRowsPerPage, currentPage)` |
 | paginationComponent | func | no | Pagination | a component that overrides the default pagination component |
-| paginationComponentOptions | object | no | See Description | overridable options for the built in pagination component. If you are developing a custom pagination component you can use `paginationComponentOptions` to pass in your own custom props. Defaults to: ```{ rowsPerPageText: 'Rows per page:', rangeSeparatorText: 'of' }```|
+| paginationComponentOptions | object | no | See Description | override options for the built in pagination component. If you are developing a custom pagination component you can use `paginationComponentOptions` to pass in your own custom props. Defaults to: ```{ rowsPerPageText: 'Rows per page:', rangeSeparatorText: 'of', noRowsPerPage: false }```|
 | paginationIconFirstPage |  | no | JSX | a component that overrides the first page icon for the pagination |
 | paginationIconLastPage |  | no | JSX | a component that overrides the last page icon for the pagination |
 | paginationIconNext |  | no | JSX | a component that overrides the next page icon for the pagination |

--- a/src/DataTable/Pagination.js
+++ b/src/DataTable/Pagination.js
@@ -5,6 +5,12 @@ import { useTableContext } from './DataTableContext';
 import Select from './Select';
 import { getNumberOfPages } from './util';
 
+const defaultComponentOptions = {
+  rowsPerPageText: 'Rows per page:',
+  rangeSeparatorText: 'of',
+  noRowsPerPage: false,
+};
+
 const Button = styled.button`
   position: relative;
   display: block;
@@ -77,7 +83,7 @@ const Pagination = ({
   const firstIndex = (lastIndex - rowsPerPage) + 1;
   const disabledLesser = currentPage === 1;
   const disabledGreater = currentPage === numPages;
-  const { rowsPerPageText, rangeSeparatorText } = paginationComponentOptions;
+  const { rowsPerPageText, rangeSeparatorText, noRowsPerPage } = { ...defaultComponentOptions, ...paginationComponentOptions };
   const range = currentPage === numPages
     ? `${firstIndex}-${rowCount} ${rangeSeparatorText} ${rowCount}`
     : `${firstIndex}-${lastIndex} ${rangeSeparatorText} ${rowCount}`;
@@ -90,17 +96,21 @@ const Pagination = ({
 
   return (
     <>
-      <RowLabel>{rowsPerPageText}</RowLabel>
-      <Select onChange={handleRowsPerPage} defaultValue={rowsPerPage}>
-        {paginationRowsPerPageOptions.map(num => (
-          <option
-            key={num}
-            value={num}
-          >
-            {num}
-          </option>
-        ))}
-      </Select>
+      {!noRowsPerPage && (
+        <>
+          <RowLabel>{rowsPerPageText}</RowLabel>
+          <Select onChange={handleRowsPerPage} defaultValue={rowsPerPage}>
+            {paginationRowsPerPageOptions.map(num => (
+              <option
+                key={num}
+                value={num}
+              >
+                {num}
+              </option>
+            ))}
+          </Select>
+        </>
+      )}
       <Range>
         {range}
       </Range>

--- a/src/DataTable/__tests__/DataTable.test.js
+++ b/src/DataTable/__tests__/DataTable.test.js
@@ -1514,6 +1514,20 @@ describe('DataTable::Pagination', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('should render correctly when a paginationComponentOptions to hide the per page dropdown are passed', () => {
+    const mock = dataMock();
+    const { container } = render(
+      <DataTable
+        data={mock.data}
+        columns={mock.columns}
+        pagination
+        paginationComponentOptions={{ noRowsPerPage: true }}
+      />,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('should render correctly when paginationResetDefaultPage is toggled', () => {
     const mock = dataMock();
     const { container, rerender } = render(

--- a/src/DataTable/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/DataTable/__tests__/__snapshots__/DataTable.test.js.snap
@@ -7229,7 +7229,7 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
       <span
         class="c19"
       >
-        1-2 undefined 2
+        1-2 of 2
       </span>
       <div
         class="c20"
@@ -7296,6 +7296,576 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
         </button>
         <button
           class="c21"
+          disabled=""
+          id="pagination-last-page"
+        >
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"
+            />
+            <path
+              d="M0 0h24v24H0V0z"
+              fill="none"
+            />
+          </svg>
+        </button>
+      </div>
+    </footer>
+  </div>
+</div>
+`;
+
+exports[`DataTable::Pagination should render correctly when a paginationComponentOptions to hide the per page dropdown are passed 1`] = `
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  text-align: left;
+  background-color: transparent;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  min-height: 56px;
+  padding-right: 8px;
+  padding-left: 8px;
+  width: 100%;
+  background-color: transparent;
+  border-top: 1px solid rgba(0,0,0,.12);
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  min-height: 48px;
+  width: 100%;
+}
+
+.c14 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+  font-size: 13px;
+  font-weight: 400;
+}
+
+.c14:first-of-type {
+  padding-left: calc(48px / 2);
+}
+
+.c14:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c14 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 48px;
+  border-top-style: solid;
+  border-top-width: 1px;
+  border-top-color: rgba(0,0,0,.12);
+  background-color: transparent;
+  color: rgba(0,0,0,.87);
+}
+
+.c10 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: calc(48px / 6);
+  padding-right: calc(48px / 6);
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+}
+
+.c10:first-of-type {
+  padding-left: calc(48px / 2);
+}
+
+.c10:last-child {
+  padding-right: calc(48px / 2);
+}
+
+.c11 {
+  color: rgba(0,0,0,.54);
+  font-size: 12px;
+  font-weight: 500;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  line-height: 1;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c11 span.__rdt_custom_sort_icon__ i,
+.c11 span.__rdt_custom_sort_icon__ svg {
+  opacity: 0;
+  color: inherit;
+  font-size: 18px !important;
+  height: 18px !important;
+  width: 18px !important;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  -webkit-transform-style: preserve-3d;
+  -ms-transform-style: preserve-3d;
+  transform-style: preserve-3d;
+  -webkit-transition-duration: 125ms;
+  transition-duration: 125ms;
+  -webkit-transition-property: -webkit-transform;
+  -webkit-transition-property: transform;
+  transition-property: transform;
+}
+
+.c11 span.__rdt_custom_sort_icon__.asc i,
+.c11 span.__rdt_custom_sort_icon__.asc svg {
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.c5 {
+  color: rgba(0,0,0,.87);
+  font-size: 18px;
+  font-weight: 400;
+}
+
+.c4 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  box-sizing: inherit;
+  background-color: #e3f2fd;
+  z-index: 1;
+  -webkit-transform: translate3d(0,-100%,0);
+  -ms-transform: translate3d(0,-100%,0);
+  transform: translate3d(0,-100%,0);
+  -webkit-transition-duration: 225ms;
+  transition-duration: 225ms;
+  -webkit-transition-timing-function: cubic-bezier(0,0,0.2,1);
+  transition-timing-function: cubic-bezier(0,0,0.2,1);
+  -webkit-transition-delay: 0;
+  transition-delay: 0;
+  will-change: transform;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 16px 16px 16px 24px;
+}
+
+.c1 {
+  position: relative;
+  box-sizing: border-box;
+  overflow: visible;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 4px 16px 4px 24px;
+  min-height: 56px;
+  width: 100%;
+  background-color: transparent;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.c2 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  color: rgba(0,0,0,.87);
+  font-size: 22px;
+  font-weight: 400;
+}
+
+.c3 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c3 > * {
+  margin-left: 5px;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  overflow-x: auto;
+}
+
+.c6 {
+  position: relative;
+  display: table;
+  width: 100%;
+  height: 100%;
+}
+
+.c18 {
+  position: relative;
+  display: block;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  cursor: pointer;
+  border: none;
+  border-radius: 50%;
+  background-color: transparent;
+  height: 40px;
+  width: 40px;
+  padding: 8px;
+  margin: 2px;
+  -webkit-transition: 0.3s;
+  transition: 0.3s;
+}
+
+.c18 svg {
+  fill: rgba(0,0,0,.54);
+}
+
+.c18:disabled {
+  opacity: 0.4;
+  cursor: unset;
+}
+
+.c18:hover:not(:disabled) {
+  background-color: rgba(0,0,0,.12);
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  white-space: nowrap;
+  direction: ltr;
+}
+
+.c16 {
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  font-size: 13px;
+  color: rgba(0,0,0,.54);
+  margin: 0 24px;
+}
+
+<div
+  class="c0"
+>
+  <header
+    class="c1 rdt_TableHeader"
+  >
+    <div
+      class="c2"
+    />
+    <div
+      class="c3"
+    />
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      />
+      <div />
+    </div>
+  </header>
+  <div
+    class="c6"
+  >
+    <div
+      class="c7 rdt_Table"
+    >
+      <div
+        class="c8 rdt_TableHead"
+      >
+        <div
+          class="c9 rdt_TableHeadRow"
+        >
+          <div
+            class="c10 rdt_TableCol"
+          >
+            <div
+              class="c11 rdt_TableCol_Sortable"
+              id="column-some.name"
+              role="button"
+            >
+              <div>
+                Test
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="c12 rdt_TableBody"
+        offset="250px"
+      >
+        <div
+          class="c13 rdt_TableRow"
+          id="row-1"
+        >
+          <div
+            class="c14 rdt_TableCell"
+            data-tag="___react-data-table-allow-propagation___"
+            id="cell-1-1"
+          >
+            <div
+              data-tag="___react-data-table-allow-propagation___"
+            >
+              Apple
+            </div>
+          </div>
+        </div>
+        <div
+          class="c13 rdt_TableRow"
+          id="row-2"
+        >
+          <div
+            class="c14 rdt_TableCell"
+            data-tag="___react-data-table-allow-propagation___"
+            id="cell-1-2"
+          >
+            <div
+              data-tag="___react-data-table-allow-propagation___"
+            >
+              Zuchinni
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <footer
+      class="c15 rdt_TableFooter"
+    >
+      <span
+        class="c16"
+      >
+        1-2 of 2
+      </span>
+      <div
+        class="c17"
+      >
+        <button
+          class="c18"
+          disabled=""
+          id="pagination-first-page"
+        >
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"
+            />
+            <path
+              d="M24 24H0V0h24v24z"
+              fill="none"
+            />
+          </svg>
+        </button>
+        <button
+          class="c18"
+          disabled=""
+          id="pagination-previous-page"
+        >
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+            />
+            <path
+              d="M0 0h24v24H0z"
+              fill="none"
+            />
+          </svg>
+        </button>
+        <button
+          class="c18"
+          disabled=""
+          id="pagination-next-page"
+        >
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+            />
+            <path
+              d="M0 0h24v24H0z"
+              fill="none"
+            />
+          </svg>
+        </button>
+        <button
+          class="c18"
           disabled=""
           id="pagination-last-page"
         >

--- a/src/DataTable/propTypes.js
+++ b/src/DataTable/propTypes.js
@@ -205,10 +205,7 @@ export const defaultProps = {
   onChangePage: () => null,
   onChangeRowsPerPage: () => null,
   paginationComponent: null,
-  paginationComponentOptions: {
-    rowsPerPageText: 'Rows per page:',
-    rangeSeparatorText: 'of',
-  },
+  paginationComponentOptions: {},
   paginationIconFirstPage: <FirstPageIcon />,
   paginationIconLastPage: <LastPageIcon />,
   paginationIconNext: <RightIcon />,


### PR DESCRIPTION
* adds a new `paginationComponentOptions={{ noRowsPerPage: true }}`
* fixes a bug where only passing partial pagination option would remove the default options
* Closes #303 