### PR TITLE
Fix: Copy Typescript Declaration on build

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,178 +1,178 @@
-  import * as React from "react";
-  import { CSSProperties } from "styled-components";
+import * as React from "react";
+import { CSSProperties } from "styled-components";
 
-  export interface IDataTableProps<T> {
-    title?: React.ReactNode;
-    columns: IDataTableColumn<T>[];
-    data: T[];
-    keyField?: string;
-    striped?: boolean;
-    highlightOnHover?: boolean;
-    pointerOnHover?: boolean;
-    noDataComponent?: React.ReactNode;
-    className?: string;
-    style?: CSSProperties;
-    responsive?: boolean;
-    customTheme?: IDataTableTheme;
-    disabled?: boolean;
-    onRowClicked?: (row: T) => void;
-    onRowDoubleClicked?: (row: T) => void;
-    overflowY?: boolean;
-    overflowYOffset?: string;
-    dense?: boolean;
-    noTableHead?: boolean;
-    defaultSortField?: string;
-    defaultSortAsc?: boolean;
-    sortIcon?: React.ReactNode;
-    onSort?: (
-      column: IDataTableColumn<T>,
-      sortDirection: "asc" | "desc"
-    ) => void;
-    sortFunction?: (
-      rows: T[],
-      field: string,
-      sortDirection: "asc" | "desc"
-    ) => T[];
-    sortServer?: boolean;
-    pagination?: boolean;
-    paginationServer?: boolean;
-    paginationDefaultPage?: number;
-    paginationResetDefaultPage?: boolean;
-    paginationTotalRows?: number;
-    paginationPerPage?: number;
-    paginationRowsPerPageOptions?: number[];
-    paginationComponentOptions?: IDataTablePaginationOptions;
-    onChangeRowsPerPage?: (
-      currentRowsPerPage: number,
-      currentPage: number
-    ) => void;
-    onChangePage?: (page: number, totalRows: number) => void;
-    paginationComponent?: React.ReactNode;
-    paginationIconFirstPage?: React.ReactNode;
-    paginationIconLastPage?: React.ReactNode;
-    paginationIconNext?: React.ReactNode;
-    paginationIconPrevious?: React.ReactNode;
-    progressPending?: boolean;
-    persistTableHead?: boolean;
-    progressComponent?: React.ReactNode;
-    expandableRows?: boolean;
-    expandableRowsComponent?: React.ReactNode;
-    expandOnRowClicked?: boolean;
-    expandOnRowDoubleClicked?: boolean;
-    defaultExpandedField?: string;
-    expandableDisabledField?: string;
-    selectableRows?: boolean;
-    clearSelectedRows?: boolean;
-    onSelectedRow?: (selectedRowState: T) => void; // Deprecated: will be removed in v5.0
-    onSelectedRowsChange?: (selectedRowState: T) => void;
-    actions?: React.ReactNode | React.ReactNode[];
-    contextTitle?: string;
-    contextActions?: React.ReactNode | React.ReactNode[];
-    noHeader?: boolean;
-    fixedHeader?: boolean;
-    fixedHeaderScrollHeight?: string;
-    subHeader?: React.ReactNode | React.ReactNode[];
-    subHeaderAlign?: string;
-    subHeaderWrap?: boolean;
-    subHeaderComponent?: React.ReactNode | React.ReactNode[];
-  }
+export interface IDataTableProps<T> {
+  title?: React.ReactNode;
+  columns: IDataTableColumn<T>[];
+  data: T[];
+  keyField?: string;
+  striped?: boolean;
+  highlightOnHover?: boolean;
+  pointerOnHover?: boolean;
+  noDataComponent?: React.ReactNode;
+  className?: string;
+  style?: CSSProperties;
+  responsive?: boolean;
+  customTheme?: IDataTableTheme;
+  disabled?: boolean;
+  onRowClicked?: (row: T) => void;
+  onRowDoubleClicked?: (row: T) => void;
+  overflowY?: boolean;
+  overflowYOffset?: string;
+  dense?: boolean;
+  noTableHead?: boolean;
+  defaultSortField?: string;
+  defaultSortAsc?: boolean;
+  sortIcon?: React.ReactNode;
+  onSort?: (
+    column: IDataTableColumn<T>,
+    sortDirection: "asc" | "desc"
+  ) => void;
+  sortFunction?: (
+    rows: T[],
+    field: string,
+    sortDirection: "asc" | "desc"
+  ) => T[];
+  sortServer?: boolean;
+  pagination?: boolean;
+  paginationServer?: boolean;
+  paginationDefaultPage?: number;
+  paginationResetDefaultPage?: boolean;
+  paginationTotalRows?: number;
+  paginationPerPage?: number;
+  paginationRowsPerPageOptions?: number[];
+  paginationComponentOptions?: IDataTablePaginationOptions;
+  onChangeRowsPerPage?: (
+    currentRowsPerPage: number,
+    currentPage: number
+  ) => void;
+  onChangePage?: (page: number, totalRows: number) => void;
+  paginationComponent?: React.ReactNode;
+  paginationIconFirstPage?: React.ReactNode;
+  paginationIconLastPage?: React.ReactNode;
+  paginationIconNext?: React.ReactNode;
+  paginationIconPrevious?: React.ReactNode;
+  progressPending?: boolean;
+  persistTableHead?: boolean;
+  progressComponent?: React.ReactNode;
+  expandableRows?: boolean;
+  expandableRowsComponent?: React.ReactNode;
+  expandOnRowClicked?: boolean;
+  expandOnRowDoubleClicked?: boolean;
+  defaultExpandedField?: string;
+  expandableDisabledField?: string;
+  selectableRows?: boolean;
+  clearSelectedRows?: boolean;
+  onSelectedRow?: (selectedRowState: T) => void; // Deprecated: will be removed in v5.0
+  onSelectedRowsChange?: (selectedRowState: T) => void;
+  actions?: React.ReactNode | React.ReactNode[];
+  contextTitle?: string;
+  contextActions?: React.ReactNode | React.ReactNode[];
+  noHeader?: boolean;
+  fixedHeader?: boolean;
+  fixedHeaderScrollHeight?: string;
+  subHeader?: React.ReactNode | React.ReactNode[];
+  subHeaderAlign?: string;
+  subHeaderWrap?: boolean;
+  subHeaderComponent?: React.ReactNode | React.ReactNode[];
+}
 
-  export interface IDataTableColumn<T> {
-    name?: string;
-    selector: string;
-    sortable?: boolean;
-    format?: (row: T) => React.ReactNode;
-    cell?: (row: T) => React.ReactNode;
-    grow?: number;
-    width?: string;
-    minWidth?: string;
-    maxWidth?: string;
-    right?: boolean;
-    center?: boolean;
-    compact?: boolean;
-    ignoreOnRowClick?: boolean;
-    button?: boolean;
-    wrap?: boolean;
-    allowOverflow?: boolean;
-    hide?: number | "sm" | "md" | "lg";
-    style?: CSSProperties;
-    conditionalCellStyles?: IDataTableConditionalCellStyles<T>;
-  }
+export interface IDataTableColumn<T> {
+  name?: string;
+  selector: string;
+  sortable?: boolean;
+  format?: (row: T) => React.ReactNode;
+  cell?: (row: T) => React.ReactNode;
+  grow?: number;
+  width?: string;
+  minWidth?: string;
+  maxWidth?: string;
+  right?: boolean;
+  center?: boolean;
+  compact?: boolean;
+  ignoreOnRowClick?: boolean;
+  button?: boolean;
+  wrap?: boolean;
+  allowOverflow?: boolean;
+  hide?: number | "sm" | "md" | "lg";
+  style?: CSSProperties;
+  conditionalCellStyles?: IDataTableConditionalCellStyles<T>;
+}
 
-  export interface IDataTableTheme {
-    title?: {
-      fontSize?: string;
-      fontColor?: string;
-      backgroundColor?: string;
-      height?: string;
-    };
-    header?: {
-      fontSize?: string;
-      fontWeight?: string;
-      fontColor?: string;
-      fontColorActive?: string;
-      backgroundColor?: string;
-      borderWidth?: string;
-      borderColor?: string;
-      borderStyle?: string;
-      height?: string;
-      denseHeight?: string;
-    };
-    contextMenu?: {
-      backgroundColor?: string;
-      fontSize?: string;
-      fontColor?: string;
-      transitionTime?: string;
-    };
-    rows?: {
-      spacing?: "default" | "spaced";
-      fontSize?: string;
-      fontColor?: string;
-      backgroundColor?: string;
-      borderStyle?: string;
-      borderWidth?: string;
-      borderColor?: string;
-      stripedColor?: string;
-      hoverFontColor?: string;
-      hoverBackgroundColor?: string;
-      height?: string;
-      denseHeight?: string;
-    };
-    cells?: {
-      cellPadding?: string;
-    };
-    expander?: {
-      fontColor?: string;
-      expanderColor?: string;
-      expanderColorDisabled?: string;
-      backgroundColor?: string;
-    };
-    pagination?: {
-      fontSize?: string;
-      fontColor?: string;
-      backgroundColor?: string;
-      buttonFontColor?: string;
-      buttonHoverBackground?: string;
-    };
-    footer?: {
-      separatorStyle?: string;
-      separatorWidth?: string;
-      separatorColor?: string;
-    };
-  }
+export interface IDataTableTheme {
+  title?: {
+    fontSize?: string;
+    fontColor?: string;
+    backgroundColor?: string;
+    height?: string;
+  };
+  header?: {
+    fontSize?: string;
+    fontWeight?: string;
+    fontColor?: string;
+    fontColorActive?: string;
+    backgroundColor?: string;
+    borderWidth?: string;
+    borderColor?: string;
+    borderStyle?: string;
+    height?: string;
+    denseHeight?: string;
+  };
+  contextMenu?: {
+    backgroundColor?: string;
+    fontSize?: string;
+    fontColor?: string;
+    transitionTime?: string;
+  };
+  rows?: {
+    spacing?: "default" | "spaced";
+    fontSize?: string;
+    fontColor?: string;
+    backgroundColor?: string;
+    borderStyle?: string;
+    borderWidth?: string;
+    borderColor?: string;
+    stripedColor?: string;
+    hoverFontColor?: string;
+    hoverBackgroundColor?: string;
+    height?: string;
+    denseHeight?: string;
+  };
+  cells?: {
+    cellPadding?: string;
+  };
+  expander?: {
+    fontColor?: string;
+    expanderColor?: string;
+    expanderColorDisabled?: string;
+    backgroundColor?: string;
+  };
+  pagination?: {
+    fontSize?: string;
+    fontColor?: string;
+    backgroundColor?: string;
+    buttonFontColor?: string;
+    buttonHoverBackground?: string;
+  };
+  footer?: {
+    separatorStyle?: string;
+    separatorWidth?: string;
+    separatorColor?: string;
+  };
+}
 
-  export interface IDataTableConditionalCellStyles<T> {
-    when: (row: T) => boolean;
-    style: CSSProperties;
-  }
+export interface IDataTableConditionalCellStyles<T> {
+  when: (row: T) => boolean;
+  style: CSSProperties;
+}
 
 export interface IDataTablePaginationOptions {
-    noRowsPerPage?: boolean;
-    rowsPerPageText?: string;
-    rangeSeparatorText?: string;
-  }
+  noRowsPerPage?: boolean;
+  rowsPerPageText?: string;
+  rangeSeparatorText?: string;
+}
 
-  export default function DataTable<T>(
-    props: IDataTableProps<T>
-  ): React.ReactElement;
+export default function DataTable<T>(
+  props: IDataTableProps<T>
+): React.ReactElement;
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "browser": "dist/index.cjs.js",
-  "types": "index.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],
@@ -115,6 +115,7 @@
     "rollup": "^1.27.4",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
+    "rollup-plugin-copy": "^3.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-scss": "^1.0.2",
     "rollup-plugin-terser": "^5.1.2",

--- a/rollup/rollup.config.common.js
+++ b/rollup/rollup.config.common.js
@@ -1,6 +1,7 @@
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import babel from 'rollup-plugin-babel';
+import copy from 'rollup-plugin-copy';
 
 export const plugins = [
   resolve({
@@ -13,6 +14,11 @@ export const plugins = [
   }),
   babel({
     exclude: 'node_modules/**',
+  }),
+  copy({
+    targets: [
+      { src: 'index.d.ts', dest: 'dist' },
+    ],
   }),
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2625,10 +2625,31 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@nodelib/fs.scandir@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.3"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
+
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.3"
+    fastq "^1.6.0"
 
 "@reach/router@^1.2.1":
   version "1.2.1"
@@ -3222,6 +3243,13 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
+
+"@types/fs-extra@^8.0.0":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.0.1.tgz#a2378d6e7e8afea1564e44aafa2e207dadf77686"
+  integrity sha512-J00cVDALmi/hJOYsunyT52Hva5TnJeKP5yd1r+mH/ZU0mbYZflR0Z5kw5kITtKTRYMhm1JMClOFYdHnQszEvqw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/glob@^7.1.1":
   version "7.1.1"
@@ -3935,6 +3963,11 @@ array-union@^1.0.1, array-union@^1.0.2:
   integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
   dependencies:
     array-uniq "^1.0.1"
+
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
 array-uniq@^1.0.1:
   version "1.0.3"
@@ -5314,6 +5347,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+colorette@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.1.0.tgz#1f943e5a357fac10b4e0f5aaef3b14cdc1af6ec7"
+  integrity sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg==
+
 colors@^1.1.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
@@ -6054,6 +6092,13 @@ dir-glob@^2.2.2:
   integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
   dependencies:
     path-type "^3.0.0"
+
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
 
 doctrine@1.5.0:
   version "1.5.0"
@@ -6887,6 +6932,17 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
+fast-glob@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.1.0.tgz#77375a7e3e6f6fc9b18f061cddd28b8d1eec75ae"
+  integrity sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -6896,6 +6952,13 @@ fast-levenshtein@~2.0.4, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fastq@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.6.0.tgz#4ec8a38f4ac25f21492673adb7eae9cfef47d1c2"
+  integrity sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==
+  dependencies:
+    reusify "^1.0.0"
 
 fault@^1.0.2:
   version "1.0.2"
@@ -7218,6 +7281,15 @@ fs-extra@^8.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -7375,6 +7447,13 @@ glob-parent@^5.0.0:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
+  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
@@ -7459,6 +7538,20 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
+globby@10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-10.0.1.tgz#4782c34cb75dd683351335c5829cc3420e606b22"
+  integrity sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.0.3"
+    glob "^7.1.3"
+    ignore "^5.1.1"
+    merge2 "^1.2.3"
+    slash "^3.0.0"
+
 globby@8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-8.0.2.tgz#5697619ccd95c5275dbb2d6faa42087c1a941d8d"
@@ -7518,6 +7611,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+
+graceful-fs@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
+  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -7847,7 +7945,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.4:
+ignore@^5.1.1, ignore@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
@@ -9639,6 +9737,11 @@ merge2@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
   integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
+
+merge2@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
+  integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
 
 methods@~1.1.2:
   version "1.1.2"
@@ -12188,6 +12291,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+reusify@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
@@ -12242,6 +12350,17 @@ rollup-plugin-commonjs@^10.1.0:
     magic-string "^0.25.2"
     resolve "^1.11.0"
     rollup-pluginutils "^2.8.1"
+
+rollup-plugin-copy@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-copy/-/rollup-plugin-copy-3.1.0.tgz#435589857f4e346ea63fc137d99dcc1b25f51c3b"
+  integrity sha512-oVw3ljRV5jv7Yw/6eCEHntVs9Mc+NFglc0iU0J8ei76gldYmtBQ0M/j6WAkZUFVRSrhgfCrEakUllnN87V2f4w==
+  dependencies:
+    "@types/fs-extra" "^8.0.0"
+    colorette "^1.1.0"
+    fs-extra "^8.1.0"
+    globby "10.0.1"
+    is-plain-object "^3.0.0"
 
 rollup-plugin-node-resolve@^5.2.0:
   version "5.2.0"
@@ -12318,6 +12437,11 @@ run-async@^2.2.0:
   integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
   dependencies:
     is-promise "^2.1.0"
+
+run-parallel@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
This makes sure that the TypeScript declarations are copied to the `dist` folder on build.

Fixed and closes #338