### PR TITLE
Unique IDs and ARIA attributes

### DIFF
--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -1,392 +1,515 @@
-import React, { memo, useReducer, useMemo, useCallback, useEffect } from 'react';
-import { ThemeProvider } from 'styled-components';
-import merge from 'lodash/merge';
-import { DataTableProvider } from './DataTableContext';
-import { tableReducer } from './tableReducer';
-import Table from './Table';
-import TableHead from './TableHead';
-import TableFooter from './TableFooter';
-import TableHeadRow from './TableHeadRow';
-import TableRow from './TableRow';
-import TableCol from './TableCol';
-import TableColCheckbox from './TableColCheckbox';
-import TableHeader from './TableHeader';
-import TableSubheader from './TableSubheader';
-import TableBody from './TableBody';
-import ResponsiveWrapper from './ResponsiveWrapper';
-import ProgressWrapper from './ProgressWrapper';
-import TableWrapper from './TableWrapper';
-import { CellBase } from './Cell';
-import NoData from './NoData';
-import NativePagination from './Pagination';
-import useDidUpdateEffect from './useDidUpdateEffect';
-import { propTypes, defaultProps } from './propTypes';
-import { sort, decorateColumns, getSortDirection, getNumberOfPages, recalculatePage } from './util';
-import getDefaultTheme from '../themes/default';
+import React, {
+  memo,
+  useReducer,
+  useMemo,
+  useCallback,
+  useEffect
+} from "react";
+import { ThemeProvider } from "styled-components";
+import merge from "lodash/merge";
+import { DataTableProvider } from "./DataTableContext";
+import { tableReducer } from "./tableReducer";
+import Table from "./Table";
+import TableHead from "./TableHead";
+import TableFooter from "./TableFooter";
+import TableHeadRow from "./TableHeadRow";
+import TableRow from "./TableRow";
+import TableCol from "./TableCol";
+import TableColCheckbox from "./TableColCheckbox";
+import TableHeader from "./TableHeader";
+import TableSubheader from "./TableSubheader";
+import TableBody from "./TableBody";
+import ResponsiveWrapper from "./ResponsiveWrapper";
+import ProgressWrapper from "./ProgressWrapper";
+import TableWrapper from "./TableWrapper";
+import { CellBase } from "./Cell";
+import NoData from "./NoData";
+import NativePagination from "./Pagination";
+import useDidUpdateEffect from "./useDidUpdateEffect";
+import styled from 'styled-components';
+import { propTypes, defaultProps } from "./propTypes";
+import {
+  sort,
+  decorateColumns,
+  getSortDirection,
+  getNumberOfPages,
+  recalculatePage
+} from "./util";
+import getDefaultTheme from "../themes/default";
 
-const DataTable = memo(({
-  data,
-  columns,
-  title,
-  actions,
-  keyField,
-  striped,
-  highlightOnHover,
-  pointerOnHover,
-  dense,
-  selectableRows,
-  selectableRowsNoSelectAll,
-  selectableRowsDisabledField,
-  selectableRowsPreSelectedField,
-  selectableRowsComponent,
-  selectableRowsComponentProps,
-  onRowSelected,
-  onSelectedRowsChange,
-  expandableIcon,
-  onChangeRowsPerPage,
-  onChangePage,
-  paginationServer,
-  paginationTotalRows,
-  paginationDefaultPage,
-  paginationResetDefaultPage,
-  paginationPerPage,
-  paginationRowsPerPageOptions,
-  paginationIconLastPage,
-  paginationIconFirstPage,
-  paginationIconNext,
-  paginationIconPrevious,
-  paginationComponent,
-  paginationComponentOptions,
-  customTheme,
-  className,
-  style,
-  responsive,
-  overflowY,
-  overflowYOffset,
-  progressPending,
-  progressComponent,
-  persistTableHead,
-  noDataComponent,
-  disabled,
-  noTableHead,
-  noHeader,
-  fixedHeader,
-  fixedHeaderScrollHeight,
-  pagination,
-  subHeader,
-  subHeaderAlign,
-  subHeaderWrap,
-  subHeaderComponent,
-  contextTitle,
-  contextActions,
-  expandableRows,
-  onRowClicked,
-  onRowDoubleClicked,
-  sortIcon,
-  onSort,
-  sortFunction,
-  sortServer,
-  expandableRowsComponent,
-  expandableDisabledField,
-  expandOnRowClicked,
-  expandOnRowDoubleClicked,
-  defaultExpandedField,
-  defaultSortField,
-  defaultSortAsc,
-  clearSelectedRows,
-  conditionalRowStyles,
-}) => {
-  const initialState = {
-    allSelected: false,
-    selectedCount: 0,
-    selectedRows: [],
-    sortColumn: defaultSortField,
-    selectedColumn: {},
-    sortDirection: getSortDirection(defaultSortAsc),
-    currentPage: paginationDefaultPage,
-    rowsPerPage: paginationPerPage,
-  };
+let dtCount = 0;
 
-  const [{
-    rowsPerPage,
-    currentPage,
-    selectedRows,
-    allSelected,
-    selectedCount,
-    sortColumn,
-    selectedColumn,
-    sortDirection,
-  }, dispatch] = useReducer(tableReducer, initialState);
+const ScreenReaderLabelStyle = styled.span`
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 10px;
+  position: absolute;
+`;
 
-  const enabledPagination = pagination && !progressPending && data.length > 0;
-  const Pagination = paginationComponent || NativePagination;
-  const columnsMemo = useMemo(() => decorateColumns(columns), [columns]);
-  const theme = useMemo(() => merge(getDefaultTheme(), customTheme), [customTheme]);
-  const expandableRowsComponentMemo = useMemo(() => expandableRowsComponent, [expandableRowsComponent]);
-  const handleRowClicked = useCallback((row, e) => onRowClicked(row, e), [onRowClicked]);
-  const handleRowDoubleClicked = useCallback((row, e) => onRowDoubleClicked(row, e), [onRowDoubleClicked]);
-  const handleChangePage = page => dispatch({ type: 'CHANGE_PAGE', page, paginationServer });
-
-  useDidUpdateEffect(() => {
-    /* istanbul ignore next */
-    if (onRowSelected) {
-      onRowSelected({ allSelected, selectedCount, selectedRows });
-      // eslint-disable-next-line no-console
-      console.error('Warning: onRowSelected has been deprecated. Please switch to onSelectedRowsChange.');
-    }
-
-    onSelectedRowsChange({ allSelected, selectedCount, selectedRows });
-  }, [selectedCount]);
-
-  useDidUpdateEffect(() => {
-    onChangePage(currentPage, paginationTotalRows || data.length);
-  }, [currentPage]);
-
-  useDidUpdateEffect(() => {
-    onChangeRowsPerPage(rowsPerPage, currentPage);
-  }, [rowsPerPage]);
-
-  useDidUpdateEffect(() => {
-    onSort(selectedColumn, sortDirection);
-  }, [sortColumn, sortDirection]);
-
-  useEffect(() => {
-    dispatch({ type: 'CLEAR_SELECTED_ROWS', selectedRowsFlag: clearSelectedRows });
-  }, [clearSelectedRows]);
-
-  useDidUpdateEffect(() => {
-    handleChangePage(paginationDefaultPage);
-  }, [paginationDefaultPage, paginationResetDefaultPage]);
-
-  useEffect(() => {
-    // if the selectableRowsPreSelectedField is defined then attempt to set the selectedRows state when the table initially loads
-    if (selectableRowsPreSelectedField) {
-      const preSelectedRows = data.filter(row => row[selectableRowsPreSelectedField]);
-
-      dispatch({ type: 'SELECT_MULTIPLE_ROWS', selectedRows: preSelectedRows, rows: data });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useDidUpdateEffect(() => {
-    if (pagination && paginationServer && paginationTotalRows > 0) {
-      const updatedPage = getNumberOfPages(paginationTotalRows, rowsPerPage);
-      const recalculatedPage = recalculatePage(currentPage, updatedPage);
-      if (currentPage !== recalculatedPage) {
-        handleChangePage(recalculatedPage);
-      }
-    }
-  }, [paginationTotalRows]);
-
-  const sortedData = useMemo(() => {
-    // server-side sorting bypasses internal sorting
-    if (!sortServer) {
-      return sort(data, sortColumn, sortDirection, sortFunction);
-    }
-
-    return data;
-  }, [data, sortColumn, sortDirection, sortFunction, sortServer]);
-
-  const calculatedRows = useMemo(() => {
-    if (pagination && !paginationServer) {
-      // when using client-side pagination we can just slice the data set
-      const lastIndex = currentPage * rowsPerPage;
-      const firstIndex = lastIndex - rowsPerPage;
-
-      return sortedData.slice(firstIndex, lastIndex);
-    }
-
-    return sortedData;
-  }, [currentPage, pagination, paginationServer, rowsPerPage, sortedData]);
-
-  // recalculate the pagination and currentPage if the data length changes
-  if (pagination && !paginationServer && data.length > 0 && calculatedRows.length === 0) {
-    const updatedPage = getNumberOfPages(data.length, rowsPerPage);
-    const recalculatedPage = recalculatePage(currentPage, updatedPage);
-
-    handleChangePage(recalculatedPage);
-  }
-
-  const handleChangeRowsPerPage = newRowsPerPage => {
-    const rowCount = paginationTotalRows || calculatedRows.length;
-    const updatedPage = getNumberOfPages(rowCount, newRowsPerPage);
-    const recalculatedPage = recalculatePage(currentPage, updatedPage);
-
-    // update the currentPage for client-side pagination
-    // server - side should be handled by onChangeRowsPerPage
-    if (!paginationServer) {
-      handleChangePage(recalculatedPage);
-    }
-
-    dispatch({ type: 'CHANGE_ROWS_PER_PAGE', page: recalculatedPage, rowsPerPage: newRowsPerPage });
-  };
-
-  const init = {
-    dispatch,
+const DataTable = memo(
+  ({
     data,
-    allSelected,
-    selectedRows,
-    selectedCount,
-    sortColumn,
-    sortDirection,
+    columns,
+    title,
+    actions,
     keyField,
-    contextTitle,
-    contextActions,
-    selectableRowsPreSelectedField,
+    striped,
+    highlightOnHover,
+    pointerOnHover,
+    dense,
+    selectableRows,
+    selectableRowsNoSelectAll,
     selectableRowsDisabledField,
+    selectableRowsPreSelectedField,
     selectableRowsComponent,
     selectableRowsComponentProps,
+    onRowSelected,
+    onSelectedRowsChange,
     expandableIcon,
-    pagination,
+    onChangeRowsPerPage,
+    onChangePage,
     paginationServer,
+    paginationTotalRows,
+    paginationDefaultPage,
+    paginationResetDefaultPage,
+    paginationPerPage,
     paginationRowsPerPageOptions,
     paginationIconLastPage,
     paginationIconFirstPage,
     paginationIconNext,
     paginationIconPrevious,
+    paginationComponent,
     paginationComponentOptions,
-  };
+    customTheme,
+    className,
+    style,
+    responsive,
+    overflowY,
+    overflowYOffset,
+    progressPending,
+    progressComponent,
+    persistTableHead,
+    noDataComponent,
+    disabled,
+    noTableHead,
+    noHeader,
+    fixedHeader,
+    fixedHeaderScrollHeight,
+    pagination,
+    subHeader,
+    subHeaderAlign,
+    subHeaderWrap,
+    subHeaderComponent,
+    contextTitle,
+    contextActions,
+    expandableRows,
+    onRowClicked,
+    onRowDoubleClicked,
+    sortIcon,
+    onSort,
+    sortFunction,
+    sortServer,
+    expandableRowsComponent,
+    expandableDisabledField,
+    expandOnRowClicked,
+    expandOnRowDoubleClicked,
+    defaultExpandedField,
+    defaultSortField,
+    defaultSortAsc,
+    clearSelectedRows,
+    conditionalRowStyles,
+    id
+  }) => {
+    const initialState = {
+      allSelected: false,
+      selectedCount: 0,
+      selectedRows: [],
+      sortColumn: defaultSortField,
+      selectedColumn: {},
+      sortDirection: getSortDirection(defaultSortAsc),
+      currentPage: paginationDefaultPage,
+      rowsPerPage: paginationPerPage,
+      myId: id ? id : `data-table-${++dtCount}`
+    };
 
-  const showTableHead = () => {
-    if (noTableHead) {
-      return false;
+    const [
+      {
+        myId,
+        rowsPerPage,
+        currentPage,
+        selectedRows,
+        allSelected,
+        selectedCount,
+        sortColumn,
+        selectedColumn,
+        sortDirection
+      },
+      dispatch
+    ] = useReducer(tableReducer, initialState);
+
+    const enabledPagination = pagination && !progressPending && data.length > 0;
+    const Pagination = paginationComponent || NativePagination;
+    const columnsMemo = useMemo(() => decorateColumns(columns), [columns]);
+    const theme = useMemo(() => merge(getDefaultTheme(), customTheme), [
+      customTheme
+    ]);
+    const expandableRowsComponentMemo = useMemo(() => expandableRowsComponent, [
+      expandableRowsComponent
+    ]);
+    const handleRowClicked = useCallback((row, e) => onRowClicked(row, e), [
+      onRowClicked
+    ]);
+    const handleRowDoubleClicked = useCallback(
+      (row, e) => onRowDoubleClicked(row, e),
+      [onRowDoubleClicked]
+    );
+    const handleChangePage = page =>
+      dispatch({ type: "CHANGE_PAGE", page, paginationServer });
+
+    useDidUpdateEffect(() => {
+      /* istanbul ignore next */
+      if (onRowSelected) {
+        onRowSelected({ allSelected, selectedCount, selectedRows });
+        // eslint-disable-next-line no-console
+        console.error(
+          "Warning: onRowSelected has been deprecated. Please switch to onSelectedRowsChange."
+        );
+      }
+
+      onSelectedRowsChange({ allSelected, selectedCount, selectedRows });
+    }, [selectedCount]);
+
+    useDidUpdateEffect(() => {
+      onChangePage(currentPage, paginationTotalRows || data.length);
+    }, [currentPage]);
+
+    useDidUpdateEffect(() => {
+      onChangeRowsPerPage(rowsPerPage, currentPage);
+    }, [rowsPerPage]);
+
+    useDidUpdateEffect(() => {
+      onSort(selectedColumn, sortDirection);
+    }, [sortColumn, sortDirection]);
+
+    useEffect(() => {
+      dispatch({
+        type: "CLEAR_SELECTED_ROWS",
+        selectedRowsFlag: clearSelectedRows
+      });
+    }, [clearSelectedRows]);
+
+    useDidUpdateEffect(() => {
+      handleChangePage(paginationDefaultPage);
+    }, [paginationDefaultPage, paginationResetDefaultPage]);
+
+    useEffect(() => {
+      // if the selectableRowsPreSelectedField is defined then attempt to set the selectedRows state when the table initially loads
+      if (selectableRowsPreSelectedField) {
+        const preSelectedRows = data.filter(
+          row => row[selectableRowsPreSelectedField]
+        );
+
+        dispatch({
+          type: "SELECT_MULTIPLE_ROWS",
+          selectedRows: preSelectedRows,
+          rows: data
+        });
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useDidUpdateEffect(() => {
+      if (pagination && paginationServer && paginationTotalRows > 0) {
+        const updatedPage = getNumberOfPages(paginationTotalRows, rowsPerPage);
+        const recalculatedPage = recalculatePage(currentPage, updatedPage);
+        if (currentPage !== recalculatedPage) {
+          handleChangePage(recalculatedPage);
+        }
+      }
+    }, [paginationTotalRows]);
+
+    const sortedData = useMemo(() => {
+      // server-side sorting bypasses internal sorting
+      if (!sortServer) {
+        return sort(data, sortColumn, sortDirection, sortFunction);
+      }
+
+      return data;
+    }, [data, sortColumn, sortDirection, sortFunction, sortServer]);
+
+    const calculatedRows = useMemo(() => {
+      if (pagination && !paginationServer) {
+        // when using client-side pagination we can just slice the data set
+        const lastIndex = currentPage * rowsPerPage;
+        const firstIndex = lastIndex - rowsPerPage;
+
+        return sortedData.slice(firstIndex, lastIndex);
+      }
+
+      return sortedData;
+    }, [currentPage, pagination, paginationServer, rowsPerPage, sortedData]);
+
+    // recalculate the pagination and currentPage if the data length changes
+    if (
+      pagination &&
+      !paginationServer &&
+      data.length > 0 &&
+      calculatedRows.length === 0
+    ) {
+      const updatedPage = getNumberOfPages(data.length, rowsPerPage);
+      const recalculatedPage = recalculatePage(currentPage, updatedPage);
+
+      handleChangePage(recalculatedPage);
     }
 
-    if (persistTableHead) {
-      return true;
-    }
+    const handleChangeRowsPerPage = newRowsPerPage => {
+      const rowCount = paginationTotalRows || calculatedRows.length;
+      const updatedPage = getNumberOfPages(rowCount, newRowsPerPage);
+      const recalculatedPage = recalculatePage(currentPage, updatedPage);
 
-    return data.length > 0 && !progressPending;
-  };
+      // update the currentPage for client-side pagination
+      // server - side should be handled by onChangeRowsPerPage
+      if (!paginationServer) {
+        handleChangePage(recalculatedPage);
+      }
 
-  return (
-    <ThemeProvider theme={theme}>
-      <DataTableProvider initialState={init}>
-        <ResponsiveWrapper
-          responsive={responsive}
-          className={className}
-          style={style}
-          overflowYOffset={overflowYOffset}
-          overflowY={overflowY}
-        >
-          {!noHeader && (
-            <TableHeader
-              title={title}
-              actions={actions}
-              pending={progressPending}
-            />
-          )}
+      dispatch({
+        type: "CHANGE_ROWS_PER_PAGE",
+        page: recalculatedPage,
+        rowsPerPage: newRowsPerPage
+      });
+    };
 
-          {subHeader && (
-            <TableSubheader
-              align={subHeaderAlign}
-              wrapContent={subHeaderWrap}
-              component={subHeaderComponent}
-            />
-          )}
+    const init = {
+      dispatch,
+      data,
+      allSelected,
+      selectedRows,
+      selectedCount,
+      sortColumn,
+      sortDirection,
+      keyField,
+      contextTitle,
+      contextActions,
+      selectableRowsPreSelectedField,
+      selectableRowsDisabledField,
+      selectableRowsComponent,
+      selectableRowsComponentProps,
+      expandableIcon,
+      pagination,
+      paginationServer,
+      paginationRowsPerPageOptions,
+      paginationIconLastPage,
+      paginationIconFirstPage,
+      paginationIconNext,
+      paginationIconPrevious,
+      paginationComponentOptions
+    };
 
-          <TableWrapper>
-            {progressPending && !persistTableHead && (
-              <ProgressWrapper>
-                {progressComponent}
-              </ProgressWrapper>
+    const showTableHead = () => {
+      if (noTableHead) {
+        return false;
+      }
+
+      if (persistTableHead) {
+        return true;
+      }
+
+      return data.length > 0 && !progressPending;
+    };
+    let rowIndex = 0;
+    let colIndex = 0;
+    const extraCols = (selectableRows ? 1 : 0) + (expandableRows ? 2 : 0);
+    return (
+      <ThemeProvider theme={theme}>
+        <DataTableProvider initialState={init}>
+          <ResponsiveWrapper
+            responsive={responsive}
+            className={className}
+            style={style}
+            overflowYOffset={overflowYOffset}
+            overflowY={overflowY}
+          >
+            {!noHeader && (
+              <TableHeader
+                id={`${myId}-header`}
+                title={title}
+                actions={actions}
+                pending={progressPending}
+              />
             )}
 
-            <Table disabled={disabled} className="rdt_Table">
-              {showTableHead() && (
-                <TableHead className="rdt_TableHead">
-                  <TableHeadRow
-                    className="rdt_TableHeadRow"
-                    dense={dense}
-                    disabled={progressPending || data.length === 0}
+            {subHeader && (
+              <TableSubheader
+                id={`${myId}-subheader`}
+                align={subHeaderAlign}
+                wrapContent={subHeaderWrap}
+                component={subHeaderComponent}
+              />
+            )}
+
+            <TableWrapper>
+              {progressPending && !persistTableHead && (
+                <ProgressWrapper>{progressComponent}</ProgressWrapper>
+              )}
+
+              <Table
+                id={myId}
+                disabled={disabled}
+                role="table"
+                className="rdt_Table"
+                aria-colcount={columnsMemo.length + extraCols}
+                aria-rowcount={
+                  !data.length > 0 && !progressPending
+                    ? -1
+                    : (paginationTotalRows || data.length) + 1
+                }
+                {...(!noHeader ? { "aria-labelledby": `${myId}-header` } : {})}
+                {...(subHeader
+                  ? { "aria-describedby": `${myId}-subheader` }
+                  : {})}
+              >
+                {showTableHead() && (
+                  <TableHead
+                    id={`${myId}-thead`}
+                    role="rowgroup"
+                    className="rdt_TableHead"
                   >
-                    {selectableRows && (
-                      selectableRowsNoSelectAll
-                        ? <CellBase style={{ flex: '0 0 48px' }} />
-                        : <TableColCheckbox />
-                    )}
-                    {expandableRows && (
-                      <CellBase style={{ flex: '0 0 56px' }} />
-                    )}
-                    {columnsMemo.map(column => (
-                      <TableCol
-                        key={column.id}
-                        column={column}
-                        sortIcon={sortIcon}
-                      />
-                    ))}
-                  </TableHeadRow>
-                </TableHead>
+                    <TableHeadRow
+                      aria-rowindex={++rowIndex}
+                      id={`${myId}-thead-row`}
+                      role="row"
+                      className="rdt_TableHeadRow"
+                      dense={dense}
+                      disabled={progressPending || data.length === 0}
+                    >
+                      {selectableRows &&
+                        (selectableRowsNoSelectAll ? (
+                          <CellBase
+                            aria-colindex={++colIndex}
+                            role="columnheader"
+                            style={{ flex: "0 0 48px" }}
+                          >
+                            <ScreenReaderLabelStyle>
+                              Row Selector
+                            </ScreenReaderLabelStyle>
+                          </CellBase>
+                        ) : (
+                          <TableColCheckbox index={++colIndex} />
+                        ))}
+                      {expandableRows && (
+                        <CellBase
+                          aria-colindex={++colIndex}
+                          role="columnheader"
+                          style={{ flex: "0 0 56px" }}
+                        >
+                        <ScreenReaderLabelStyle>
+                          Toggle Expanded Details
+                        </ScreenReaderLabelStyle>
+                      </CellBase>
+                      )}
+                      {columnsMemo.map(column => (
+                        <TableCol
+                          tableId={myId}
+                          aria-colindex={++colIndex}
+                          key={column.id}
+                          column={column}
+                          sortIcon={sortIcon}
+                        />
+                      ))}
+                      {expandableRows && (
+                        <ScreenReaderLabelStyle
+                          aria-colindex={++colIndex}
+                          role="columnheader"
+                        >
+                          Expanded Details
+                        </ScreenReaderLabelStyle>
+                      )}
+                    </TableHeadRow>
+                  </TableHead>
+                )}
+
+                {!data.length > 0 && !progressPending && (
+                  <NoData component={noDataComponent} />
+                )}
+
+                {progressPending && persistTableHead && (
+                  <ProgressWrapper>{progressComponent}</ProgressWrapper>
+                )}
+
+                {!progressPending && data.length > 0 && (
+                  <TableBody
+                    role="rowgroup"
+                    fixedHeader={fixedHeader}
+                    fixedHeaderScrollHeight={fixedHeaderScrollHeight}
+                    hasOffset={overflowY}
+                    offset={overflowYOffset}
+                    className="rdt_TableBody"
+                  >
+                    {calculatedRows.map(row => {
+                      // aria-rowindex includes header rows
+                      const index =
+                        ++rowIndex +
+                        (enabledPagination
+                          ? (currentPage - 1) * rowsPerPage
+                          : 0);
+                      const id = row[keyField] || rowIndex;
+                      const defaultExpanded =
+                        row[defaultExpandedField] || false;
+
+                      return (
+                        <TableRow
+                          index={index}
+                          tableId={myId}
+                          id={id}
+                          key={id}
+                          keyField={keyField}
+                          row={row}
+                          columns={columnsMemo}
+                          selectableRows={selectableRows}
+                          expandableRows={expandableRows}
+                          striped={striped}
+                          highlightOnHover={highlightOnHover}
+                          pointerOnHover={pointerOnHover}
+                          dense={dense}
+                          expandOnRowClicked={expandOnRowClicked}
+                          expandOnRowDoubleClicked={expandOnRowDoubleClicked}
+                          expandableRowsComponent={expandableRowsComponentMemo}
+                          expandableDisabledField={expandableDisabledField}
+                          defaultExpanded={defaultExpanded}
+                          onRowClicked={handleRowClicked}
+                          onRowDoubleClicked={handleRowDoubleClicked}
+                          conditionalRowStyles={conditionalRowStyles}
+                        />
+                      );
+                    })}
+                  </TableBody>
+                )}
+              </Table>
+
+              {enabledPagination && (
+                <TableFooter className="rdt_TableFooter">
+                  <Pagination
+                    onChangePage={handleChangePage}
+                    onChangeRowsPerPage={handleChangeRowsPerPage}
+                    rowCount={paginationTotalRows || data.length}
+                    currentPage={currentPage}
+                    rowsPerPage={rowsPerPage}
+                    theme={theme}
+                  />
+                </TableFooter>
               )}
-
-              {!data.length > 0 && !progressPending && (
-                <NoData component={noDataComponent} />
-              )}
-
-              {progressPending && persistTableHead && (
-                <ProgressWrapper>
-                  {progressComponent}
-                </ProgressWrapper>
-              )}
-
-              {!progressPending && data.length > 0 && (
-                <TableBody
-                  fixedHeader={fixedHeader}
-                  fixedHeaderScrollHeight={fixedHeaderScrollHeight}
-                  hasOffset={overflowY}
-                  offset={overflowYOffset}
-                  className="rdt_TableBody"
-                >
-                  {calculatedRows.map((row, i) => {
-                    const id = row[keyField] || i;
-                    const defaultExpanded = row[defaultExpandedField] || false;
-
-                    return (
-                      <TableRow
-                        id={id}
-                        key={id}
-                        keyField={keyField}
-                        row={row}
-                        columns={columnsMemo}
-                        selectableRows={selectableRows}
-                        expandableRows={expandableRows}
-                        striped={striped}
-                        highlightOnHover={highlightOnHover}
-                        pointerOnHover={pointerOnHover}
-                        dense={dense}
-                        expandOnRowClicked={expandOnRowClicked}
-                        expandOnRowDoubleClicked={expandOnRowDoubleClicked}
-                        expandableRowsComponent={expandableRowsComponentMemo}
-                        expandableDisabledField={expandableDisabledField}
-                        defaultExpanded={defaultExpanded}
-                        onRowClicked={handleRowClicked}
-                        onRowDoubleClicked={handleRowDoubleClicked}
-                        conditionalRowStyles={conditionalRowStyles}
-                      />
-                    );
-                  })}
-                </TableBody>
-              )}
-            </Table>
-
-            {enabledPagination && (
-              <TableFooter className="rdt_TableFooter">
-                <Pagination
-                  onChangePage={handleChangePage}
-                  onChangeRowsPerPage={handleChangeRowsPerPage}
-                  rowCount={paginationTotalRows || data.length}
-                  currentPage={currentPage}
-                  rowsPerPage={rowsPerPage}
-                  theme={theme}
-                />
-              </TableFooter>
-            )}
-          </TableWrapper>
-        </ResponsiveWrapper>
-      </DataTableProvider>
-    </ThemeProvider>
-  );
-});
+            </TableWrapper>
+          </ResponsiveWrapper>
+        </DataTableProvider>
+      </ThemeProvider>
+    );
+  }
+);
 
 DataTable.propTypes = propTypes;
 DataTable.defaultProps = defaultProps;

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -3,39 +3,39 @@ import React, {
   useReducer,
   useMemo,
   useCallback,
-  useEffect
-} from "react";
-import { ThemeProvider } from "styled-components";
-import merge from "lodash/merge";
-import { DataTableProvider } from "./DataTableContext";
-import { tableReducer } from "./tableReducer";
-import Table from "./Table";
-import TableHead from "./TableHead";
-import TableFooter from "./TableFooter";
-import TableHeadRow from "./TableHeadRow";
-import TableRow from "./TableRow";
-import TableCol from "./TableCol";
-import TableColCheckbox from "./TableColCheckbox";
-import TableHeader from "./TableHeader";
-import TableSubheader from "./TableSubheader";
-import TableBody from "./TableBody";
-import ResponsiveWrapper from "./ResponsiveWrapper";
-import ProgressWrapper from "./ProgressWrapper";
-import TableWrapper from "./TableWrapper";
-import { CellBase } from "./Cell";
-import NoData from "./NoData";
-import NativePagination from "./Pagination";
-import useDidUpdateEffect from "./useDidUpdateEffect";
-import styled from 'styled-components';
-import { propTypes, defaultProps } from "./propTypes";
+  useEffect,
+} from 'react';
+import styled, { ThemeProvider } from 'styled-components';
+import merge from 'lodash/merge';
+import { DataTableProvider } from './DataTableContext';
+import { tableReducer } from './tableReducer';
+import Table from './Table';
+import TableHead from './TableHead';
+import TableFooter from './TableFooter';
+import TableHeadRow from './TableHeadRow';
+import TableRow from './TableRow';
+import TableCol from './TableCol';
+import TableColCheckbox from './TableColCheckbox';
+import TableHeader from './TableHeader';
+import TableSubheader from './TableSubheader';
+import TableBody from './TableBody';
+import ResponsiveWrapper from './ResponsiveWrapper';
+import ProgressWrapper from './ProgressWrapper';
+import TableWrapper from './TableWrapper';
+import { CellBase } from './Cell';
+import NoData from './NoData';
+import NativePagination from './Pagination';
+import useDidUpdateEffect from './useDidUpdateEffect';
+
+import { propTypes, defaultProps } from './propTypes';
 import {
   sort,
   decorateColumns,
   getSortDirection,
   getNumberOfPages,
-  recalculatePage
-} from "./util";
-import getDefaultTheme from "../themes/default";
+  recalculatePage,
+} from './util';
+import getDefaultTheme from '../themes/default';
 
 let dtCount = 0;
 
@@ -122,7 +122,7 @@ const DataTable = memo(
     defaultSortAsc,
     clearSelectedRows,
     conditionalRowStyles,
-    id
+    id,
   }) => {
     const initialState = {
       allSelected: false,
@@ -133,7 +133,7 @@ const DataTable = memo(
       sortDirection: getSortDirection(defaultSortAsc),
       currentPage: paginationDefaultPage,
       rowsPerPage: paginationPerPage,
-      myId: id ? id : `data-table-${++dtCount}`
+      myId: id || `data-table-${(dtCount += 1)}`,
     };
 
     const [
@@ -146,29 +146,29 @@ const DataTable = memo(
         selectedCount,
         sortColumn,
         selectedColumn,
-        sortDirection
+        sortDirection,
       },
-      dispatch
+      dispatch,
     ] = useReducer(tableReducer, initialState);
 
     const enabledPagination = pagination && !progressPending && data.length > 0;
     const Pagination = paginationComponent || NativePagination;
     const columnsMemo = useMemo(() => decorateColumns(columns), [columns]);
     const theme = useMemo(() => merge(getDefaultTheme(), customTheme), [
-      customTheme
+      customTheme,
     ]);
     const expandableRowsComponentMemo = useMemo(() => expandableRowsComponent, [
-      expandableRowsComponent
+      expandableRowsComponent,
     ]);
     const handleRowClicked = useCallback((row, e) => onRowClicked(row, e), [
-      onRowClicked
+      onRowClicked,
     ]);
     const handleRowDoubleClicked = useCallback(
       (row, e) => onRowDoubleClicked(row, e),
-      [onRowDoubleClicked]
+      [onRowDoubleClicked],
     );
     const handleChangePage = page =>
-      dispatch({ type: "CHANGE_PAGE", page, paginationServer });
+      dispatch({ type: 'CHANGE_PAGE', page, paginationServer });
 
     useDidUpdateEffect(() => {
       /* istanbul ignore next */
@@ -176,7 +176,7 @@ const DataTable = memo(
         onRowSelected({ allSelected, selectedCount, selectedRows });
         // eslint-disable-next-line no-console
         console.error(
-          "Warning: onRowSelected has been deprecated. Please switch to onSelectedRowsChange."
+          'Warning: onRowSelected has been deprecated. Please switch to onSelectedRowsChange.',
         );
       }
 
@@ -197,8 +197,8 @@ const DataTable = memo(
 
     useEffect(() => {
       dispatch({
-        type: "CLEAR_SELECTED_ROWS",
-        selectedRowsFlag: clearSelectedRows
+        type: 'CLEAR_SELECTED_ROWS',
+        selectedRowsFlag: clearSelectedRows,
       });
     }, [clearSelectedRows]);
 
@@ -210,13 +210,13 @@ const DataTable = memo(
       // if the selectableRowsPreSelectedField is defined then attempt to set the selectedRows state when the table initially loads
       if (selectableRowsPreSelectedField) {
         const preSelectedRows = data.filter(
-          row => row[selectableRowsPreSelectedField]
+          row => row[selectableRowsPreSelectedField],
         );
 
         dispatch({
-          type: "SELECT_MULTIPLE_ROWS",
+          type: 'SELECT_MULTIPLE_ROWS',
           selectedRows: preSelectedRows,
-          rows: data
+          rows: data,
         });
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -278,9 +278,9 @@ const DataTable = memo(
       }
 
       dispatch({
-        type: "CHANGE_ROWS_PER_PAGE",
+        type: 'CHANGE_ROWS_PER_PAGE',
         page: recalculatedPage,
-        rowsPerPage: newRowsPerPage
+        rowsPerPage: newRowsPerPage,
       });
     };
 
@@ -307,7 +307,7 @@ const DataTable = memo(
       paginationIconFirstPage,
       paginationIconNext,
       paginationIconPrevious,
-      paginationComponentOptions
+      paginationComponentOptions,
     };
 
     const showTableHead = () => {
@@ -322,7 +322,17 @@ const DataTable = memo(
       return data.length > 0 && !progressPending;
     };
     let rowIndex = 0;
+    // workaround for eslint no-plusplus
+    const rowIncrement = () => {
+      rowIndex += 1;
+      return rowIndex;
+    };
     let colIndex = 0;
+    // workaround for eslint no-plusplus
+    const colIncrement = () => {
+      colIndex += 1;
+      return colIndex;
+    };
     const extraCols = (selectableRows ? 1 : 0) + (expandableRows ? 2 : 0);
     return (
       <ThemeProvider theme={theme}>
@@ -368,9 +378,9 @@ const DataTable = memo(
                     ? -1
                     : (paginationTotalRows || data.length) + 1
                 }
-                {...(!noHeader ? { "aria-labelledby": `${myId}-header` } : {})}
+                {...(!noHeader ? { 'aria-labelledby': `${myId}-header` } : {})}
                 {...(subHeader
-                  ? { "aria-describedby": `${myId}-subheader` }
+                  ? { 'aria-describedby': `${myId}-subheader` }
                   : {})}
               >
                 {showTableHead() && (
@@ -380,7 +390,7 @@ const DataTable = memo(
                     className="rdt_TableHead"
                   >
                     <TableHeadRow
-                      aria-rowindex={++rowIndex}
+                      aria-rowindex={rowIncrement()}
                       id={`${myId}-thead-row`}
                       role="row"
                       className="rdt_TableHeadRow"
@@ -390,32 +400,32 @@ const DataTable = memo(
                       {selectableRows &&
                         (selectableRowsNoSelectAll ? (
                           <CellBase
-                            aria-colindex={++colIndex}
+                            aria-colindex={colIncrement()}
                             role="columnheader"
-                            style={{ flex: "0 0 48px" }}
+                            style={{ flex: '0 0 48px' }}
                           >
                             <ScreenReaderLabelStyle>
                               Row Selector
                             </ScreenReaderLabelStyle>
                           </CellBase>
                         ) : (
-                          <TableColCheckbox index={++colIndex} />
+                          <TableColCheckbox index={colIncrement()} />
                         ))}
                       {expandableRows && (
                         <CellBase
-                          aria-colindex={++colIndex}
+                          aria-colindex={colIncrement()}
                           role="columnheader"
-                          style={{ flex: "0 0 56px" }}
+                          style={{ flex: '0 0 56px' }}
                         >
-                        <ScreenReaderLabelStyle>
+                          <ScreenReaderLabelStyle>
                           Toggle Expanded Details
-                        </ScreenReaderLabelStyle>
-                      </CellBase>
+                          </ScreenReaderLabelStyle>
+                        </CellBase>
                       )}
                       {columnsMemo.map(column => (
                         <TableCol
                           tableId={myId}
-                          aria-colindex={++colIndex}
+                          aria-colindex={colIncrement()}
                           key={column.id}
                           column={column}
                           sortIcon={sortIcon}
@@ -423,7 +433,7 @@ const DataTable = memo(
                       ))}
                       {expandableRows && (
                         <ScreenReaderLabelStyle
-                          aria-colindex={++colIndex}
+                          aria-colindex={colIncrement()}
                           role="columnheader"
                         >
                           Expanded Details
@@ -453,11 +463,11 @@ const DataTable = memo(
                     {calculatedRows.map(row => {
                       // aria-rowindex includes header rows
                       const index =
-                        ++rowIndex +
+                        rowIncrement() +
                         (enabledPagination
                           ? (currentPage - 1) * rowsPerPage
                           : 0);
-                      const id = row[keyField] || rowIndex;
+                      const ident = row[keyField] || rowIndex;
                       const defaultExpanded =
                         row[defaultExpandedField] || false;
 
@@ -465,8 +475,8 @@ const DataTable = memo(
                         <TableRow
                           index={index}
                           tableId={myId}
-                          id={id}
-                          key={id}
+                          id={ident}
+                          key={ident}
                           keyField={keyField}
                           row={row}
                           columns={columnsMemo}
@@ -508,7 +518,7 @@ const DataTable = memo(
         </DataTableProvider>
       </ThemeProvider>
     );
-  }
+  },
 );
 
 DataTable.propTypes = propTypes;

--- a/src/DataTable/ExpanderRow.js
+++ b/src/DataTable/ExpanderRow.js
@@ -1,6 +1,6 @@
-import React, { Children, cloneElement } from "react";
-import PropTypes from "prop-types";
-import styled from "styled-components";
+import React, { Children, cloneElement } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 // Make "data" available on our any child component
 // eslint-disable-next-line arrow-body-style
@@ -23,16 +23,18 @@ const ExpanderRow = ({ data, children, id, index }) => (
 );
 
 ExpanderRow.propTypes = {
+  id: PropTypes.any.isRequired,
+  index: PropTypes.number.isRequired,
   data: PropTypes.object,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node
-  ])
+    PropTypes.node,
+  ]),
 };
 
 ExpanderRow.defaultProps = {
   data: {},
-  children: null
+  children: null,
 };
 
 export default ExpanderRow;

--- a/src/DataTable/ExpanderRow.js
+++ b/src/DataTable/ExpanderRow.js
@@ -1,6 +1,6 @@
-import React, { Children, cloneElement } from 'react';
-import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import React, { Children, cloneElement } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
 
 // Make "data" available on our any child component
 // eslint-disable-next-line arrow-body-style
@@ -9,17 +9,15 @@ const renderChildren = (children, data) => {
 };
 
 const ExpanderRowStyle = styled.div`
+  flex: 0 0 100%;
   width: 100%;
   box-sizing: border-box;
   color: ${props => props.theme.expander.fontColor};
   background-color: ${props => props.theme.expander.backgroundColor};
 `;
 
-const ExpanderRow = ({
-  data,
-  children,
-}) => (
-  <ExpanderRowStyle className="rdt_ExpanderRow">
+const ExpanderRow = ({ data, children, id, index }) => (
+  <ExpanderRowStyle id={id} aria-colindex={index} className="rdt_ExpanderRow">
     {renderChildren(children, data)}
   </ExpanderRowStyle>
 );
@@ -28,13 +26,13 @@ ExpanderRow.propTypes = {
   data: PropTypes.object,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-  ]),
+    PropTypes.node
+  ])
 };
 
 ExpanderRow.defaultProps = {
   data: {},
-  children: null,
+  children: null
 };
 
 export default ExpanderRow;

--- a/src/DataTable/TableCell.js
+++ b/src/DataTable/TableCell.js
@@ -18,13 +18,15 @@ const TableCellStyle = styled(Cell)`
   ${props => props.extendedCellStyle};
 `;
 
-const TableCell = memo(({ id, column, row }) => {
+const TableCell = memo(({ id, index, column, row }) => {
   // apply a tag that TableRow will use to stop event propagation when TableCell is clicked
   const dataTag = column.ignoreRowClick || column.button ? null : '___react-data-table-allow-propagation___';
   const extendedCellStyle = getConditionalStyle(row, column.conditionalCellStyles);
 
   return (
     <TableCellStyle
+      role="cell"
+      aria-colindex={index}
       id={id}
       column={column}
       data-tag={dataTag}

--- a/src/DataTable/TableCell.js
+++ b/src/DataTable/TableCell.js
@@ -44,7 +44,8 @@ const TableCell = memo(({ id, index, column, row }) => {
 });
 
 TableCell.propTypes = {
-  id: PropTypes.string.isRequired,
+  id: PropTypes.any.isRequired,
+  index: PropTypes.number.isRequired,
   column: PropTypes.object.isRequired,
   row: PropTypes.object.isRequired,
 };

--- a/src/DataTable/TableCellCheckbox.js
+++ b/src/DataTable/TableCellCheckbox.js
@@ -12,7 +12,7 @@ const TableCellCheckboxStyle = styled(CellBase)`
   color: ${props => props.theme.rows.fontColor};
 `;
 
-const TableCellCheckbox = ({ name, row }) => {
+const TableCellCheckbox = ({ id, index, name, row }) => {
   const { dispatch, data, keyField, selectedRows, selectableRowsComponent, selectableRowsComponentProps, selectableRowsDisabledField } = useTableContext();
   const checked = isRowSelected(row, selectedRows, keyField);
   const disabled = row[selectableRowsDisabledField];
@@ -21,6 +21,9 @@ const TableCellCheckbox = ({ name, row }) => {
 
   return (
     <TableCellCheckboxStyle
+      role="cell"
+      id={id}
+      aria-colindex={index}
       onClick={e => e.stopPropagation()}
       className="rdt_TableCell"
     >

--- a/src/DataTable/TableCellCheckbox.js
+++ b/src/DataTable/TableCellCheckbox.js
@@ -40,6 +40,8 @@ const TableCellCheckbox = ({ id, index, name, row }) => {
 };
 
 TableCellCheckbox.propTypes = {
+  id: PropTypes.any.isRequired,
+  index: PropTypes.number.isRequired,
   name: PropTypes.string.isRequired,
   row: PropTypes.object.isRequired,
 };

--- a/src/DataTable/TableCellExpander.js
+++ b/src/DataTable/TableCellExpander.js
@@ -25,12 +25,12 @@ const TableCellExpander = ({
   onExpandToggled,
   disabled,
 }) => (
-    <TableCellExpanderStyle
-      role="cell"
-      aria-colindex={index}
-      id={id}
-      column={column}
-      onClick={e => e.stopPropagation()}
+  <TableCellExpanderStyle
+    role="cell"
+    aria-colindex={index}
+    id={id}
+    column={column}
+    onClick={e => e.stopPropagation()}
   >
     <ExpanderButton
       onToggled={onExpandToggled}
@@ -42,6 +42,8 @@ const TableCellExpander = ({
 );
 
 TableCellExpander.propTypes = {
+  id: PropTypes.any.isRequired,
+  index: PropTypes.number.isRequired,
   column: PropTypes.object,
   row: PropTypes.object,
   expanded: PropTypes.bool,

--- a/src/DataTable/TableCellExpander.js
+++ b/src/DataTable/TableCellExpander.js
@@ -17,15 +17,20 @@ const TableCellExpanderStyle = styled(CellBase)`
 `;
 
 const TableCellExpander = ({
+  id,
+  index,
   column,
   row,
   expanded,
   onExpandToggled,
   disabled,
 }) => (
-  <TableCellExpanderStyle
-    column={column}
-    onClick={e => e.stopPropagation()}
+    <TableCellExpanderStyle
+      role="cell"
+      aria-colindex={index}
+      id={id}
+      column={column}
+      onClick={e => e.stopPropagation()}
   >
     <ExpanderButton
       onToggled={onExpandToggled}

--- a/src/DataTable/TableCol.js
+++ b/src/DataTable/TableCol.js
@@ -132,6 +132,7 @@ const TableCol = memo(({
 });
 
 TableCol.propTypes = {
+  tableId: PropTypes.string.isRequired,
   column: PropTypes.object.isRequired,
   sortIcon: PropTypes.oneOfType([
     PropTypes.bool,

--- a/src/DataTable/TableCol.js
+++ b/src/DataTable/TableCol.js
@@ -58,6 +58,7 @@ const ColumnSortable = styled.div`
 
 
 const TableCol = memo(({
+  tableId,
   column,
   sortIcon,
 }) => {
@@ -104,12 +105,13 @@ const TableCol = memo(({
 
   return (
     <TableColStyle
+      role="columnheader"
       className="rdt_TableCol"
       column={column} // required by Cell.js
     >
       {column.name && (
         <ColumnSortable
-          id={`column-${column.selector}`}
+          id={`${tableId}-column-${column.selector}`}
           role="button"
           className="rdt_TableCol_Sortable"
           onClick={handleSortChange}

--- a/src/DataTable/TableHeader.js
+++ b/src/DataTable/TableHeader.js
@@ -51,6 +51,7 @@ const TableHeader = ({ id, title, actions }) => (
 );
 
 TableHeader.propTypes = {
+  id: PropTypes.string.isRequired,
   title: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.node,

--- a/src/DataTable/TableHeader.js
+++ b/src/DataTable/TableHeader.js
@@ -36,8 +36,8 @@ const Actions = styled.div`
   }
 `;
 
-const TableHeader = ({ title, actions }) => (
-  <TableHeaderStyle className="rdt_TableHeader">
+const TableHeader = ({ id, title, actions }) => (
+  <TableHeaderStyle id={id} className="rdt_TableHeader">
     <Title>
       {title}
     </Title>

--- a/src/DataTable/TableRow.js
+++ b/src/DataTable/TableRow.js
@@ -1,13 +1,13 @@
-import React, { memo, useCallback, useState } from "react";
-import PropTypes from "prop-types";
-import styled, { css } from "styled-components";
-import TableCell from "./TableCell";
-import TableCellCheckbox from "./TableCellCheckbox";
-import TableCellExpander from "./TableCellExpander";
-import ExpanderRow from "./ExpanderRow";
-import { getConditionalStyle } from "./util";
+import React, { memo, useCallback, useState } from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+import TableCell from './TableCell';
+import TableCellCheckbox from './TableCellCheckbox';
+import TableCellExpander from './TableCellExpander';
+import ExpanderRow from './ExpanderRow';
+import { getConditionalStyle } from './util';
 
-const STOP_PROP_TAG = "___react-data-table-allow-propagation___";
+const STOP_PROP_TAG = '___react-data-table-allow-propagation___';
 
 const defaultRowsCSS = css`
   &:not(:first-child) {
@@ -58,9 +58,9 @@ const TableRowStyle = styled.div`
   width: 100%;
   box-sizing: border-box;
   min-height: ${props =>
-    props.dense ? props.theme.rows.denseHeight : props.theme.rows.height};
+    (props.dense ? props.theme.rows.denseHeight : props.theme.rows.height)};
   ${props =>
-    props.theme.rows.spacing === "spaced" ? spacedRowsCSS : defaultRowsCSS};
+    (props.theme.rows.spacing === 'spaced' ? spacedRowsCSS : defaultRowsCSS)};
   background-color: ${props => props.theme.rows.backgroundColor};
   color: ${props => props.theme.rows.fontColor};
   ${props => props.striped && stripedCSS};
@@ -90,7 +90,7 @@ const TableRow = memo(
     defaultExpanded,
     expandOnRowClicked,
     expandOnRowDoubleClicked,
-    conditionalRowStyles
+    conditionalRowStyles,
   }) => {
     const [expanded, setExpanded] = useState(defaultExpanded);
     const handleExpanded = useCallback(() => {
@@ -105,7 +105,7 @@ const TableRow = memo(
     const handleRowClick = useCallback(
       e => {
         // use event delegation allow events to propagate only when the element with data-tag ___react-data-table-allow-propagation___ is present
-        if (e.target && e.target.getAttribute("data-tag") === STOP_PROP_TAG) {
+        if (e.target && e.target.getAttribute('data-tag') === STOP_PROP_TAG) {
           onRowClicked(row, e);
 
           if (!disableRowClick && expandableRows && expandOnRowClicked) {
@@ -119,13 +119,13 @@ const TableRow = memo(
         expandableRows,
         handleExpanded,
         onRowClicked,
-        row
-      ]
+        row,
+      ],
     );
 
     const handleRowDoubleClick = useCallback(
       e => {
-        if (e.target && e.target.getAttribute("data-tag") === STOP_PROP_TAG) {
+        if (e.target && e.target.getAttribute('data-tag') === STOP_PROP_TAG) {
           onRowDoubleClicked(row, e);
           if (!disableRowClick && expandableRows && expandOnRowDoubleClicked) {
             handleExpanded();
@@ -138,12 +138,17 @@ const TableRow = memo(
         expandableRows,
         handleExpanded,
         onRowDoubleClicked,
-        row
-      ]
+        row,
+      ],
     );
 
     const extendedRowStyle = getConditionalStyle(row, conditionalRowStyles);
     let columnIndex = 0;
+    // workaround for eslint no-plusplus
+    const colIncrement = () => {
+      columnIndex += 1;
+      return columnIndex;
+    };
     const rowId = `${tableId}-row-${id}`;
     return (
       <TableRowStyle
@@ -161,7 +166,7 @@ const TableRow = memo(
       >
         {selectableRows && (
           <TableCellCheckbox
-            index={++columnIndex}
+            index={colIncrement()}
             id={`${tableId}-selector-${id}`}
             key={`selector-${id}`}
             name={`select-row-${row[keyField]}`}
@@ -171,7 +176,7 @@ const TableRow = memo(
 
         {expandableRows && (
           <TableCellExpander
-            index={++columnIndex}
+            index={colIncrement()}
             id={`${tableId}-expander-${id}`}
             key={`expander-${id}`}
             expanded={expanded}
@@ -183,7 +188,7 @@ const TableRow = memo(
 
         {columns.map(column => (
           <TableCell
-            index={++columnIndex}
+            index={colIncrement()}
             rowId={rowId}
             id={`${tableId}-cell-${id}-${columnIndex}`}
             key={`cell-${id}-${columnIndex}`}
@@ -193,17 +198,19 @@ const TableRow = memo(
         ))}
 
         {expandableRows && expanded && (
-          <ExpanderRow id={`${tableId}-expanded-content-${id}`} index={++columnIndex} key={`expanded-content-${row[keyField]}`} data={row}>
+          <ExpanderRow id={`${tableId}-expanded-content-${id}`} index={colIncrement()} key={`expanded-content-${row[keyField]}`} data={row}>
             {expandableRowsComponent}
           </ExpanderRow>
         )}
       </TableRowStyle>
     );
-  }
+  },
 );
 
 TableRow.propTypes = {
   id: PropTypes.any.isRequired,
+  tableId: PropTypes.any.isRequired,
+  index: PropTypes.number.isRequired,
   keyField: PropTypes.string.isRequired,
   columns: PropTypes.array.isRequired,
   row: PropTypes.object.isRequired,
@@ -219,12 +226,12 @@ TableRow.propTypes = {
   expandableRowsComponent: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
-    PropTypes.func
+    PropTypes.func,
   ]).isRequired,
   expandableDisabledField: PropTypes.string.isRequired,
   expandOnRowClicked: PropTypes.bool.isRequired,
   expandOnRowDoubleClicked: PropTypes.bool.isRequired,
-  conditionalRowStyles: PropTypes.array.isRequired
+  conditionalRowStyles: PropTypes.array.isRequired,
 };
 
 export default TableRow;

--- a/src/DataTable/TableRow.js
+++ b/src/DataTable/TableRow.js
@@ -1,13 +1,13 @@
-import React, { memo, useCallback, useState } from 'react';
-import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
-import TableCell from './TableCell';
-import TableCellCheckbox from './TableCellCheckbox';
-import TableCellExpander from './TableCellExpander';
-import ExpanderRow from './ExpanderRow';
-import { getConditionalStyle } from './util';
+import React, { memo, useCallback, useState } from "react";
+import PropTypes from "prop-types";
+import styled, { css } from "styled-components";
+import TableCell from "./TableCell";
+import TableCellCheckbox from "./TableCellCheckbox";
+import TableCellExpander from "./TableCellExpander";
+import ExpanderRow from "./ExpanderRow";
+import { getConditionalStyle } from "./util";
 
-const STOP_PROP_TAG = '___react-data-table-allow-propagation___';
+const STOP_PROP_TAG = "___react-data-table-allow-propagation___";
 
 const defaultRowsCSS = css`
   &:not(:first-child) {
@@ -24,7 +24,9 @@ const spacedRowsCSS = css`
   border-style: ${props => props.theme.rows.borderStyle};
   border-width: ${props => props.theme.rows.borderWidth};
   border-color: ${props => props.theme.rows.borderColor};
-  ${props => props.theme.rows.spacingShadow && `box-shadow: ${props.theme.rows.spacingShadow}`};
+  ${props =>
+    props.theme.rows.spacingShadow &&
+    `box-shadow: ${props.theme.rows.spacingShadow}`};
 `;
 
 const stripedCSS = css`
@@ -50,12 +52,15 @@ const pointerCSS = css`
 
 const TableRowStyle = styled.div`
   display: flex;
+  flex-wrap: wrap;
   align-items: stretch;
   align-content: stretch;
   width: 100%;
   box-sizing: border-box;
-  min-height: ${props => (props.dense ? props.theme.rows.denseHeight : props.theme.rows.height)};
-  ${props => (props.theme.rows.spacing === 'spaced' ? spacedRowsCSS : defaultRowsCSS)};
+  min-height: ${props =>
+    props.dense ? props.theme.rows.denseHeight : props.theme.rows.height};
+  ${props =>
+    props.theme.rows.spacing === "spaced" ? spacedRowsCSS : defaultRowsCSS};
   background-color: ${props => props.theme.rows.backgroundColor};
   color: ${props => props.theme.rows.fontColor};
   ${props => props.striped && stripedCSS};
@@ -64,60 +69,87 @@ const TableRowStyle = styled.div`
   ${props => props.extendedRowStyle};
 `;
 
-const TableRow = memo(({
-  id,
-  keyField,
-  columns,
-  row,
-  onRowClicked,
-  onRowDoubleClicked,
-  selectableRows,
-  expandableRows,
-  striped,
-  highlightOnHover,
-  pointerOnHover,
-  dense,
-  expandableRowsComponent,
-  expandableDisabledField,
-  defaultExpanded,
-  expandOnRowClicked,
-  expandOnRowDoubleClicked,
-  conditionalRowStyles,
-}) => {
-  const [expanded, setExpanded] = useState(defaultExpanded);
-  const handleExpanded = useCallback(() => {
-    setExpanded(!expanded);
-  }, [expanded]);
+const TableRow = memo(
+  ({
+    tableId,
+    index,
+    id,
+    keyField,
+    columns,
+    row,
+    onRowClicked,
+    onRowDoubleClicked,
+    selectableRows,
+    expandableRows,
+    striped,
+    highlightOnHover,
+    pointerOnHover,
+    dense,
+    expandableRowsComponent,
+    expandableDisabledField,
+    defaultExpanded,
+    expandOnRowClicked,
+    expandOnRowDoubleClicked,
+    conditionalRowStyles
+  }) => {
+    const [expanded, setExpanded] = useState(defaultExpanded);
+    const handleExpanded = useCallback(() => {
+      setExpanded(!expanded);
+    }, [expanded]);
 
-  const disableRowClick = row[expandableDisabledField] || false;
-  const showPointer = pointerOnHover || (expandableRows && (expandOnRowClicked || expandOnRowDoubleClicked));
+    const disableRowClick = row[expandableDisabledField] || false;
+    const showPointer =
+      pointerOnHover ||
+      (expandableRows && (expandOnRowClicked || expandOnRowDoubleClicked));
 
-  const handleRowClick = useCallback(e => {
-    // use event delegation allow events to propagate only when the element with data-tag ___react-data-table-allow-propagation___ is present
-    if (e.target && e.target.getAttribute('data-tag') === STOP_PROP_TAG) {
-      onRowClicked(row, e);
+    const handleRowClick = useCallback(
+      e => {
+        // use event delegation allow events to propagate only when the element with data-tag ___react-data-table-allow-propagation___ is present
+        if (e.target && e.target.getAttribute("data-tag") === STOP_PROP_TAG) {
+          onRowClicked(row, e);
 
-      if (!disableRowClick && expandableRows && expandOnRowClicked) {
-        handleExpanded();
-      }
-    }
-  }, [disableRowClick, expandOnRowClicked, expandableRows, handleExpanded, onRowClicked, row]);
+          if (!disableRowClick && expandableRows && expandOnRowClicked) {
+            handleExpanded();
+          }
+        }
+      },
+      [
+        disableRowClick,
+        expandOnRowClicked,
+        expandableRows,
+        handleExpanded,
+        onRowClicked,
+        row
+      ]
+    );
 
-  const handleRowDoubleClick = useCallback(e => {
-    if (e.target && e.target.getAttribute('data-tag') === STOP_PROP_TAG) {
-      onRowDoubleClicked(row, e);
-      if (!disableRowClick && expandableRows && expandOnRowDoubleClicked) {
-        handleExpanded();
-      }
-    }
-  }, [disableRowClick, expandOnRowDoubleClicked, expandableRows, handleExpanded, onRowDoubleClicked, row]);
+    const handleRowDoubleClick = useCallback(
+      e => {
+        if (e.target && e.target.getAttribute("data-tag") === STOP_PROP_TAG) {
+          onRowDoubleClicked(row, e);
+          if (!disableRowClick && expandableRows && expandOnRowDoubleClicked) {
+            handleExpanded();
+          }
+        }
+      },
+      [
+        disableRowClick,
+        expandOnRowDoubleClicked,
+        expandableRows,
+        handleExpanded,
+        onRowDoubleClicked,
+        row
+      ]
+    );
 
-  const extendedRowStyle = getConditionalStyle(row, conditionalRowStyles);
-
-  return (
-    <>
+    const extendedRowStyle = getConditionalStyle(row, conditionalRowStyles);
+    let columnIndex = 0;
+    const rowId = `${tableId}-row-${id}`;
+    return (
       <TableRowStyle
-        id={`row-${id}`}
+        role="row"
+        aria-rowindex={index}
+        id={rowId}
         striped={striped}
         highlightOnHover={highlightOnHover}
         pointerOnHover={!disableRowClick && showPointer}
@@ -129,6 +161,9 @@ const TableRow = memo(({
       >
         {selectableRows && (
           <TableCellCheckbox
+            index={++columnIndex}
+            id={`${tableId}-selector-${id}`}
+            key={`selector-${id}`}
             name={`select-row-${row[keyField]}`}
             row={row}
           />
@@ -136,6 +171,9 @@ const TableRow = memo(({
 
         {expandableRows && (
           <TableCellExpander
+            index={++columnIndex}
+            id={`${tableId}-expander-${id}`}
+            key={`expander-${id}`}
             expanded={expanded}
             row={row}
             onExpandToggled={handleExpanded}
@@ -145,25 +183,24 @@ const TableRow = memo(({
 
         {columns.map(column => (
           <TableCell
-            id={`cell-${column.id}-${row[keyField]}`}
-            key={`cell-${column.id}-${row[keyField]}`}
+            index={++columnIndex}
+            rowId={rowId}
+            id={`${tableId}-cell-${id}-${columnIndex}`}
+            key={`cell-${id}-${columnIndex}`}
             column={column}
             row={row}
           />
         ))}
-      </TableRowStyle>
 
-      {expandableRows && expanded && (
-        <ExpanderRow
-          key={`expander--${row[keyField]}`}
-          data={row}
-        >
-          {expandableRowsComponent}
-        </ExpanderRow>
-      )}
-    </>
-  );
-});
+        {expandableRows && expanded && (
+          <ExpanderRow id={`${tableId}-expanded-content-${id}`} index={++columnIndex} key={`expanded-content-${row[keyField]}`} data={row}>
+            {expandableRowsComponent}
+          </ExpanderRow>
+        )}
+      </TableRowStyle>
+    );
+  }
+);
 
 TableRow.propTypes = {
   id: PropTypes.any.isRequired,
@@ -182,12 +219,12 @@ TableRow.propTypes = {
   expandableRowsComponent: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
-    PropTypes.func,
+    PropTypes.func
   ]).isRequired,
   expandableDisabledField: PropTypes.string.isRequired,
   expandOnRowClicked: PropTypes.bool.isRequired,
   expandOnRowDoubleClicked: PropTypes.bool.isRequired,
-  conditionalRowStyles: PropTypes.array.isRequired,
+  conditionalRowStyles: PropTypes.array.isRequired
 };
 
 export default TableRow;

--- a/src/DataTable/__tests__/DataTable.test.js
+++ b/src/DataTable/__tests__/DataTable.test.js
@@ -43,7 +43,8 @@ test('should render correctly if data has no unique key', () => {
 test('should render correctly when disabled', () => {
   const mock = dataMock();
   const { container } = render(
-    <DataTable id="dt"
+    <DataTable
+      id="dt"
       data={mock.data}
       columns={mock.columns}
       disabled
@@ -56,7 +57,8 @@ test('should render correctly when disabled', () => {
 test('should not show the TableHead when noTableHead is true', () => {
   const mock = dataMock();
   const { container } = render(
-    <DataTable id="dt"
+    <DataTable
+      id="dt"
       data={mock.data}
       columns={mock.columns}
       noTableHead
@@ -71,7 +73,8 @@ describe('DataTable::onSelectedRowsChange', () => {
     const mock = dataMock();
     const updatedMock = jest.fn();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -92,7 +95,8 @@ describe('DataTable::onSelectedRowsChange', () => {
     const mock = dataMock();
     const updatedMock = jest.fn();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -114,7 +118,8 @@ describe('DataTable::onSelectedRowsChange', () => {
     const mock = dataMock();
     const updatedMock = jest.fn();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -136,14 +141,16 @@ describe('data prop changes', () => {
   test('should update state if the data prop changes', () => {
     const mock = dataMock();
     const { container, rerender } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
     );
 
     rerender(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={[{ id: 1, some: { name: 'Someone else' } }]}
         columns={mock.columns}
       />,
@@ -164,7 +171,8 @@ describe('DataTable::columns', () => {
   test('should render correctly when column.sortable = true', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -176,7 +184,8 @@ describe('DataTable::columns', () => {
   test('should render correctly when column.wrap = true', () => {
     const mock = dataMock({ wrap: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -188,7 +197,8 @@ describe('DataTable::columns', () => {
   test('should render correctly when column.allowOverflow = true', () => {
     const mock = dataMock({ allowOverflow: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -200,7 +210,8 @@ describe('DataTable::columns', () => {
   test('should render correctly when column.compact = true', () => {
     const mock = dataMock({ compact: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -212,7 +223,8 @@ describe('DataTable::columns', () => {
   test('should render correctly when column.button = true', () => {
     const mock = dataMock({ button: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -225,7 +237,8 @@ describe('DataTable::columns', () => {
   test('should render correctly when ignoreRowClick = true', () => {
     const mock = dataMock({ ignoreRowClick: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -237,7 +250,8 @@ describe('DataTable::columns', () => {
   test('should render correctly when column.cell is set to a component', () => {
     const mock = dataMock({ cell: row => <div>{row.some.name}</div> });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -249,7 +263,8 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.right', () => {
     const mock = dataMock({ right: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -261,7 +276,8 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.center', () => {
     const mock = dataMock({ center: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -273,7 +289,8 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.minWidth', () => {
     const mock = dataMock({ minWidth: '200px' });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -285,7 +302,8 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.maxWidth', () => {
     const mock = dataMock({ maxWidth: '600px' });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -297,7 +315,8 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.width', () => {
     const mock = dataMock({ width: '200px' });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -309,7 +328,8 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.hide sm', () => {
     const mock = dataMock({ hide: 'sm' });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -321,7 +341,8 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.hide md', () => {
     const mock = dataMock({ hide: 'md' });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -333,7 +354,8 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.hide lg', () => {
     const mock = dataMock({ hide: 'lg' });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -345,7 +367,8 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.hide is an integer', () => {
     const mock = dataMock({ hide: 300 });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -360,7 +383,8 @@ describe('DataTable:RowClicks', () => {
     const onRowClickedMock = jest.fn();
     const mock = dataMock({ ignoreRowClick: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         onRowClicked={onRowClickedMock}
@@ -375,7 +399,8 @@ describe('DataTable:RowClicks', () => {
     const onRowClickedMock = jest.fn();
     const mock = dataMock({ button: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         onRowClicked={onRowClickedMock}
@@ -390,7 +415,8 @@ describe('DataTable:RowClicks', () => {
     const onRowDoubleClickedMock = jest.fn();
     const mock = dataMock({ ignoreRowClick: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         onRowDoubleClicked={onRowDoubleClickedMock}
@@ -405,7 +431,8 @@ describe('DataTable:RowClicks', () => {
     const onRowDoubleClickedMock = jest.fn();
     const mock = dataMock({ button: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         onRowDoubleClicked={onRowDoubleClickedMock}
@@ -421,7 +448,8 @@ describe('DataTable::progress/nodata', () => {
   test('should render correctly when progressPending is true', () => {
     const mock = dataMock();
     const { container, getByText } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -436,7 +464,8 @@ describe('DataTable::progress/nodata', () => {
   test('should only show Loading if progressPending prop changes', () => {
     const mock = dataMock();
     const { getByText, rerender, container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -445,7 +474,8 @@ describe('DataTable::progress/nodata', () => {
     );
 
     rerender(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -462,7 +492,8 @@ describe('DataTable::progress/nodata', () => {
     test('should only Loading and TableHead if progressPending prop changes', () => {
       const mock = dataMock();
       const { getByText, rerender, container } = render(
-        <DataTable id="dt"
+        <DataTable
+          id="dt"
           data={mock.data}
           columns={mock.columns}
           defaultSortField="some.name"
@@ -472,7 +503,8 @@ describe('DataTable::progress/nodata', () => {
       );
 
       rerender(
-        <DataTable id="dt"
+        <DataTable
+          id="dt"
           data={mock.data}
           columns={mock.columns}
           defaultSortField="some.name"
@@ -489,7 +521,8 @@ describe('DataTable::progress/nodata', () => {
     test('should disable TableHead if no data', () => {
       const mock = dataMock();
       const { container } = render(
-        <DataTable id="dt"
+        <DataTable
+          id="dt"
           data={[]}
           columns={mock.columns}
           defaultSortField="some.name"
@@ -503,7 +536,8 @@ describe('DataTable::progress/nodata', () => {
     test('should disable TableHead if progressPending', () => {
       const mock = dataMock();
       const { container } = render(
-        <DataTable id="dt"
+        <DataTable
+          id="dt"
           data={[]}
           columns={mock.columns}
           defaultSortField="some.name"
@@ -520,7 +554,8 @@ describe('DataTable::progress/nodata', () => {
     test('should only Loading if progressPending prop changes', () => {
       const mock = dataMock();
       const { getByText, rerender, container } = render(
-        <DataTable id="dt"
+        <DataTable
+          id="dt"
           data={mock.data}
           columns={mock.columns}
           defaultSortField="some.name"
@@ -531,7 +566,8 @@ describe('DataTable::progress/nodata', () => {
       );
 
       rerender(
-        <DataTable id="dt"
+        <DataTable
+          id="dt"
           data={mock.data}
           columns={mock.columns}
           defaultSortField="some.name"
@@ -550,7 +586,8 @@ describe('DataTable::progress/nodata', () => {
   test('should render correctly when progressPending is false and there are no row items', () => {
     const mock = dataMock();
     const { container, getByText } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={[]}
         columns={mock.columns}
       />,
@@ -563,7 +600,8 @@ describe('DataTable::progress/nodata', () => {
   test('should render correctly when a component is passed that is a string', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -578,7 +616,8 @@ describe('DataTable::progress/nodata', () => {
   test('should render correctly when a component is passed that is a react component', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -595,7 +634,8 @@ describe('DataTable::responsive', () => {
   test('should render correctly responsive by default', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -607,7 +647,8 @@ describe('DataTable::responsive', () => {
   test('should render correctly when responsive=false', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         responsive={false}
@@ -620,7 +661,8 @@ describe('DataTable::responsive', () => {
   test('should not apply overFlowY without an overflowYOffset or not responsive', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         responsive
@@ -639,7 +681,8 @@ describe('DataTable::sorting', () => {
     const onSortMock = jest.fn();
     const mock = dataMock({ sortable: false });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         onSort={onSortMock}
@@ -654,7 +697,8 @@ describe('DataTable::sorting', () => {
   test('should render correctly with a default sort field and the native sort icon', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -667,7 +711,8 @@ describe('DataTable::sorting', () => {
   test('should render correctly with a default sort field and the icon to the right when column.right = true and the native sort icon', () => {
     const mock = dataMock({ sortable: true, right: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -680,7 +725,8 @@ describe('DataTable::sorting', () => {
   test('should render correctly and not be sorted when a column.sort === false', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -694,7 +740,8 @@ describe('DataTable::sorting', () => {
   test('should render correctly when a column is sorted in default asc', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -708,7 +755,8 @@ describe('DataTable::sorting', () => {
   test('should render correctly when a column is sorted from asc to desc', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -728,7 +776,8 @@ describe('DataTable::sorting', () => {
     const onSortMock = jest.fn();
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         onSort={onSortMock}
@@ -744,7 +793,8 @@ describe('DataTable::sorting', () => {
     const onSortMock = jest.fn();
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         onSort={onSortMock}
@@ -761,7 +811,8 @@ describe('DataTable::sorting', () => {
   test('should render correctly with a custom sortIcon', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -775,7 +826,8 @@ describe('DataTable::sorting', () => {
   test('should render correctly with a custom sortIcon and column.right = true', () => {
     const mock = dataMock({ sortable: true, right: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -789,7 +841,8 @@ describe('DataTable::sorting', () => {
   test('should render correctly with a defaultSortAsc = false', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -803,7 +856,8 @@ describe('DataTable::sorting', () => {
   test('should render correctly and bypass internal sort when sortServer = true and asc sort', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         sortServer
@@ -818,7 +872,8 @@ describe('DataTable::sorting', () => {
   test('should render correctly and bypass internal sort when sortServer = true and desc sort', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         sortServer
@@ -837,7 +892,8 @@ describe('DataTable::expandableRows', () => {
   test('should render correctly when expandableRows is true', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         expandableRows
@@ -851,7 +907,8 @@ describe('DataTable::expandableRows', () => {
     const mock = dataMock();
     mock.data[0].defaultExpanded = true;
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultExpandedField="defaultExpanded"
@@ -864,7 +921,8 @@ describe('DataTable::expandableRows', () => {
   test('should render correctly when expandableRows is true and the row is toggled', () => {
     const mock = dataMock();
     const { container, getByTestId } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         expandableRows
@@ -880,7 +938,8 @@ describe('DataTable::expandableRows', () => {
     const mock = dataMock();
     mock.data[0].defaultExpanded = true;
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         expandableRows
@@ -895,7 +954,8 @@ describe('DataTable::expandableRows', () => {
     const mock = dataMock();
     mock.data[0].disabled = true;
     const { container, getByTestId } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         expandableRows
@@ -910,7 +970,8 @@ describe('DataTable::expandableRows', () => {
   test('should not expand a row if expandableRows is false and expandOnRowClicked is true ', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         expandOnRowClicked
@@ -925,7 +986,8 @@ describe('DataTable::expandableRows', () => {
   test('should expand a row if expandableRows is true and expandOnRowClicked is true', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         expandableRows
@@ -942,7 +1004,8 @@ describe('DataTable::expandableRows', () => {
   test('should not expand a row if expandableRows is false and expandOnRowDoubleClicked is true ', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         expandOnRowDoubleClicked
@@ -957,7 +1020,8 @@ describe('DataTable::expandableRows', () => {
   test('should expand a row if expandableRows is true and expandOnRowDoubleClicked is true', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         expandableRows
@@ -975,7 +1039,8 @@ describe('DataTable::expandableRows', () => {
     const mock = dataMock();
     mock.data[0].disabled = true;
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         expandableRows
@@ -995,7 +1060,8 @@ describe('DataTable::selectableRows', () => {
   test('should render correctly when selectableRows is true', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1008,7 +1074,8 @@ describe('DataTable::selectableRows', () => {
   test('should not render a select all checkbox when selectableRowsNoSelectAll is true', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1023,7 +1090,8 @@ describe('DataTable::selectableRows', () => {
   test('select-all-rows should be true is all rows are selected', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1038,7 +1106,8 @@ describe('DataTable::selectableRows', () => {
   test('select-all-rows should be false and not when all rows is de-selected', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1054,7 +1123,8 @@ describe('DataTable::selectableRows', () => {
   test('should render correctly when selectableRows is true and a single row is checked', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1070,7 +1140,8 @@ describe('DataTable::selectableRows', () => {
   test('select-all-rows should not be indeterminate when all rows are selected', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1086,7 +1157,8 @@ describe('DataTable::selectableRows', () => {
   test('select-all-rows should be indeterminate when a single row is selected', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1102,7 +1174,8 @@ describe('DataTable::selectableRows', () => {
     const mock = dataMock();
 
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1118,7 +1191,8 @@ describe('DataTable::selectableRows', () => {
   test('should render correctly when selectableRows is true and a single row is un-checked', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1136,7 +1210,8 @@ describe('DataTable::selectableRows', () => {
     mock.data[0].disabled = true;
 
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1155,7 +1230,8 @@ describe('DataTable::selectableRows', () => {
     mock.data[0].disabled = true;
 
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1175,7 +1251,8 @@ describe('DataTable::selectableRows', () => {
     mock.data[1].disabled = true;
 
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1195,7 +1272,8 @@ describe('DataTable::selectableRows', () => {
     mock.data[0].selected = true;
 
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1213,7 +1291,8 @@ describe('DataTable::selectableRows', () => {
     mock.data[1].selected = true;
 
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1228,7 +1307,8 @@ describe('DataTable::selectableRows', () => {
   test('should render correctly when clearSelectedRows is toggled', () => {
     const mock = dataMock();
     const { container, rerender } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1238,7 +1318,8 @@ describe('DataTable::selectableRows', () => {
     fireEvent.click(container.querySelector('input[name="select-row-1"]'));
 
     rerender(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1253,7 +1334,8 @@ describe('DataTable::selectableRows', () => {
     const rowClickedMock = jest.fn();
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1272,7 +1354,8 @@ describe('DataTable::Pagination', () => {
   test('should render correctly if pagination is enabled', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1285,7 +1368,8 @@ describe('DataTable::Pagination', () => {
   test('should have the correct amount of rows when paging forward', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationPerPage={1}
@@ -1303,7 +1387,8 @@ describe('DataTable::Pagination', () => {
   test('should have the correct amount of rows when paging backward', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationDefaultPage={2}
@@ -1322,7 +1407,8 @@ describe('DataTable::Pagination', () => {
   test('should have the correct amount of rows when paging to the last page', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationPerPage={1}
@@ -1340,7 +1426,8 @@ describe('DataTable::Pagination', () => {
   test('should have the correct amount of rows when paging backward to the first page', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationDefaultPage={2}
@@ -1359,7 +1446,8 @@ describe('DataTable::Pagination', () => {
   test('should navigate to page 1 if the table is sorted', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationPerPage={1}
@@ -1379,7 +1467,8 @@ describe('DataTable::Pagination', () => {
     const mockOneDeleted = dataMock().data.slice(0, 1);
     const onChangePageMock = jest.fn();
     const { container, rerender } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationPerPage={1}
@@ -1393,7 +1482,8 @@ describe('DataTable::Pagination', () => {
     fireEvent.click(container.querySelector('button#pagination-last-page'));
 
     rerender(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mockOneDeleted}
         columns={mock.columns}
         onChangePage={onChangePageMock}
@@ -1413,7 +1503,8 @@ describe('DataTable::Pagination', () => {
     const onChangePageMock = jest.fn();
     const onChangeRowsPerPageMock = jest.fn();
     const { container, rerender } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         onChangePage={onChangePageMock}
@@ -1430,7 +1521,8 @@ describe('DataTable::Pagination', () => {
     fireEvent.click(container.querySelector('button#pagination-last-page'));
 
     rerender(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mockOneDeleted}
         columns={mock.columns}
         onChangePage={onChangePageMock}
@@ -1452,7 +1544,8 @@ describe('DataTable::Pagination', () => {
     const mockOneDeleted = dataMock().data.slice(0, 2);
     const onChangePageMock = jest.fn();
     const { container, rerender } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationPerPage={1}
@@ -1466,7 +1559,8 @@ describe('DataTable::Pagination', () => {
     fireEvent.click(container.querySelector('button#pagination-last-page'));
 
     rerender(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mockOneDeleted}
         columns={mock.columns}
         onChangePage={onChangePageMock}
@@ -1484,7 +1578,8 @@ describe('DataTable::Pagination', () => {
     const onChangePageMock = jest.fn();
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1502,7 +1597,8 @@ describe('DataTable::Pagination', () => {
     const onChangePageMock = jest.fn();
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1521,7 +1617,8 @@ describe('DataTable::Pagination', () => {
   test('should not deselect all rows if using pagination and selectedRows', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1540,7 +1637,8 @@ describe('DataTable::Pagination', () => {
   test('should deselect all rows if using paginationServer and selectedRows', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1560,7 +1658,8 @@ describe('DataTable::Pagination', () => {
   test('should deselect all rows if using pagination && paginationServer and selectedRows and the table is sorted', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1581,7 +1680,8 @@ describe('DataTable::Pagination', () => {
     const onChangePageMock = jest.fn();
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1600,7 +1700,8 @@ describe('DataTable::Pagination', () => {
     const onChangeRowsPerPageMock = jest.fn();
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1616,7 +1717,8 @@ describe('DataTable::Pagination', () => {
     const onChangeRowsPerPageMock = jest.fn();
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1632,7 +1734,8 @@ describe('DataTable::Pagination', () => {
   test('should render correctly when a paginationComponentOptions are passed', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1646,7 +1749,8 @@ describe('DataTable::Pagination', () => {
   test('should render correctly when a paginationComponentOptions to hide the per page dropdown are passed', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1660,7 +1764,8 @@ describe('DataTable::Pagination', () => {
   test('should render correctly when paginationResetDefaultPage is toggled', () => {
     const mock = dataMock();
     const { container, rerender } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationPerPage={1} // force 2 pages
@@ -1672,7 +1777,8 @@ describe('DataTable::Pagination', () => {
     fireEvent.click(container.querySelector('button#pagination-next-page'));
 
     rerender(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationPerPage={1} // force 2 pages
@@ -1690,7 +1796,8 @@ describe('DataTable::subHeader', () => {
   test('should render correctly when a subheader is enabled', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         subHeader
@@ -1705,7 +1812,8 @@ describe('DataTable::subHeader', () => {
   test('should render when subHeaderWrap is false', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         subHeader
@@ -1720,7 +1828,8 @@ describe('DataTable::subHeader', () => {
   test('should render correctly with left align', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         subHeader
@@ -1735,7 +1844,8 @@ describe('DataTable::subHeader', () => {
   test('should render correctly with center align', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         subHeader
@@ -1750,7 +1860,8 @@ describe('DataTable::subHeader', () => {
   test('should render correctly with right align', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         subHeader
@@ -1768,7 +1879,8 @@ describe('DataTable::Header', () => {
   test('should render without a header if noHeader is true', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         noHeader
@@ -1781,7 +1893,8 @@ describe('DataTable::Header', () => {
   test('title should render correctly', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         title="whoa!"
@@ -1794,7 +1907,8 @@ describe('DataTable::Header', () => {
   test('contextTitle should render correctly', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         title="whoa!"
@@ -1808,7 +1922,8 @@ describe('DataTable::Header', () => {
   test('actions should render correctly', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         title="whoa!"
@@ -1823,7 +1938,8 @@ describe('DataTable::Header', () => {
   test('context menu should render correctly when selectableRows', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         title="whoa!"
@@ -1844,7 +1960,8 @@ describe('DataTable::fixedHeader', () => {
   test('should render correctly when fixedHeader', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         fixedHeader
@@ -1857,7 +1974,8 @@ describe('DataTable::fixedHeader', () => {
   test('should render correctly when fixedHeader and fixedHeaderScrollHeight', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         fixedHeader
@@ -1871,7 +1989,8 @@ describe('DataTable::fixedHeader', () => {
   test('should render correctly when fixedHeader with an offset', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         fixedHeader
@@ -1885,7 +2004,8 @@ describe('DataTable::fixedHeader', () => {
   test('should render correctly when fixedHeader with an offset with a value', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         fixedHeader
@@ -1902,7 +2022,8 @@ describe('DataTable::striped', () => {
   test('should render correctly when striped', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         striped
@@ -1917,7 +2038,8 @@ describe('DataTable::highlightOnHover', () => {
   test('should render correctly when highlightOnHover', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         highlightOnHover
@@ -1932,7 +2054,8 @@ describe('DataTable::pointerOnHover', () => {
   test('should render correctly when pointerOnHover', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         pointerOnHover
@@ -1947,7 +2070,8 @@ describe('DataTable::dense', () => {
   test('should render correctly when dense', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         dense
@@ -1967,7 +2091,8 @@ describe('DataTable::Theming', () => {
       },
     };
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -1987,7 +2112,8 @@ describe('DataTable::Theming', () => {
       },
     };
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -2006,7 +2132,8 @@ describe('DataTable::conditionalRowStyles', () => {
     const conditionalRowStyles = [];
 
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         conditionalRowStyles={conditionalRowStyles}
@@ -2033,7 +2160,8 @@ describe('DataTable::conditionalRowStyles', () => {
     ];
 
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         conditionalRowStyles={conditionalRowStyles}
@@ -2060,7 +2188,8 @@ describe('DataTable::conditionalRowStyles', () => {
     ];
 
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
         conditionalRowStyles={conditionalRowStyles}
@@ -2079,7 +2208,8 @@ describe('DataTable::column.style', () => {
     };
 
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -2103,7 +2233,8 @@ describe('DataTable::conditionalCellStyles', () => {
     ];
 
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -2125,7 +2256,8 @@ describe('DataTable::conditionalCellStyles', () => {
     ];
 
     const { container } = render(
-      <DataTable id="dt"
+      <DataTable
+        id="dt"
         data={mock.data}
         columns={mock.columns}
       />,

--- a/src/DataTable/__tests__/DataTable.test.js
+++ b/src/DataTable/__tests__/DataTable.test.js
@@ -19,7 +19,7 @@ const dataMock = colProps => {
 };
 
 test('should render and empty table correctly', () => {
-  const { container } = render(<DataTable data={[]} columns={[]} />);
+  const { container } = render(<DataTable id="dt" data={[]} columns={[]} />);
 
   expect(container.firstChild).toMatchSnapshot();
 });
@@ -27,23 +27,23 @@ test('should render and empty table correctly', () => {
 test('should render correctly if the keyField is overridden', () => {
   const mock = dataMock();
   const data = [{ uuid: 123, some: { name: 'Henry the 8th' } }];
-  const { container } = render(<DataTable data={data} columns={mock.columns} keyField="uuid" />);
+  const { container } = render(<DataTable id="dt" data={data} columns={mock.columns} keyField="uuid" />);
 
-  expect(container.querySelector('div[id="row-123"]')).not.toBeNull();
+  expect(container.querySelector('div[id="dt-row-123"]')).not.toBeNull();
 });
 
-test('should fallback to array indexes if data has no unique key', () => {
+test('should render correctly if data has no unique key', () => {
   const mock = dataMock();
   const data = [{ some: { name: 'Henry the 8th' } }];
-  const { container } = render(<DataTable data={data} columns={mock.columns} />);
+  const { container } = render(<DataTable id="dt" data={data} columns={mock.columns} />);
 
-  expect(container.querySelector('div[id="row-0"]')).not.toBeNull();
+  expect(container.querySelector('div[id="dt-row-2"]')).not.toBeNull();
 });
 
 test('should render correctly when disabled', () => {
   const mock = dataMock();
   const { container } = render(
-    <DataTable
+    <DataTable id="dt"
       data={mock.data}
       columns={mock.columns}
       disabled
@@ -56,7 +56,7 @@ test('should render correctly when disabled', () => {
 test('should not show the TableHead when noTableHead is true', () => {
   const mock = dataMock();
   const { container } = render(
-    <DataTable
+    <DataTable id="dt"
       data={mock.data}
       columns={mock.columns}
       noTableHead
@@ -71,7 +71,7 @@ describe('DataTable::onSelectedRowsChange', () => {
     const mock = dataMock();
     const updatedMock = jest.fn();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -92,7 +92,7 @@ describe('DataTable::onSelectedRowsChange', () => {
     const mock = dataMock();
     const updatedMock = jest.fn();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -114,7 +114,7 @@ describe('DataTable::onSelectedRowsChange', () => {
     const mock = dataMock();
     const updatedMock = jest.fn();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -136,14 +136,14 @@ describe('data prop changes', () => {
   test('should update state if the data prop changes', () => {
     const mock = dataMock();
     const { container, rerender } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
     );
 
     rerender(
-      <DataTable
+      <DataTable id="dt"
         data={[{ id: 1, some: { name: 'Someone else' } }]}
         columns={mock.columns}
       />,
@@ -156,7 +156,7 @@ describe('data prop changes', () => {
 describe('DataTable::columns', () => {
   test('should render correctly with columns/data', () => {
     const mock = dataMock();
-    const { container } = render(<DataTable data={mock.data} columns={mock.columns} />);
+    const { container } = render(<DataTable id="dt" data={mock.data} columns={mock.columns} />);
 
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -164,7 +164,7 @@ describe('DataTable::columns', () => {
   test('should render correctly when column.sortable = true', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -176,7 +176,7 @@ describe('DataTable::columns', () => {
   test('should render correctly when column.wrap = true', () => {
     const mock = dataMock({ wrap: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -188,7 +188,7 @@ describe('DataTable::columns', () => {
   test('should render correctly when column.allowOverflow = true', () => {
     const mock = dataMock({ allowOverflow: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -200,7 +200,7 @@ describe('DataTable::columns', () => {
   test('should render correctly when column.compact = true', () => {
     const mock = dataMock({ compact: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -212,7 +212,7 @@ describe('DataTable::columns', () => {
   test('should render correctly when column.button = true', () => {
     const mock = dataMock({ button: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -225,7 +225,7 @@ describe('DataTable::columns', () => {
   test('should render correctly when ignoreRowClick = true', () => {
     const mock = dataMock({ ignoreRowClick: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -237,7 +237,7 @@ describe('DataTable::columns', () => {
   test('should render correctly when column.cell is set to a component', () => {
     const mock = dataMock({ cell: row => <div>{row.some.name}</div> });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -249,7 +249,7 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.right', () => {
     const mock = dataMock({ right: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -261,7 +261,7 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.center', () => {
     const mock = dataMock({ center: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -273,7 +273,7 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.minWidth', () => {
     const mock = dataMock({ minWidth: '200px' });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -285,7 +285,7 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.maxWidth', () => {
     const mock = dataMock({ maxWidth: '600px' });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -297,7 +297,7 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.width', () => {
     const mock = dataMock({ width: '200px' });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -309,7 +309,7 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.hide sm', () => {
     const mock = dataMock({ hide: 'sm' });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -321,7 +321,7 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.hide md', () => {
     const mock = dataMock({ hide: 'md' });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -333,7 +333,7 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.hide lg', () => {
     const mock = dataMock({ hide: 'lg' });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -345,7 +345,7 @@ describe('DataTable::columns', () => {
   test('should render correctly if column.hide is an integer', () => {
     const mock = dataMock({ hide: 300 });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -360,14 +360,14 @@ describe('DataTable:RowClicks', () => {
     const onRowClickedMock = jest.fn();
     const mock = dataMock({ ignoreRowClick: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         onRowClicked={onRowClickedMock}
       />,
     );
 
-    fireEvent.click(container.querySelector('div[id="cell-1-1"]'));
+    fireEvent.click(container.querySelector('div[id="dt-cell-1-1"]'));
     expect(onRowClickedMock).not.toBeCalled();
   });
 
@@ -375,14 +375,14 @@ describe('DataTable:RowClicks', () => {
     const onRowClickedMock = jest.fn();
     const mock = dataMock({ button: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         onRowClicked={onRowClickedMock}
       />,
     );
 
-    fireEvent.click(container.querySelector('div[id="cell-1-1"]'));
+    fireEvent.click(container.querySelector('div[id="dt-cell-1-1"]'));
     expect(onRowClickedMock).not.toBeCalled();
   });
 
@@ -390,14 +390,14 @@ describe('DataTable:RowClicks', () => {
     const onRowDoubleClickedMock = jest.fn();
     const mock = dataMock({ ignoreRowClick: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         onRowDoubleClicked={onRowDoubleClickedMock}
       />,
     );
 
-    fireEvent.click(container.querySelector('div[id="cell-1-1"]'));
+    fireEvent.click(container.querySelector('div[id="dt-cell-1-1"]'));
     expect(onRowDoubleClickedMock).not.toBeCalled();
   });
 
@@ -405,14 +405,14 @@ describe('DataTable:RowClicks', () => {
     const onRowDoubleClickedMock = jest.fn();
     const mock = dataMock({ button: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         onRowDoubleClicked={onRowDoubleClickedMock}
       />,
     );
 
-    fireEvent.click(container.querySelector('div[id="cell-1-1"]'));
+    fireEvent.click(container.querySelector('div[id="dt-cell-1-1"]'));
     expect(onRowDoubleClickedMock).not.toBeCalled();
   });
 });
@@ -421,7 +421,7 @@ describe('DataTable::progress/nodata', () => {
   test('should render correctly when progressPending is true', () => {
     const mock = dataMock();
     const { container, getByText } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -436,7 +436,7 @@ describe('DataTable::progress/nodata', () => {
   test('should only show Loading if progressPending prop changes', () => {
     const mock = dataMock();
     const { getByText, rerender, container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -445,7 +445,7 @@ describe('DataTable::progress/nodata', () => {
     );
 
     rerender(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -462,7 +462,7 @@ describe('DataTable::progress/nodata', () => {
     test('should only Loading and TableHead if progressPending prop changes', () => {
       const mock = dataMock();
       const { getByText, rerender, container } = render(
-        <DataTable
+        <DataTable id="dt"
           data={mock.data}
           columns={mock.columns}
           defaultSortField="some.name"
@@ -472,7 +472,7 @@ describe('DataTable::progress/nodata', () => {
       );
 
       rerender(
-        <DataTable
+        <DataTable id="dt"
           data={mock.data}
           columns={mock.columns}
           defaultSortField="some.name"
@@ -489,7 +489,7 @@ describe('DataTable::progress/nodata', () => {
     test('should disable TableHead if no data', () => {
       const mock = dataMock();
       const { container } = render(
-        <DataTable
+        <DataTable id="dt"
           data={[]}
           columns={mock.columns}
           defaultSortField="some.name"
@@ -503,7 +503,7 @@ describe('DataTable::progress/nodata', () => {
     test('should disable TableHead if progressPending', () => {
       const mock = dataMock();
       const { container } = render(
-        <DataTable
+        <DataTable id="dt"
           data={[]}
           columns={mock.columns}
           defaultSortField="some.name"
@@ -520,7 +520,7 @@ describe('DataTable::progress/nodata', () => {
     test('should only Loading if progressPending prop changes', () => {
       const mock = dataMock();
       const { getByText, rerender, container } = render(
-        <DataTable
+        <DataTable id="dt"
           data={mock.data}
           columns={mock.columns}
           defaultSortField="some.name"
@@ -531,7 +531,7 @@ describe('DataTable::progress/nodata', () => {
       );
 
       rerender(
-        <DataTable
+        <DataTable id="dt"
           data={mock.data}
           columns={mock.columns}
           defaultSortField="some.name"
@@ -550,7 +550,7 @@ describe('DataTable::progress/nodata', () => {
   test('should render correctly when progressPending is false and there are no row items', () => {
     const mock = dataMock();
     const { container, getByText } = render(
-      <DataTable
+      <DataTable id="dt"
         data={[]}
         columns={mock.columns}
       />,
@@ -563,7 +563,7 @@ describe('DataTable::progress/nodata', () => {
   test('should render correctly when a component is passed that is a string', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -578,7 +578,7 @@ describe('DataTable::progress/nodata', () => {
   test('should render correctly when a component is passed that is a react component', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -595,7 +595,7 @@ describe('DataTable::responsive', () => {
   test('should render correctly responsive by default', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -607,7 +607,7 @@ describe('DataTable::responsive', () => {
   test('should render correctly when responsive=false', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         responsive={false}
@@ -620,7 +620,7 @@ describe('DataTable::responsive', () => {
   test('should not apply overFlowY without an overflowYOffset or not responsive', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         responsive
@@ -639,14 +639,14 @@ describe('DataTable::sorting', () => {
     const onSortMock = jest.fn();
     const mock = dataMock({ sortable: false });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         onSort={onSortMock}
       />,
     );
 
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    fireEvent.click(container.querySelector('div[id="dt-column-some.name"]'));
 
     expect(onSortMock).not.toBeCalled();
   });
@@ -654,7 +654,7 @@ describe('DataTable::sorting', () => {
   test('should render correctly with a default sort field and the native sort icon', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -667,7 +667,7 @@ describe('DataTable::sorting', () => {
   test('should render correctly with a default sort field and the icon to the right when column.right = true and the native sort icon', () => {
     const mock = dataMock({ sortable: true, right: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -680,13 +680,13 @@ describe('DataTable::sorting', () => {
   test('should render correctly and not be sorted when a column.sort === false', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
     );
 
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    fireEvent.click(container.querySelector('div[id="dt-column-some.name"]'));
 
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -694,13 +694,13 @@ describe('DataTable::sorting', () => {
   test('should render correctly when a column is sorted in default asc', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
     );
 
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    fireEvent.click(container.querySelector('div[id="dt-column-some.name"]'));
 
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -708,18 +708,18 @@ describe('DataTable::sorting', () => {
   test('should render correctly when a column is sorted from asc to desc', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
     );
 
     // select the column to sort
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    fireEvent.click(container.querySelector('div[id="dt-column-some.name"]'));
     // sort asc
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    fireEvent.click(container.querySelector('div[id="dt-column-some.name"]'));
     // sort desc
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    fireEvent.click(container.querySelector('div[id="dt-column-some.name"]'));
 
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -728,14 +728,14 @@ describe('DataTable::sorting', () => {
     const onSortMock = jest.fn();
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         onSort={onSortMock}
       />,
     );
 
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    fireEvent.click(container.querySelector('div[id="dt-column-some.name"]'));
 
     expect(onSortMock).toBeCalledWith({ id: 1, ...mock.columns[0] }, 'asc');
   });
@@ -744,24 +744,24 @@ describe('DataTable::sorting', () => {
     const onSortMock = jest.fn();
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         onSort={onSortMock}
       />,
     );
 
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    fireEvent.click(container.querySelector('div[id="dt-column-some.name"]'));
     expect(onSortMock).toBeCalledWith({ id: 1, ...mock.columns[0] }, 'asc');
 
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    fireEvent.click(container.querySelector('div[id="dt-column-some.name"]'));
     expect(onSortMock).toBeCalledWith({ id: 1, ...mock.columns[0] }, 'desc');
   });
 
   test('should render correctly with a custom sortIcon', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -775,7 +775,7 @@ describe('DataTable::sorting', () => {
   test('should render correctly with a custom sortIcon and column.right = true', () => {
     const mock = dataMock({ sortable: true, right: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -789,7 +789,7 @@ describe('DataTable::sorting', () => {
   test('should render correctly with a defaultSortAsc = false', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -803,14 +803,14 @@ describe('DataTable::sorting', () => {
   test('should render correctly and bypass internal sort when sortServer = true and asc sort', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         sortServer
       />,
     );
 
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    fireEvent.click(container.querySelector('div[id="dt-column-some.name"]'));
     // note row order should not change, but sort arrows should
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -818,15 +818,15 @@ describe('DataTable::sorting', () => {
   test('should render correctly and bypass internal sort when sortServer = true and desc sort', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         sortServer
       />,
     );
 
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    fireEvent.click(container.querySelector('div[id="dt-column-some.name"]'));
+    fireEvent.click(container.querySelector('div[id="dt-column-some.name"]'));
     // note row order should not change, but sort arrows should
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -837,7 +837,7 @@ describe('DataTable::expandableRows', () => {
   test('should render correctly when expandableRows is true', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         expandableRows
@@ -851,7 +851,7 @@ describe('DataTable::expandableRows', () => {
     const mock = dataMock();
     mock.data[0].defaultExpanded = true;
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultExpandedField="defaultExpanded"
@@ -864,7 +864,7 @@ describe('DataTable::expandableRows', () => {
   test('should render correctly when expandableRows is true and the row is toggled', () => {
     const mock = dataMock();
     const { container, getByTestId } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         expandableRows
@@ -880,7 +880,7 @@ describe('DataTable::expandableRows', () => {
     const mock = dataMock();
     mock.data[0].defaultExpanded = true;
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         expandableRows
@@ -895,7 +895,7 @@ describe('DataTable::expandableRows', () => {
     const mock = dataMock();
     mock.data[0].disabled = true;
     const { container, getByTestId } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         expandableRows
@@ -910,7 +910,7 @@ describe('DataTable::expandableRows', () => {
   test('should not expand a row if expandableRows is false and expandOnRowClicked is true ', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         expandOnRowClicked
@@ -925,7 +925,7 @@ describe('DataTable::expandableRows', () => {
   test('should expand a row if expandableRows is true and expandOnRowClicked is true', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         expandableRows
@@ -942,7 +942,7 @@ describe('DataTable::expandableRows', () => {
   test('should not expand a row if expandableRows is false and expandOnRowDoubleClicked is true ', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         expandOnRowDoubleClicked
@@ -957,7 +957,7 @@ describe('DataTable::expandableRows', () => {
   test('should expand a row if expandableRows is true and expandOnRowDoubleClicked is true', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         expandableRows
@@ -975,7 +975,7 @@ describe('DataTable::expandableRows', () => {
     const mock = dataMock();
     mock.data[0].disabled = true;
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         expandableRows
@@ -995,7 +995,7 @@ describe('DataTable::selectableRows', () => {
   test('should render correctly when selectableRows is true', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1008,7 +1008,7 @@ describe('DataTable::selectableRows', () => {
   test('should not render a select all checkbox when selectableRowsNoSelectAll is true', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1023,7 +1023,7 @@ describe('DataTable::selectableRows', () => {
   test('select-all-rows should be true is all rows are selected', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1038,7 +1038,7 @@ describe('DataTable::selectableRows', () => {
   test('select-all-rows should be false and not when all rows is de-selected', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1054,7 +1054,7 @@ describe('DataTable::selectableRows', () => {
   test('should render correctly when selectableRows is true and a single row is checked', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1070,7 +1070,7 @@ describe('DataTable::selectableRows', () => {
   test('select-all-rows should not be indeterminate when all rows are selected', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1086,7 +1086,7 @@ describe('DataTable::selectableRows', () => {
   test('select-all-rows should be indeterminate when a single row is selected', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1102,7 +1102,7 @@ describe('DataTable::selectableRows', () => {
     const mock = dataMock();
 
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1118,7 +1118,7 @@ describe('DataTable::selectableRows', () => {
   test('should render correctly when selectableRows is true and a single row is un-checked', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1136,7 +1136,7 @@ describe('DataTable::selectableRows', () => {
     mock.data[0].disabled = true;
 
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1155,7 +1155,7 @@ describe('DataTable::selectableRows', () => {
     mock.data[0].disabled = true;
 
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1175,7 +1175,7 @@ describe('DataTable::selectableRows', () => {
     mock.data[1].disabled = true;
 
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1195,7 +1195,7 @@ describe('DataTable::selectableRows', () => {
     mock.data[0].selected = true;
 
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1213,7 +1213,7 @@ describe('DataTable::selectableRows', () => {
     mock.data[1].selected = true;
 
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1228,7 +1228,7 @@ describe('DataTable::selectableRows', () => {
   test('should render correctly when clearSelectedRows is toggled', () => {
     const mock = dataMock();
     const { container, rerender } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1238,7 +1238,7 @@ describe('DataTable::selectableRows', () => {
     fireEvent.click(container.querySelector('input[name="select-row-1"]'));
 
     rerender(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1253,7 +1253,7 @@ describe('DataTable::selectableRows', () => {
     const rowClickedMock = jest.fn();
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         selectableRows
@@ -1272,7 +1272,7 @@ describe('DataTable::Pagination', () => {
   test('should render correctly if pagination is enabled', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1285,7 +1285,7 @@ describe('DataTable::Pagination', () => {
   test('should have the correct amount of rows when paging forward', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationPerPage={1}
@@ -1295,15 +1295,15 @@ describe('DataTable::Pagination', () => {
     );
 
     fireEvent.click(container.querySelector('button#pagination-next-page'));
-    expect(container.querySelector('div[id="row-1"]')).toBeNull();
-    expect(container.querySelector('div[id="row-2"]')).not.toBeNull();
+    expect(container.querySelector('div[id="dt-row-1"]')).toBeNull();
+    expect(container.querySelector('div[id="dt-row-2"]')).not.toBeNull();
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test('should have the correct amount of rows when paging backward', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationDefaultPage={2}
@@ -1314,15 +1314,15 @@ describe('DataTable::Pagination', () => {
     );
 
     fireEvent.click(container.querySelector('button#pagination-previous-page'));
-    expect(container.querySelector('div[id="row-1"]')).not.toBeNull();
-    expect(container.querySelector('div[id="row-2"]')).toBeNull();
+    expect(container.querySelector('div[id="dt-row-1"]')).not.toBeNull();
+    expect(container.querySelector('div[id="dt-row-2"]')).toBeNull();
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test('should have the correct amount of rows when paging to the last page', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationPerPage={1}
@@ -1332,15 +1332,15 @@ describe('DataTable::Pagination', () => {
     );
 
     fireEvent.click(container.querySelector('button#pagination-last-page'));
-    expect(container.querySelector('div[id="row-1"]')).toBeNull();
-    expect(container.querySelector('div[id="row-2"]')).not.toBeNull();
+    expect(container.querySelector('div[id="dt-row-1"]')).toBeNull();
+    expect(container.querySelector('div[id="dt-row-2"]')).not.toBeNull();
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test('should have the correct amount of rows when paging backward to the first page', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationDefaultPage={2}
@@ -1351,15 +1351,15 @@ describe('DataTable::Pagination', () => {
     );
 
     fireEvent.click(container.querySelector('button#pagination-first-page'));
-    expect(container.querySelector('div[id="row-1"]')).not.toBeNull();
-    expect(container.querySelector('div[id="row-2"]')).toBeNull();
+    expect(container.querySelector('div[id="dt-row-1"]')).not.toBeNull();
+    expect(container.querySelector('div[id="dt-row-2"]')).toBeNull();
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test('should navigate to page 1 if the table is sorted', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationPerPage={1}
@@ -1369,9 +1369,9 @@ describe('DataTable::Pagination', () => {
     );
 
     fireEvent.click(container.querySelector('button#pagination-next-page'));
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    fireEvent.click(container.querySelector('div[id="dt-column-some.name"]'));
     expect(container.firstChild).toMatchSnapshot();
-    expect(container.querySelector('div[id="row-1"]')).not.toBeNull();
+    expect(container.querySelector('div[id="dt-row-1"]')).not.toBeNull();
   });
 
   test('should recalculate pagination position if there is only 1 item and it is removed from the data', () => {
@@ -1379,7 +1379,7 @@ describe('DataTable::Pagination', () => {
     const mockOneDeleted = dataMock().data.slice(0, 1);
     const onChangePageMock = jest.fn();
     const { container, rerender } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationPerPage={1}
@@ -1393,7 +1393,7 @@ describe('DataTable::Pagination', () => {
     fireEvent.click(container.querySelector('button#pagination-last-page'));
 
     rerender(
-      <DataTable
+      <DataTable id="dt"
         data={mockOneDeleted}
         columns={mock.columns}
         onChangePage={onChangePageMock}
@@ -1413,7 +1413,7 @@ describe('DataTable::Pagination', () => {
     const onChangePageMock = jest.fn();
     const onChangeRowsPerPageMock = jest.fn();
     const { container, rerender } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         onChangePage={onChangePageMock}
@@ -1430,7 +1430,7 @@ describe('DataTable::Pagination', () => {
     fireEvent.click(container.querySelector('button#pagination-last-page'));
 
     rerender(
-      <DataTable
+      <DataTable id="dt"
         data={mockOneDeleted}
         columns={mock.columns}
         onChangePage={onChangePageMock}
@@ -1452,7 +1452,7 @@ describe('DataTable::Pagination', () => {
     const mockOneDeleted = dataMock().data.slice(0, 2);
     const onChangePageMock = jest.fn();
     const { container, rerender } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationPerPage={1}
@@ -1466,7 +1466,7 @@ describe('DataTable::Pagination', () => {
     fireEvent.click(container.querySelector('button#pagination-last-page'));
 
     rerender(
-      <DataTable
+      <DataTable id="dt"
         data={mockOneDeleted}
         columns={mock.columns}
         onChangePage={onChangePageMock}
@@ -1484,7 +1484,7 @@ describe('DataTable::Pagination', () => {
     const onChangePageMock = jest.fn();
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1502,7 +1502,7 @@ describe('DataTable::Pagination', () => {
     const onChangePageMock = jest.fn();
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1521,7 +1521,7 @@ describe('DataTable::Pagination', () => {
   test('should not deselect all rows if using pagination and selectedRows', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1540,7 +1540,7 @@ describe('DataTable::Pagination', () => {
   test('should deselect all rows if using paginationServer and selectedRows', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1560,7 +1560,7 @@ describe('DataTable::Pagination', () => {
   test('should deselect all rows if using pagination && paginationServer and selectedRows and the table is sorted', () => {
     const mock = dataMock({ sortable: true });
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1573,7 +1573,7 @@ describe('DataTable::Pagination', () => {
 
     fireEvent.click(container.querySelector('input[name="select-all-rows"]'));
     expect(container.querySelector('input[name="select-all-rows"]').checked).toBe(true);
-    fireEvent.click(container.querySelector('div[id="column-some.name"]'));
+    fireEvent.click(container.querySelector('div[id="dt-column-some.name"]'));
     expect(container.querySelector('input[name="select-all-rows"]').checked).toBe(false);
   });
 
@@ -1581,7 +1581,7 @@ describe('DataTable::Pagination', () => {
     const onChangePageMock = jest.fn();
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1600,7 +1600,7 @@ describe('DataTable::Pagination', () => {
     const onChangeRowsPerPageMock = jest.fn();
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1616,7 +1616,7 @@ describe('DataTable::Pagination', () => {
     const onChangeRowsPerPageMock = jest.fn();
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1632,7 +1632,7 @@ describe('DataTable::Pagination', () => {
   test('should render correctly when a paginationComponentOptions are passed', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1646,7 +1646,7 @@ describe('DataTable::Pagination', () => {
   test('should render correctly when a paginationComponentOptions to hide the per page dropdown are passed', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         pagination
@@ -1660,7 +1660,7 @@ describe('DataTable::Pagination', () => {
   test('should render correctly when paginationResetDefaultPage is toggled', () => {
     const mock = dataMock();
     const { container, rerender } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationPerPage={1} // force 2 pages
@@ -1672,7 +1672,7 @@ describe('DataTable::Pagination', () => {
     fireEvent.click(container.querySelector('button#pagination-next-page'));
 
     rerender(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         paginationPerPage={1} // force 2 pages
@@ -1690,7 +1690,7 @@ describe('DataTable::subHeader', () => {
   test('should render correctly when a subheader is enabled', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         subHeader
@@ -1705,7 +1705,7 @@ describe('DataTable::subHeader', () => {
   test('should render when subHeaderWrap is false', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         subHeader
@@ -1720,7 +1720,7 @@ describe('DataTable::subHeader', () => {
   test('should render correctly with left align', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         subHeader
@@ -1735,7 +1735,7 @@ describe('DataTable::subHeader', () => {
   test('should render correctly with center align', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         subHeader
@@ -1750,7 +1750,7 @@ describe('DataTable::subHeader', () => {
   test('should render correctly with right align', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         subHeader
@@ -1768,7 +1768,7 @@ describe('DataTable::Header', () => {
   test('should render without a header if noHeader is true', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         noHeader
@@ -1781,7 +1781,7 @@ describe('DataTable::Header', () => {
   test('title should render correctly', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         title="whoa!"
@@ -1794,7 +1794,7 @@ describe('DataTable::Header', () => {
   test('contextTitle should render correctly', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         title="whoa!"
@@ -1808,7 +1808,7 @@ describe('DataTable::Header', () => {
   test('actions should render correctly', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         title="whoa!"
@@ -1823,7 +1823,7 @@ describe('DataTable::Header', () => {
   test('context menu should render correctly when selectableRows', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         title="whoa!"
@@ -1844,7 +1844,7 @@ describe('DataTable::fixedHeader', () => {
   test('should render correctly when fixedHeader', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         fixedHeader
@@ -1857,7 +1857,7 @@ describe('DataTable::fixedHeader', () => {
   test('should render correctly when fixedHeader and fixedHeaderScrollHeight', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         fixedHeader
@@ -1871,7 +1871,7 @@ describe('DataTable::fixedHeader', () => {
   test('should render correctly when fixedHeader with an offset', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         fixedHeader
@@ -1885,7 +1885,7 @@ describe('DataTable::fixedHeader', () => {
   test('should render correctly when fixedHeader with an offset with a value', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         fixedHeader
@@ -1902,7 +1902,7 @@ describe('DataTable::striped', () => {
   test('should render correctly when striped', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         striped
@@ -1917,7 +1917,7 @@ describe('DataTable::highlightOnHover', () => {
   test('should render correctly when highlightOnHover', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         highlightOnHover
@@ -1932,7 +1932,7 @@ describe('DataTable::pointerOnHover', () => {
   test('should render correctly when pointerOnHover', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         pointerOnHover
@@ -1947,7 +1947,7 @@ describe('DataTable::dense', () => {
   test('should render correctly when dense', () => {
     const mock = dataMock();
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         dense
@@ -1967,7 +1967,7 @@ describe('DataTable::Theming', () => {
       },
     };
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -1987,7 +1987,7 @@ describe('DataTable::Theming', () => {
       },
     };
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         defaultSortField="some.name"
@@ -2006,7 +2006,7 @@ describe('DataTable::conditionalRowStyles', () => {
     const conditionalRowStyles = [];
 
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         conditionalRowStyles={conditionalRowStyles}
@@ -2033,7 +2033,7 @@ describe('DataTable::conditionalRowStyles', () => {
     ];
 
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         conditionalRowStyles={conditionalRowStyles}
@@ -2060,7 +2060,7 @@ describe('DataTable::conditionalRowStyles', () => {
     ];
 
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
         conditionalRowStyles={conditionalRowStyles}
@@ -2079,7 +2079,7 @@ describe('DataTable::column.style', () => {
     };
 
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -2103,7 +2103,7 @@ describe('DataTable::conditionalCellStyles', () => {
     ];
 
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,
@@ -2125,7 +2125,7 @@ describe('DataTable::conditionalCellStyles', () => {
     ];
 
     const { container } = render(
-      <DataTable
+      <DataTable id="dt"
         data={mock.data}
         columns={mock.columns}
       />,

--- a/src/DataTable/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/DataTable/__tests__/__snapshots__/DataTable.test.js.snap
@@ -90,6 +90,9 @@ exports[`DataTable::Header actions should render correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -319,6 +322,7 @@ exports[`DataTable::Header actions should render correctly 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -349,20 +353,31 @@ exports[`DataTable::Header actions should render correctly 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -375,15 +390,20 @@ exports[`DataTable::Header actions should render correctly 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -393,13 +413,17 @@ exports[`DataTable::Header actions should render correctly 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -525,6 +549,9 @@ exports[`DataTable::Header context menu should render correctly when selectableR
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -780,6 +807,7 @@ exports[`DataTable::Header context menu should render correctly when selectableR
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -810,13 +838,23 @@ exports[`DataTable::Header context menu should render correctly when selectableR
     class="c6"
   >
     <div
+      aria-colcount="2"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
@@ -830,10 +868,11 @@ exports[`DataTable::Header context menu should render correctly when selectableR
           </div>
           <div
             class="c11 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c12 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -846,13 +885,19 @@ exports[`DataTable::Header context menu should render correctly when selectableR
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
+            id="dt-selector-1"
+            role="cell"
           >
             <input
               aria-label="select-row-1"
@@ -862,9 +907,11 @@ exports[`DataTable::Header context menu should render correctly when selectableR
             />
           </div>
           <div
+            aria-colindex="2"
             class="c16 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -874,11 +921,16 @@ exports[`DataTable::Header context menu should render correctly when selectableR
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c14 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
+            id="dt-selector-2"
+            role="cell"
           >
             <input
               aria-label="select-row-2"
@@ -888,9 +940,11 @@ exports[`DataTable::Header context menu should render correctly when selectableR
             />
           </div>
           <div
+            aria-colindex="2"
             class="c16 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -995,6 +1049,9 @@ exports[`DataTable::Header contextTitle should render correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -1224,6 +1281,7 @@ exports[`DataTable::Header contextTitle should render correctly 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -1246,20 +1304,31 @@ exports[`DataTable::Header contextTitle should render correctly 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -1272,15 +1341,20 @@ exports[`DataTable::Header contextTitle should render correctly 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -1290,13 +1364,17 @@ exports[`DataTable::Header contextTitle should render correctly 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -1401,6 +1479,9 @@ exports[`DataTable::Header should render without a header if noHeader is true 1`
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -1533,20 +1614,30 @@ exports[`DataTable::Header should render without a header if noHeader is true 1`
     class="c1"
   >
     <div
+      aria-colcount="1"
+      aria-rowcount="3"
       class="c2 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c3 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c4 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c5 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c6 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -1559,15 +1650,20 @@ exports[`DataTable::Header should render without a header if noHeader is true 1`
       <div
         class="c7 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c8 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c9 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -1577,13 +1673,17 @@ exports[`DataTable::Header should render without a header if noHeader is true 1`
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c8 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c9 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -1688,6 +1788,9 @@ exports[`DataTable::Header title should render correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -1917,6 +2020,7 @@ exports[`DataTable::Header title should render correctly 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -1939,20 +2043,31 @@ exports[`DataTable::Header title should render correctly 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -1965,15 +2080,20 @@ exports[`DataTable::Header title should render correctly 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -1983,13 +2103,17 @@ exports[`DataTable::Header title should render correctly 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -2121,6 +2245,9 @@ exports[`DataTable::Pagination should change the page position when using pagina
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -2476,6 +2603,7 @@ exports[`DataTable::Pagination should change the page position when using pagina
   >
     <header
       class="c1 rdt_TableHeader"
+      id="dt-header"
     >
       <div
         class="c2"
@@ -2496,20 +2624,31 @@ exports[`DataTable::Pagination should change the page position when using pagina
       class="c6"
     >
       <div
+        aria-colcount="1"
+        aria-labelledby="dt-header"
+        aria-rowcount="2"
         class="c7 rdt_Table"
+        id="dt"
+        role="table"
       >
         <div
           class="c8 rdt_TableHead"
+          id="dt-thead"
+          role="rowgroup"
         >
           <div
+            aria-rowindex="1"
             class="c9 rdt_TableHeadRow"
+            id="dt-thead-row"
+            role="row"
           >
             <div
               class="c10 rdt_TableCol"
+              role="columnheader"
             >
               <div
                 class="c11 rdt_TableCol_Sortable"
-                id="column-some.name"
+                id="dt-column-some.name"
                 role="button"
               >
                 <div>
@@ -2522,15 +2661,20 @@ exports[`DataTable::Pagination should change the page position when using pagina
         <div
           class="c12 rdt_TableBody"
           offset="250px"
+          role="rowgroup"
         >
           <div
+            aria-rowindex="2"
             class="c13 rdt_TableRow"
-            id="row-1"
+            id="dt-row-1"
+            role="row"
           >
             <div
+              aria-colindex="1"
               class="c14 rdt_TableCell"
               data-tag="___react-data-table-allow-propagation___"
-              id="cell-1-1"
+              id="dt-cell-1-1"
+              role="cell"
             >
               <div
                 data-tag="___react-data-table-allow-propagation___"
@@ -2794,6 +2938,9 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -3148,6 +3295,7 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -3168,20 +3316,31 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -3194,15 +3353,20 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -3463,6 +3627,9 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -3817,6 +3984,7 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -3837,20 +4005,31 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -3863,15 +4042,20 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -4132,6 +4316,9 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -4486,6 +4673,7 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -4506,20 +4694,31 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -4532,15 +4731,20 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -4801,6 +5005,9 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -5155,6 +5362,7 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -5175,20 +5383,31 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -5201,15 +5420,20 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -5470,6 +5694,9 @@ exports[`DataTable::Pagination should navigate to page 1 if the table is sorted 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -5843,6 +6070,7 @@ exports[`DataTable::Pagination should navigate to page 1 if the table is sorted 
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -5863,20 +6091,31 @@ exports[`DataTable::Pagination should navigate to page 1 if the table is sorted 
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -5894,15 +6133,20 @@ exports[`DataTable::Pagination should navigate to page 1 if the table is sorted 
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -6163,6 +6407,9 @@ exports[`DataTable::Pagination should recalculate pagination position if there i
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -6517,6 +6764,7 @@ exports[`DataTable::Pagination should recalculate pagination position if there i
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -6537,20 +6785,31 @@ exports[`DataTable::Pagination should recalculate pagination position if there i
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="2"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -6563,15 +6822,20 @@ exports[`DataTable::Pagination should recalculate pagination position if there i
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -6834,6 +7098,9 @@ exports[`DataTable::Pagination should render correctly if pagination is enabled 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -7188,6 +7455,7 @@ exports[`DataTable::Pagination should render correctly if pagination is enabled 
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -7208,20 +7476,31 @@ exports[`DataTable::Pagination should render correctly if pagination is enabled 
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -7234,15 +7513,20 @@ exports[`DataTable::Pagination should render correctly if pagination is enabled 
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -7252,13 +7536,17 @@ exports[`DataTable::Pagination should render correctly if pagination is enabled 
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -7536,6 +7824,9 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -7890,6 +8181,7 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -7910,20 +8202,31 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -7936,15 +8239,20 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -7954,13 +8262,17 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -8238,6 +8550,9 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -8523,6 +8838,7 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -8543,20 +8859,31 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -8569,15 +8896,20 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -8587,13 +8919,17 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -8818,6 +9154,9 @@ exports[`DataTable::Pagination should render correctly when paginationResetDefau
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -9172,6 +9511,7 @@ exports[`DataTable::Pagination should render correctly when paginationResetDefau
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -9192,20 +9532,31 @@ exports[`DataTable::Pagination should render correctly when paginationResetDefau
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -9218,15 +9569,20 @@ exports[`DataTable::Pagination should render correctly when paginationResetDefau
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -9460,6 +9816,9 @@ exports[`DataTable::Theming should render correctly when rows spaced 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -9689,6 +10048,7 @@ exports[`DataTable::Theming should render correctly when rows spaced 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -9709,20 +10069,31 @@ exports[`DataTable::Theming should render correctly when rows spaced 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -9735,15 +10106,20 @@ exports[`DataTable::Theming should render correctly when rows spaced 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -9753,13 +10129,17 @@ exports[`DataTable::Theming should render correctly when rows spaced 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -9864,6 +10244,9 @@ exports[`DataTable::Theming should render correctly when rows spaced with spacin
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -10094,6 +10477,7 @@ exports[`DataTable::Theming should render correctly when rows spaced with spacin
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -10114,20 +10498,31 @@ exports[`DataTable::Theming should render correctly when rows spaced with spacin
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -10140,15 +10535,20 @@ exports[`DataTable::Theming should render correctly when rows spaced with spacin
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -10158,13 +10558,17 @@ exports[`DataTable::Theming should render correctly when rows spaced with spacin
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -10270,6 +10674,9 @@ exports[`DataTable::column.style should render correctly when a style is set on 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -10499,6 +10906,7 @@ exports[`DataTable::column.style should render correctly when a style is set on 
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -10519,20 +10927,31 @@ exports[`DataTable::column.style should render correctly when a style is set on 
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -10545,15 +10964,20 @@ exports[`DataTable::column.style should render correctly when a style is set on 
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -10563,13 +10987,17 @@ exports[`DataTable::column.style should render correctly when a style is set on 
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -10678,6 +11106,9 @@ exports[`DataTable::columns should render correctly if column.center 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -10911,6 +11342,7 @@ exports[`DataTable::columns should render correctly if column.center 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -10931,20 +11363,31 @@ exports[`DataTable::columns should render correctly if column.center 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -10957,15 +11400,20 @@ exports[`DataTable::columns should render correctly if column.center 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -10975,13 +11423,17 @@ exports[`DataTable::columns should render correctly if column.center 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -11086,6 +11538,9 @@ exports[`DataTable::columns should render correctly if column.hide is an integer
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -11327,6 +11782,7 @@ exports[`DataTable::columns should render correctly if column.hide is an integer
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -11347,20 +11803,31 @@ exports[`DataTable::columns should render correctly if column.hide is an integer
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -11373,15 +11840,20 @@ exports[`DataTable::columns should render correctly if column.hide is an integer
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -11391,13 +11863,17 @@ exports[`DataTable::columns should render correctly if column.hide is an integer
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -11502,6 +11978,9 @@ exports[`DataTable::columns should render correctly if column.hide lg 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -11743,6 +12222,7 @@ exports[`DataTable::columns should render correctly if column.hide lg 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -11763,20 +12243,31 @@ exports[`DataTable::columns should render correctly if column.hide lg 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -11789,15 +12280,20 @@ exports[`DataTable::columns should render correctly if column.hide lg 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -11807,13 +12303,17 @@ exports[`DataTable::columns should render correctly if column.hide lg 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -11918,6 +12418,9 @@ exports[`DataTable::columns should render correctly if column.hide md 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -12159,6 +12662,7 @@ exports[`DataTable::columns should render correctly if column.hide md 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -12179,20 +12683,31 @@ exports[`DataTable::columns should render correctly if column.hide md 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -12205,15 +12720,20 @@ exports[`DataTable::columns should render correctly if column.hide md 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -12223,13 +12743,17 @@ exports[`DataTable::columns should render correctly if column.hide md 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -12334,6 +12858,9 @@ exports[`DataTable::columns should render correctly if column.hide sm 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -12575,6 +13102,7 @@ exports[`DataTable::columns should render correctly if column.hide sm 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -12595,20 +13123,31 @@ exports[`DataTable::columns should render correctly if column.hide sm 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -12621,15 +13160,20 @@ exports[`DataTable::columns should render correctly if column.hide sm 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -12639,13 +13183,17 @@ exports[`DataTable::columns should render correctly if column.hide sm 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -12750,6 +13298,9 @@ exports[`DataTable::columns should render correctly if column.maxWidth 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -12979,6 +13530,7 @@ exports[`DataTable::columns should render correctly if column.maxWidth 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -12999,20 +13551,31 @@ exports[`DataTable::columns should render correctly if column.maxWidth 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -13025,15 +13588,20 @@ exports[`DataTable::columns should render correctly if column.maxWidth 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -13043,13 +13611,17 @@ exports[`DataTable::columns should render correctly if column.maxWidth 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -13154,6 +13726,9 @@ exports[`DataTable::columns should render correctly if column.minWidth 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -13383,6 +13958,7 @@ exports[`DataTable::columns should render correctly if column.minWidth 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -13403,20 +13979,31 @@ exports[`DataTable::columns should render correctly if column.minWidth 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -13429,15 +14016,20 @@ exports[`DataTable::columns should render correctly if column.minWidth 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -13447,13 +14039,17 @@ exports[`DataTable::columns should render correctly if column.minWidth 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -13562,6 +14158,9 @@ exports[`DataTable::columns should render correctly if column.right 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -13795,6 +14394,7 @@ exports[`DataTable::columns should render correctly if column.right 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -13815,20 +14415,31 @@ exports[`DataTable::columns should render correctly if column.right 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -13841,15 +14452,20 @@ exports[`DataTable::columns should render correctly if column.right 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -13859,13 +14475,17 @@ exports[`DataTable::columns should render correctly if column.right 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -13972,6 +14592,9 @@ exports[`DataTable::columns should render correctly if column.width 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -14203,6 +14826,7 @@ exports[`DataTable::columns should render correctly if column.width 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -14223,20 +14847,31 @@ exports[`DataTable::columns should render correctly if column.width 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -14249,15 +14884,20 @@ exports[`DataTable::columns should render correctly if column.width 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -14267,13 +14907,17 @@ exports[`DataTable::columns should render correctly if column.width 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -14378,6 +15022,9 @@ exports[`DataTable::columns should render correctly when column.allowOverflow = 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -14607,6 +15254,7 @@ exports[`DataTable::columns should render correctly when column.allowOverflow = 
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -14627,20 +15275,31 @@ exports[`DataTable::columns should render correctly when column.allowOverflow = 
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -14653,15 +15312,20 @@ exports[`DataTable::columns should render correctly when column.allowOverflow = 
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -14671,13 +15335,17 @@ exports[`DataTable::columns should render correctly when column.allowOverflow = 
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -14786,6 +15454,9 @@ exports[`DataTable::columns should render correctly when column.button = true 1`
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -15020,6 +15691,7 @@ exports[`DataTable::columns should render correctly when column.button = true 1`
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -15040,20 +15712,31 @@ exports[`DataTable::columns should render correctly when column.button = true 1`
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -15066,14 +15749,19 @@ exports[`DataTable::columns should render correctly when column.button = true 1`
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div>
               Apple
@@ -15081,12 +15769,16 @@ exports[`DataTable::columns should render correctly when column.button = true 1`
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div>
               Zuchinni
@@ -15189,6 +15881,9 @@ exports[`DataTable::columns should render correctly when column.cell is set to a
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -15418,6 +16113,7 @@ exports[`DataTable::columns should render correctly when column.cell is set to a
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -15438,20 +16134,31 @@ exports[`DataTable::columns should render correctly when column.cell is set to a
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -15464,15 +16171,20 @@ exports[`DataTable::columns should render correctly when column.cell is set to a
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div>
               Apple
@@ -15480,13 +16192,17 @@ exports[`DataTable::columns should render correctly when column.cell is set to a
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div>
               Zuchinni
@@ -15590,6 +16306,9 @@ exports[`DataTable::columns should render correctly when column.compact = true 1
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -15820,6 +16539,7 @@ exports[`DataTable::columns should render correctly when column.compact = true 1
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -15840,20 +16560,31 @@ exports[`DataTable::columns should render correctly when column.compact = true 1
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -15866,15 +16597,20 @@ exports[`DataTable::columns should render correctly when column.compact = true 1
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -15884,13 +16620,17 @@ exports[`DataTable::columns should render correctly when column.compact = true 1
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -15995,6 +16735,9 @@ exports[`DataTable::columns should render correctly when column.sortable = true 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -16248,6 +16991,7 @@ exports[`DataTable::columns should render correctly when column.sortable = true 
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -16268,20 +17012,31 @@ exports[`DataTable::columns should render correctly when column.sortable = true 
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -16299,15 +17054,20 @@ exports[`DataTable::columns should render correctly when column.sortable = true 
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -16317,13 +17077,17 @@ exports[`DataTable::columns should render correctly when column.sortable = true 
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c14 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -16428,6 +17192,9 @@ exports[`DataTable::columns should render correctly when column.wrap = true 1`] 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -16657,6 +17424,7 @@ exports[`DataTable::columns should render correctly when column.wrap = true 1`] 
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -16677,20 +17445,31 @@ exports[`DataTable::columns should render correctly when column.wrap = true 1`] 
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -16703,15 +17482,20 @@ exports[`DataTable::columns should render correctly when column.wrap = true 1`] 
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -16721,13 +17505,17 @@ exports[`DataTable::columns should render correctly when column.wrap = true 1`] 
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -16832,6 +17620,9 @@ exports[`DataTable::columns should render correctly when ignoreRowClick = true 1
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -17061,6 +17852,7 @@ exports[`DataTable::columns should render correctly when ignoreRowClick = true 1
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -17081,20 +17873,31 @@ exports[`DataTable::columns should render correctly when ignoreRowClick = true 1
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -17107,14 +17910,19 @@ exports[`DataTable::columns should render correctly when ignoreRowClick = true 1
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div>
               Apple
@@ -17122,12 +17930,16 @@ exports[`DataTable::columns should render correctly when ignoreRowClick = true 1
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div>
               Zuchinni
@@ -17230,6 +18042,9 @@ exports[`DataTable::columns should render correctly with columns/data 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -17459,6 +18274,7 @@ exports[`DataTable::columns should render correctly with columns/data 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -17479,20 +18295,31 @@ exports[`DataTable::columns should render correctly with columns/data 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -17505,15 +18332,20 @@ exports[`DataTable::columns should render correctly with columns/data 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -17523,13 +18355,17 @@ exports[`DataTable::columns should render correctly with columns/data 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -17679,6 +18515,9 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -17908,6 +18747,7 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -17928,20 +18768,31 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -17954,15 +18805,20 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -17972,13 +18828,17 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -18083,6 +18943,9 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -18312,6 +19175,7 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -18332,20 +19196,31 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -18358,15 +19233,20 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -18376,13 +19256,17 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -18487,6 +19371,9 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -18716,6 +19603,7 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -18736,20 +19624,31 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -18762,15 +19661,20 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -18780,13 +19684,17 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -18891,6 +19799,9 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -18916,6 +19827,9 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -19151,6 +20065,7 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -19171,20 +20086,31 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -19197,15 +20123,20 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -19215,13 +20146,17 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c15 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -19326,6 +20261,9 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -19555,6 +20493,7 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -19575,20 +20514,31 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -19601,15 +20551,20 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -19619,13 +20574,17 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -19730,6 +20689,9 @@ exports[`DataTable::dense should render correctly when dense 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -19959,6 +20921,7 @@ exports[`DataTable::dense should render correctly when dense 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -19979,20 +20942,31 @@ exports[`DataTable::dense should render correctly when dense 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -20005,15 +20979,20 @@ exports[`DataTable::dense should render correctly when dense 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -20023,13 +21002,17 @@ exports[`DataTable::dense should render correctly when dense 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -20101,7 +21084,7 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   padding-right: calc(48px / 6);
 }
 
-.c17 {
+.c18 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -20131,21 +21114,21 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   font-weight: 400;
 }
 
-.c17:first-of-type {
+.c18:first-of-type {
   padding-left: calc(48px / 2);
 }
 
-.c17:last-child {
+.c18:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c17 div:first-child {
+.c18 div:first-child {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c17 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -20160,15 +21143,15 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   color: rgba(0,0,0,.54);
 }
 
-.c16:disabled {
+.c17:disabled {
   color: rgba(0,0,0,.12);
 }
 
-.c16:hover:enabled {
+.c17:hover:enabled {
   cursor: pointer;
 }
 
-.c15 {
+.c16 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -20191,22 +21174,28 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   color: rgba(0,0,0,.87);
 }
 
-.c15:not(:first-of-type) {
+.c16:not(:first-of-type) {
   padding-left: 0;
 }
 
-.c18 {
+.c19 {
+  -webkit-flex: 0 0 100%;
+  -ms-flex: 0 0 100%;
+  flex: 0 0 100%;
   width: 100%;
   box-sizing: border-box;
   color: rgba(0,0,0,.87);
   background-color: transparent;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -20221,17 +21210,17 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   color: rgba(0,0,0,.87);
 }
 
-.c14:not(:first-child) {
+.c15:not(:first-child) {
   border-top-style: solid;
   border-top-width: 1px;
   border-top-color: rgba(0,0,0,.12);
 }
 
-.c14:hover {
+.c15:hover {
   cursor: pointer;
 }
 
-.c11 {
+.c12 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -20259,15 +21248,15 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   min-width: 100px;
 }
 
-.c11:first-of-type {
+.c12:first-of-type {
   padding-left: calc(48px / 2);
 }
 
-.c11:last-child {
+.c12:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c12 {
+.c13 {
   color: rgba(0,0,0,.54);
   font-size: 12px;
   font-weight: 500;
@@ -20287,8 +21276,8 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   user-select: none;
 }
 
-.c12 span.__rdt_custom_sort_icon__ i,
-.c12 span.__rdt_custom_sort_icon__ svg {
+.c13 span.__rdt_custom_sort_icon__ i,
+.c13 span.__rdt_custom_sort_icon__ svg {
   opacity: 0;
   color: inherit;
   font-size: 18px !important;
@@ -20306,8 +21295,8 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   transition-property: transform;
 }
 
-.c12 span.__rdt_custom_sort_icon__.asc i,
-.c12 span.__rdt_custom_sort_icon__.asc svg {
+.c13 span.__rdt_custom_sort_icon__.asc i,
+.c13 span.__rdt_custom_sort_icon__.asc svg {
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
@@ -20412,7 +21401,7 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   margin-left: 5px;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20435,11 +21424,25 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   height: 100%;
 }
 
+.c11 {
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 10px;
+  position: absolute;
+}
+
 <div
   class="c0"
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -20460,24 +21463,43 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
     class="c6"
   >
     <div
+      aria-colcount="3"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c10"
+            role="columnheader"
             style="flex: 0 0 56px;"
-          />
+          >
+            <span
+              class="c11"
+            >
+              Toggle Expanded Details
+            </span>
+          </div>
           <div
-            class="c11 rdt_TableCol"
+            class="c12 rdt_TableCol"
+            role="columnheader"
           >
             <div
-              class="c12 rdt_TableCol_Sortable"
-              id="column-some.name"
+              class="c13 rdt_TableCol_Sortable"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -20485,21 +21507,34 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
               </div>
             </div>
           </div>
+          <span
+            aria-colindex="3"
+            class="c11"
+            role="columnheader"
+          >
+            Expanded Details
+          </span>
         </div>
       </div>
       <div
-        class="c13 rdt_TableBody"
+        class="c14 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
-          class="c14 rdt_TableRow"
-          id="row-1"
+          aria-rowindex="2"
+          class="c15 rdt_TableRow"
+          id="dt-row-1"
+          role="row"
         >
           <div
-            class="c15"
+            aria-colindex="1"
+            class="c16"
+            id="dt-expander-1"
+            role="cell"
           >
             <button
-              class="c16"
+              class="c17"
               data-testid="expander-button-1"
               role="button"
             >
@@ -20521,9 +21556,11 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
             </button>
           </div>
           <div
-            class="c17 rdt_TableCell"
+            aria-colindex="2"
+            class="c18 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -20531,25 +21568,32 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
               Apple
             </div>
           </div>
-        </div>
-        <div
-          class="c18 rdt_ExpanderRow"
-        >
           <div
-            data="[object Object]"
+            aria-colindex="3"
+            class="c19 rdt_ExpanderRow"
+            id="dt-expanded-content-1"
           >
-            Add a custom expander component. Use props.data for row data
+            <div
+              data="[object Object]"
+            >
+              Add a custom expander component. Use props.data for row data
+            </div>
           </div>
         </div>
         <div
-          class="c14 rdt_TableRow"
-          id="row-2"
+          aria-rowindex="3"
+          class="c15 rdt_TableRow"
+          id="dt-row-2"
+          role="row"
         >
           <div
-            class="c15"
+            aria-colindex="1"
+            class="c16"
+            id="dt-expander-2"
+            role="cell"
           >
             <button
-              class="c16"
+              class="c17"
               data-testid="expander-button-2"
               role="button"
             >
@@ -20571,9 +21615,11 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
             </button>
           </div>
           <div
-            class="c17 rdt_TableCell"
+            aria-colindex="2"
+            class="c18 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -20645,7 +21691,7 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   padding-right: calc(48px / 6);
 }
 
-.c17 {
+.c18 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -20675,21 +21721,21 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   font-weight: 400;
 }
 
-.c17:first-of-type {
+.c18:first-of-type {
   padding-left: calc(48px / 2);
 }
 
-.c17:last-child {
+.c18:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c17 div:first-child {
+.c18 div:first-child {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c17 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -20704,15 +21750,15 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   color: rgba(0,0,0,.54);
 }
 
-.c16:disabled {
+.c17:disabled {
   color: rgba(0,0,0,.12);
 }
 
-.c16:hover:enabled {
+.c17:hover:enabled {
   cursor: pointer;
 }
 
-.c15 {
+.c16 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -20735,22 +21781,28 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   color: rgba(0,0,0,.87);
 }
 
-.c15:not(:first-of-type) {
+.c16:not(:first-of-type) {
   padding-left: 0;
 }
 
-.c18 {
+.c19 {
+  -webkit-flex: 0 0 100%;
+  -ms-flex: 0 0 100%;
+  flex: 0 0 100%;
   width: 100%;
   box-sizing: border-box;
   color: rgba(0,0,0,.87);
   background-color: transparent;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -20765,17 +21817,17 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   color: rgba(0,0,0,.87);
 }
 
-.c14:not(:first-child) {
+.c15:not(:first-child) {
   border-top-style: solid;
   border-top-width: 1px;
   border-top-color: rgba(0,0,0,.12);
 }
 
-.c14:hover {
+.c15:hover {
   cursor: pointer;
 }
 
-.c11 {
+.c12 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -20803,15 +21855,15 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   min-width: 100px;
 }
 
-.c11:first-of-type {
+.c12:first-of-type {
   padding-left: calc(48px / 2);
 }
 
-.c11:last-child {
+.c12:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c12 {
+.c13 {
   color: rgba(0,0,0,.54);
   font-size: 12px;
   font-weight: 500;
@@ -20831,8 +21883,8 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   user-select: none;
 }
 
-.c12 span.__rdt_custom_sort_icon__ i,
-.c12 span.__rdt_custom_sort_icon__ svg {
+.c13 span.__rdt_custom_sort_icon__ i,
+.c13 span.__rdt_custom_sort_icon__ svg {
   opacity: 0;
   color: inherit;
   font-size: 18px !important;
@@ -20850,8 +21902,8 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   transition-property: transform;
 }
 
-.c12 span.__rdt_custom_sort_icon__.asc i,
-.c12 span.__rdt_custom_sort_icon__.asc svg {
+.c13 span.__rdt_custom_sort_icon__.asc i,
+.c13 span.__rdt_custom_sort_icon__.asc svg {
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
@@ -20956,7 +22008,7 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   margin-left: 5px;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20979,11 +22031,25 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   height: 100%;
 }
 
+.c11 {
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 10px;
+  position: absolute;
+}
+
 <div
   class="c0"
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -21004,24 +22070,43 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
     class="c6"
   >
     <div
+      aria-colcount="3"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c10"
+            role="columnheader"
             style="flex: 0 0 56px;"
-          />
+          >
+            <span
+              class="c11"
+            >
+              Toggle Expanded Details
+            </span>
+          </div>
           <div
-            class="c11 rdt_TableCol"
+            class="c12 rdt_TableCol"
+            role="columnheader"
           >
             <div
-              class="c12 rdt_TableCol_Sortable"
-              id="column-some.name"
+              class="c13 rdt_TableCol_Sortable"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -21029,21 +22114,34 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
               </div>
             </div>
           </div>
+          <span
+            aria-colindex="3"
+            class="c11"
+            role="columnheader"
+          >
+            Expanded Details
+          </span>
         </div>
       </div>
       <div
-        class="c13 rdt_TableBody"
+        class="c14 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
-          class="c14 rdt_TableRow"
-          id="row-1"
+          aria-rowindex="2"
+          class="c15 rdt_TableRow"
+          id="dt-row-1"
+          role="row"
         >
           <div
-            class="c15"
+            aria-colindex="1"
+            class="c16"
+            id="dt-expander-1"
+            role="cell"
           >
             <button
-              class="c16"
+              class="c17"
               data-testid="expander-button-1"
               role="button"
             >
@@ -21065,9 +22163,11 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
             </button>
           </div>
           <div
-            class="c17 rdt_TableCell"
+            aria-colindex="2"
+            class="c18 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -21075,25 +22175,32 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
               Apple
             </div>
           </div>
-        </div>
-        <div
-          class="c18 rdt_ExpanderRow"
-        >
           <div
-            data="[object Object]"
+            aria-colindex="3"
+            class="c19 rdt_ExpanderRow"
+            id="dt-expanded-content-1"
           >
-            Add a custom expander component. Use props.data for row data
+            <div
+              data="[object Object]"
+            >
+              Add a custom expander component. Use props.data for row data
+            </div>
           </div>
         </div>
         <div
-          class="c14 rdt_TableRow"
-          id="row-2"
+          aria-rowindex="3"
+          class="c15 rdt_TableRow"
+          id="dt-row-2"
+          role="row"
         >
           <div
-            class="c15"
+            aria-colindex="1"
+            class="c16"
+            id="dt-expander-2"
+            role="cell"
           >
             <button
-              class="c16"
+              class="c17"
               data-testid="expander-button-2"
               role="button"
             >
@@ -21115,9 +22222,11 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
             </button>
           </div>
           <div
-            class="c17 rdt_TableCell"
+            aria-colindex="2"
+            class="c18 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -21189,7 +22298,7 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
   padding-right: calc(48px / 6);
 }
 
-.c17 {
+.c18 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -21219,21 +22328,21 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
   font-weight: 400;
 }
 
-.c17:first-of-type {
+.c18:first-of-type {
   padding-left: calc(48px / 2);
 }
 
-.c17:last-child {
+.c18:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c17 div:first-child {
+.c18 div:first-child {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c17 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -21248,15 +22357,15 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
   color: rgba(0,0,0,.54);
 }
 
-.c16:disabled {
+.c17:disabled {
   color: rgba(0,0,0,.12);
 }
 
-.c16:hover:enabled {
+.c17:hover:enabled {
   cursor: pointer;
 }
 
-.c15 {
+.c16 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -21279,15 +22388,18 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
   color: rgba(0,0,0,.87);
 }
 
-.c15:not(:first-of-type) {
+.c16:not(:first-of-type) {
   padding-left: 0;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -21302,17 +22414,20 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
   color: rgba(0,0,0,.87);
 }
 
-.c14:not(:first-child) {
+.c15:not(:first-child) {
   border-top-style: solid;
   border-top-width: 1px;
   border-top-color: rgba(0,0,0,.12);
 }
 
-.c18 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -21327,17 +22442,17 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
   color: rgba(0,0,0,.87);
 }
 
-.c18:not(:first-child) {
+.c19:not(:first-child) {
   border-top-style: solid;
   border-top-width: 1px;
   border-top-color: rgba(0,0,0,.12);
 }
 
-.c18:hover {
+.c19:hover {
   cursor: pointer;
 }
 
-.c11 {
+.c12 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -21365,15 +22480,15 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
   min-width: 100px;
 }
 
-.c11:first-of-type {
+.c12:first-of-type {
   padding-left: calc(48px / 2);
 }
 
-.c11:last-child {
+.c12:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c12 {
+.c13 {
   color: rgba(0,0,0,.54);
   font-size: 12px;
   font-weight: 500;
@@ -21393,8 +22508,8 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
   user-select: none;
 }
 
-.c12 span.__rdt_custom_sort_icon__ i,
-.c12 span.__rdt_custom_sort_icon__ svg {
+.c13 span.__rdt_custom_sort_icon__ i,
+.c13 span.__rdt_custom_sort_icon__ svg {
   opacity: 0;
   color: inherit;
   font-size: 18px !important;
@@ -21412,8 +22527,8 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
   transition-property: transform;
 }
 
-.c12 span.__rdt_custom_sort_icon__.asc i,
-.c12 span.__rdt_custom_sort_icon__.asc svg {
+.c13 span.__rdt_custom_sort_icon__.asc i,
+.c13 span.__rdt_custom_sort_icon__.asc svg {
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
@@ -21518,7 +22633,7 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
   margin-left: 5px;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -21541,11 +22656,25 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
   height: 100%;
 }
 
+.c11 {
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 10px;
+  position: absolute;
+}
+
 <div
   class="c0"
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -21566,24 +22695,43 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
     class="c6"
   >
     <div
+      aria-colcount="3"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c10"
+            role="columnheader"
             style="flex: 0 0 56px;"
-          />
+          >
+            <span
+              class="c11"
+            >
+              Toggle Expanded Details
+            </span>
+          </div>
           <div
-            class="c11 rdt_TableCol"
+            class="c12 rdt_TableCol"
+            role="columnheader"
           >
             <div
-              class="c12 rdt_TableCol_Sortable"
-              id="column-some.name"
+              class="c13 rdt_TableCol_Sortable"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -21591,21 +22739,34 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
               </div>
             </div>
           </div>
+          <span
+            aria-colindex="3"
+            class="c11"
+            role="columnheader"
+          >
+            Expanded Details
+          </span>
         </div>
       </div>
       <div
-        class="c13 rdt_TableBody"
+        class="c14 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
-          class="c14 rdt_TableRow"
-          id="row-1"
+          aria-rowindex="2"
+          class="c15 rdt_TableRow"
+          id="dt-row-1"
+          role="row"
         >
           <div
-            class="c15"
+            aria-colindex="1"
+            class="c16"
+            id="dt-expander-1"
+            role="cell"
           >
             <button
-              class="c16"
+              class="c17"
               data-testid="expander-button-1"
               disabled=""
               role="button"
@@ -21628,9 +22789,11 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
             </button>
           </div>
           <div
-            class="c17 rdt_TableCell"
+            aria-colindex="2"
+            class="c18 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -21640,14 +22803,19 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
           </div>
         </div>
         <div
-          class="c18 rdt_TableRow"
-          id="row-2"
+          aria-rowindex="3"
+          class="c19 rdt_TableRow"
+          id="dt-row-2"
+          role="row"
         >
           <div
-            class="c15"
+            aria-colindex="1"
+            class="c16"
+            id="dt-expander-2"
+            role="cell"
           >
             <button
-              class="c16"
+              class="c17"
               data-testid="expander-button-2"
               role="button"
             >
@@ -21669,9 +22837,11 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
             </button>
           </div>
           <div
-            class="c17 rdt_TableCell"
+            aria-colindex="2"
+            class="c18 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -21776,6 +22946,9 @@ exports[`DataTable::expandableRows should not render expandableRows expandableRo
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -22005,6 +23178,7 @@ exports[`DataTable::expandableRows should not render expandableRows expandableRo
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -22025,20 +23199,31 @@ exports[`DataTable::expandableRows should not render expandableRows expandableRo
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -22051,15 +23236,20 @@ exports[`DataTable::expandableRows should not render expandableRows expandableRo
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -22069,13 +23259,17 @@ exports[`DataTable::expandableRows should not render expandableRows expandableRo
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -22147,7 +23341,7 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
   padding-right: calc(48px / 6);
 }
 
-.c17 {
+.c18 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -22177,21 +23371,21 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
   font-weight: 400;
 }
 
-.c17:first-of-type {
+.c18:first-of-type {
   padding-left: calc(48px / 2);
 }
 
-.c17:last-child {
+.c18:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c17 div:first-child {
+.c18 div:first-child {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c17 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -22206,15 +23400,15 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
   color: rgba(0,0,0,.54);
 }
 
-.c16:disabled {
+.c17:disabled {
   color: rgba(0,0,0,.12);
 }
 
-.c16:hover:enabled {
+.c17:hover:enabled {
   cursor: pointer;
 }
 
-.c15 {
+.c16 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -22237,22 +23431,28 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
   color: rgba(0,0,0,.87);
 }
 
-.c15:not(:first-of-type) {
+.c16:not(:first-of-type) {
   padding-left: 0;
 }
 
-.c18 {
+.c19 {
+  -webkit-flex: 0 0 100%;
+  -ms-flex: 0 0 100%;
+  flex: 0 0 100%;
   width: 100%;
   box-sizing: border-box;
   color: rgba(0,0,0,.87);
   background-color: transparent;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -22267,13 +23467,13 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
   color: rgba(0,0,0,.87);
 }
 
-.c14:not(:first-child) {
+.c15:not(:first-child) {
   border-top-style: solid;
   border-top-width: 1px;
   border-top-color: rgba(0,0,0,.12);
 }
 
-.c11 {
+.c12 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -22301,15 +23501,15 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
   min-width: 100px;
 }
 
-.c11:first-of-type {
+.c12:first-of-type {
   padding-left: calc(48px / 2);
 }
 
-.c11:last-child {
+.c12:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c12 {
+.c13 {
   color: rgba(0,0,0,.54);
   font-size: 12px;
   font-weight: 500;
@@ -22329,8 +23529,8 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
   user-select: none;
 }
 
-.c12 span.__rdt_custom_sort_icon__ i,
-.c12 span.__rdt_custom_sort_icon__ svg {
+.c13 span.__rdt_custom_sort_icon__ i,
+.c13 span.__rdt_custom_sort_icon__ svg {
   opacity: 0;
   color: inherit;
   font-size: 18px !important;
@@ -22348,8 +23548,8 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
   transition-property: transform;
 }
 
-.c12 span.__rdt_custom_sort_icon__.asc i,
-.c12 span.__rdt_custom_sort_icon__.asc svg {
+.c13 span.__rdt_custom_sort_icon__.asc i,
+.c13 span.__rdt_custom_sort_icon__.asc svg {
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
@@ -22454,7 +23654,7 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
   margin-left: 5px;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -22477,11 +23677,25 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
   height: 100%;
 }
 
+.c11 {
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 10px;
+  position: absolute;
+}
+
 <div
   class="c0"
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -22502,24 +23716,43 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
     class="c6"
   >
     <div
+      aria-colcount="3"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c10"
+            role="columnheader"
             style="flex: 0 0 56px;"
-          />
+          >
+            <span
+              class="c11"
+            >
+              Toggle Expanded Details
+            </span>
+          </div>
           <div
-            class="c11 rdt_TableCol"
+            class="c12 rdt_TableCol"
+            role="columnheader"
           >
             <div
-              class="c12 rdt_TableCol_Sortable"
-              id="column-some.name"
+              class="c13 rdt_TableCol_Sortable"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -22527,21 +23760,34 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
               </div>
             </div>
           </div>
+          <span
+            aria-colindex="3"
+            class="c11"
+            role="columnheader"
+          >
+            Expanded Details
+          </span>
         </div>
       </div>
       <div
-        class="c13 rdt_TableBody"
+        class="c14 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
-          class="c14 rdt_TableRow"
-          id="row-1"
+          aria-rowindex="2"
+          class="c15 rdt_TableRow"
+          id="dt-row-1"
+          role="row"
         >
           <div
-            class="c15"
+            aria-colindex="1"
+            class="c16"
+            id="dt-expander-1"
+            role="cell"
           >
             <button
-              class="c16"
+              class="c17"
               data-testid="expander-button-1"
               role="button"
             >
@@ -22563,9 +23809,11 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
             </button>
           </div>
           <div
-            class="c17 rdt_TableCell"
+            aria-colindex="2"
+            class="c18 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -22573,25 +23821,32 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
               Apple
             </div>
           </div>
-        </div>
-        <div
-          class="c18 rdt_ExpanderRow"
-        >
           <div
-            data="[object Object]"
+            aria-colindex="3"
+            class="c19 rdt_ExpanderRow"
+            id="dt-expanded-content-1"
           >
-            Add a custom expander component. Use props.data for row data
+            <div
+              data="[object Object]"
+            >
+              Add a custom expander component. Use props.data for row data
+            </div>
           </div>
         </div>
         <div
-          class="c14 rdt_TableRow"
-          id="row-2"
+          aria-rowindex="3"
+          class="c15 rdt_TableRow"
+          id="dt-row-2"
+          role="row"
         >
           <div
-            class="c15"
+            aria-colindex="1"
+            class="c16"
+            id="dt-expander-2"
+            role="cell"
           >
             <button
-              class="c16"
+              class="c17"
               data-testid="expander-button-2"
               role="button"
             >
@@ -22613,9 +23868,11 @@ exports[`DataTable::expandableRows should render correctly when defaultExpandedF
             </button>
           </div>
           <div
-            class="c17 rdt_TableCell"
+            aria-colindex="2"
+            class="c18 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -22687,7 +23944,7 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   padding-right: calc(48px / 6);
 }
 
-.c17 {
+.c18 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -22717,21 +23974,21 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   font-weight: 400;
 }
 
-.c17:first-of-type {
+.c18:first-of-type {
   padding-left: calc(48px / 2);
 }
 
-.c17:last-child {
+.c18:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c17 div:first-child {
+.c18 div:first-child {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c17 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -22746,15 +24003,15 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   color: rgba(0,0,0,.54);
 }
 
-.c16:disabled {
+.c17:disabled {
   color: rgba(0,0,0,.12);
 }
 
-.c16:hover:enabled {
+.c17:hover:enabled {
   cursor: pointer;
 }
 
-.c15 {
+.c16 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -22777,15 +24034,18 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   color: rgba(0,0,0,.87);
 }
 
-.c15:not(:first-of-type) {
+.c16:not(:first-of-type) {
   padding-left: 0;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -22800,13 +24060,13 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   color: rgba(0,0,0,.87);
 }
 
-.c14:not(:first-child) {
+.c15:not(:first-child) {
   border-top-style: solid;
   border-top-width: 1px;
   border-top-color: rgba(0,0,0,.12);
 }
 
-.c11 {
+.c12 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -22834,15 +24094,15 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   min-width: 100px;
 }
 
-.c11:first-of-type {
+.c12:first-of-type {
   padding-left: calc(48px / 2);
 }
 
-.c11:last-child {
+.c12:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c12 {
+.c13 {
   color: rgba(0,0,0,.54);
   font-size: 12px;
   font-weight: 500;
@@ -22862,8 +24122,8 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   user-select: none;
 }
 
-.c12 span.__rdt_custom_sort_icon__ i,
-.c12 span.__rdt_custom_sort_icon__ svg {
+.c13 span.__rdt_custom_sort_icon__ i,
+.c13 span.__rdt_custom_sort_icon__ svg {
   opacity: 0;
   color: inherit;
   font-size: 18px !important;
@@ -22881,8 +24141,8 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   transition-property: transform;
 }
 
-.c12 span.__rdt_custom_sort_icon__.asc i,
-.c12 span.__rdt_custom_sort_icon__.asc svg {
+.c13 span.__rdt_custom_sort_icon__.asc i,
+.c13 span.__rdt_custom_sort_icon__.asc svg {
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
@@ -22987,7 +24247,7 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   margin-left: 5px;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -23010,11 +24270,25 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   height: 100%;
 }
 
+.c11 {
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 10px;
+  position: absolute;
+}
+
 <div
   class="c0"
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -23035,24 +24309,43 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
     class="c6"
   >
     <div
+      aria-colcount="3"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c10"
+            role="columnheader"
             style="flex: 0 0 56px;"
-          />
+          >
+            <span
+              class="c11"
+            >
+              Toggle Expanded Details
+            </span>
+          </div>
           <div
-            class="c11 rdt_TableCol"
+            class="c12 rdt_TableCol"
+            role="columnheader"
           >
             <div
-              class="c12 rdt_TableCol_Sortable"
-              id="column-some.name"
+              class="c13 rdt_TableCol_Sortable"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -23060,21 +24353,34 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
               </div>
             </div>
           </div>
+          <span
+            aria-colindex="3"
+            class="c11"
+            role="columnheader"
+          >
+            Expanded Details
+          </span>
         </div>
       </div>
       <div
-        class="c13 rdt_TableBody"
+        class="c14 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
-          class="c14 rdt_TableRow"
-          id="row-1"
+          aria-rowindex="2"
+          class="c15 rdt_TableRow"
+          id="dt-row-1"
+          role="row"
         >
           <div
-            class="c15"
+            aria-colindex="1"
+            class="c16"
+            id="dt-expander-1"
+            role="cell"
           >
             <button
-              class="c16"
+              class="c17"
               data-testid="expander-button-1"
               role="button"
             >
@@ -23096,9 +24402,11 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
             </button>
           </div>
           <div
-            class="c17 rdt_TableCell"
+            aria-colindex="2"
+            class="c18 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -23108,14 +24416,19 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
           </div>
         </div>
         <div
-          class="c14 rdt_TableRow"
-          id="row-2"
+          aria-rowindex="3"
+          class="c15 rdt_TableRow"
+          id="dt-row-2"
+          role="row"
         >
           <div
-            class="c15"
+            aria-colindex="1"
+            class="c16"
+            id="dt-expander-2"
+            role="cell"
           >
             <button
-              class="c16"
+              class="c17"
               data-testid="expander-button-2"
               role="button"
             >
@@ -23137,9 +24450,11 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
             </button>
           </div>
           <div
-            class="c17 rdt_TableCell"
+            aria-colindex="2"
+            class="c18 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -23211,7 +24526,7 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   padding-right: calc(48px / 6);
 }
 
-.c17 {
+.c18 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -23241,21 +24556,21 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   font-weight: 400;
 }
 
-.c17:first-of-type {
+.c18:first-of-type {
   padding-left: calc(48px / 2);
 }
 
-.c17:last-child {
+.c18:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c17 div:first-child {
+.c18 div:first-child {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c17 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -23270,15 +24585,15 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   color: rgba(0,0,0,.54);
 }
 
-.c16:disabled {
+.c17:disabled {
   color: rgba(0,0,0,.12);
 }
 
-.c16:hover:enabled {
+.c17:hover:enabled {
   cursor: pointer;
 }
 
-.c15 {
+.c16 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -23301,22 +24616,28 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   color: rgba(0,0,0,.87);
 }
 
-.c15:not(:first-of-type) {
+.c16:not(:first-of-type) {
   padding-left: 0;
 }
 
-.c18 {
+.c19 {
+  -webkit-flex: 0 0 100%;
+  -ms-flex: 0 0 100%;
+  flex: 0 0 100%;
   width: 100%;
   box-sizing: border-box;
   color: rgba(0,0,0,.87);
   background-color: transparent;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -23331,13 +24652,13 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   color: rgba(0,0,0,.87);
 }
 
-.c14:not(:first-child) {
+.c15:not(:first-child) {
   border-top-style: solid;
   border-top-width: 1px;
   border-top-color: rgba(0,0,0,.12);
 }
 
-.c11 {
+.c12 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -23365,15 +24686,15 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   min-width: 100px;
 }
 
-.c11:first-of-type {
+.c12:first-of-type {
   padding-left: calc(48px / 2);
 }
 
-.c11:last-child {
+.c12:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c12 {
+.c13 {
   color: rgba(0,0,0,.54);
   font-size: 12px;
   font-weight: 500;
@@ -23393,8 +24714,8 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   user-select: none;
 }
 
-.c12 span.__rdt_custom_sort_icon__ i,
-.c12 span.__rdt_custom_sort_icon__ svg {
+.c13 span.__rdt_custom_sort_icon__ i,
+.c13 span.__rdt_custom_sort_icon__ svg {
   opacity: 0;
   color: inherit;
   font-size: 18px !important;
@@ -23412,8 +24733,8 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   transition-property: transform;
 }
 
-.c12 span.__rdt_custom_sort_icon__.asc i,
-.c12 span.__rdt_custom_sort_icon__.asc svg {
+.c13 span.__rdt_custom_sort_icon__.asc i,
+.c13 span.__rdt_custom_sort_icon__.asc svg {
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
@@ -23518,7 +24839,7 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   margin-left: 5px;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -23541,11 +24862,25 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   height: 100%;
 }
 
+.c11 {
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 10px;
+  position: absolute;
+}
+
 <div
   class="c0"
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -23566,24 +24901,43 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
     class="c6"
   >
     <div
+      aria-colcount="3"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c10"
+            role="columnheader"
             style="flex: 0 0 56px;"
-          />
+          >
+            <span
+              class="c11"
+            >
+              Toggle Expanded Details
+            </span>
+          </div>
           <div
-            class="c11 rdt_TableCol"
+            class="c12 rdt_TableCol"
+            role="columnheader"
           >
             <div
-              class="c12 rdt_TableCol_Sortable"
-              id="column-some.name"
+              class="c13 rdt_TableCol_Sortable"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -23591,21 +24945,34 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
               </div>
             </div>
           </div>
+          <span
+            aria-colindex="3"
+            class="c11"
+            role="columnheader"
+          >
+            Expanded Details
+          </span>
         </div>
       </div>
       <div
-        class="c13 rdt_TableBody"
+        class="c14 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
-          class="c14 rdt_TableRow"
-          id="row-1"
+          aria-rowindex="2"
+          class="c15 rdt_TableRow"
+          id="dt-row-1"
+          role="row"
         >
           <div
-            class="c15"
+            aria-colindex="1"
+            class="c16"
+            id="dt-expander-1"
+            role="cell"
           >
             <button
-              class="c16"
+              class="c17"
               data-testid="expander-button-1"
               role="button"
             >
@@ -23627,9 +24994,11 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
             </button>
           </div>
           <div
-            class="c17 rdt_TableCell"
+            aria-colindex="2"
+            class="c18 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -23637,25 +25006,32 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
               Apple
             </div>
           </div>
-        </div>
-        <div
-          class="c18 rdt_ExpanderRow"
-        >
           <div
-            data="[object Object]"
+            aria-colindex="3"
+            class="c19 rdt_ExpanderRow"
+            id="dt-expanded-content-1"
           >
-            Add a custom expander component. Use props.data for row data
+            <div
+              data="[object Object]"
+            >
+              Add a custom expander component. Use props.data for row data
+            </div>
           </div>
         </div>
         <div
-          class="c14 rdt_TableRow"
-          id="row-2"
+          aria-rowindex="3"
+          class="c15 rdt_TableRow"
+          id="dt-row-2"
+          role="row"
         >
           <div
-            class="c15"
+            aria-colindex="1"
+            class="c16"
+            id="dt-expander-2"
+            role="cell"
           >
             <button
-              class="c16"
+              class="c17"
               data-testid="expander-button-2"
               role="button"
             >
@@ -23677,9 +25053,11 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
             </button>
           </div>
           <div
-            class="c17 rdt_TableCell"
+            aria-colindex="2"
+            class="c18 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -23784,6 +25162,9 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -24016,6 +25397,7 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -24036,20 +25418,31 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -24062,15 +25455,20 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -24080,13 +25478,17 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -24191,6 +25593,9 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader and fix
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -24423,6 +25828,7 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader and fix
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -24443,20 +25849,31 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader and fix
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -24469,15 +25886,20 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader and fix
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -24487,13 +25909,17 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader and fix
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -24598,6 +26024,9 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -24832,6 +26261,7 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -24852,20 +26282,31 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -24878,15 +26319,20 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -24896,13 +26342,17 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -25007,6 +26457,9 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -25241,6 +26694,7 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -25261,20 +26715,31 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -25287,15 +26752,20 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -25305,13 +26775,17 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader with an
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -25416,6 +26890,9 @@ exports[`DataTable::highlightOnHover should render correctly when highlightOnHov
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -25654,6 +27131,7 @@ exports[`DataTable::highlightOnHover should render correctly when highlightOnHov
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -25674,20 +27152,31 @@ exports[`DataTable::highlightOnHover should render correctly when highlightOnHov
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -25700,15 +27189,20 @@ exports[`DataTable::highlightOnHover should render correctly when highlightOnHov
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -25718,13 +27212,17 @@ exports[`DataTable::highlightOnHover should render correctly when highlightOnHov
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -25829,6 +27327,9 @@ exports[`DataTable::pointerOnHover should render correctly when pointerOnHover 1
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -26062,6 +27563,7 @@ exports[`DataTable::pointerOnHover should render correctly when pointerOnHover 1
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -26082,20 +27584,31 @@ exports[`DataTable::pointerOnHover should render correctly when pointerOnHover 1
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -26108,15 +27621,20 @@ exports[`DataTable::pointerOnHover should render correctly when pointerOnHover 1
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -26126,13 +27644,17 @@ exports[`DataTable::pointerOnHover should render correctly when pointerOnHover 1
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -26300,6 +27822,7 @@ exports[`DataTable::progress/nodata should only show Loading if progressPending 
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -26329,7 +27852,12 @@ exports[`DataTable::progress/nodata should only show Loading if progressPending 
       </div>
     </div>
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c8 rdt_Table"
+      id="dt"
+      role="table"
     />
   </div>
 </div>
@@ -26488,6 +28016,7 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -26515,7 +28044,12 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
       </div>
     </div>
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c8 rdt_Table"
+      id="dt"
+      role="table"
     />
   </div>
 </div>
@@ -26674,6 +28208,7 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -26699,7 +28234,12 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
       A Component that is passed in
     </div>
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c8 rdt_Table"
+      id="dt"
+      role="table"
     />
   </div>
 </div>
@@ -26857,6 +28397,7 @@ exports[`DataTable::progress/nodata should render correctly when progressPending
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -26877,7 +28418,12 @@ exports[`DataTable::progress/nodata should render correctly when progressPending
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="-1"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8"
@@ -27042,6 +28588,7 @@ exports[`DataTable::progress/nodata should render correctly when progressPending
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -27071,7 +28618,12 @@ exports[`DataTable::progress/nodata should render correctly when progressPending
       </div>
     </div>
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c8 rdt_Table"
+      id="dt"
+      role="table"
     />
   </div>
 </div>
@@ -27230,6 +28782,7 @@ exports[`DataTable::progress/nodata when noTableHead should only Loading if prog
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -27250,7 +28803,12 @@ exports[`DataTable::progress/nodata when noTableHead should only Loading if prog
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8"
@@ -27526,6 +29084,7 @@ exports[`DataTable::progress/nodata when persistTableHead should disable TableHe
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -27546,21 +29105,32 @@ exports[`DataTable::progress/nodata when persistTableHead should disable TableHe
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="-1"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
           disabled=""
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -27841,6 +29411,7 @@ exports[`DataTable::progress/nodata when persistTableHead should disable TableHe
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -27861,21 +29432,32 @@ exports[`DataTable::progress/nodata when persistTableHead should disable TableHe
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="1"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
           disabled=""
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -28160,6 +29742,7 @@ exports[`DataTable::progress/nodata when persistTableHead should only Loading an
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -28180,21 +29763,32 @@ exports[`DataTable::progress/nodata when persistTableHead should only Loading an
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
           disabled=""
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -28308,6 +29902,9 @@ exports[`DataTable::responsive should not apply overFlowY without an overflowYOf
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -28539,6 +30136,7 @@ exports[`DataTable::responsive should not apply overFlowY without an overflowYOf
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -28559,20 +30157,31 @@ exports[`DataTable::responsive should not apply overFlowY without an overflowYOf
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -28585,15 +30194,20 @@ exports[`DataTable::responsive should not apply overFlowY without an overflowYOf
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -28603,13 +30217,17 @@ exports[`DataTable::responsive should not apply overFlowY without an overflowYOf
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -28714,6 +30332,9 @@ exports[`DataTable::responsive should render correctly responsive by default 1`]
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -28943,6 +30564,7 @@ exports[`DataTable::responsive should render correctly responsive by default 1`]
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -28963,20 +30585,31 @@ exports[`DataTable::responsive should render correctly responsive by default 1`]
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -28989,15 +30622,20 @@ exports[`DataTable::responsive should render correctly responsive by default 1`]
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -29007,13 +30645,17 @@ exports[`DataTable::responsive should render correctly responsive by default 1`]
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -29118,6 +30760,9 @@ exports[`DataTable::responsive should render correctly when responsive=false 1`]
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -29346,6 +30991,7 @@ exports[`DataTable::responsive should render correctly when responsive=false 1`]
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -29366,20 +31012,31 @@ exports[`DataTable::responsive should render correctly when responsive=false 1`]
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -29392,15 +31049,20 @@ exports[`DataTable::responsive should render correctly when responsive=false 1`]
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -29410,13 +31072,17 @@ exports[`DataTable::responsive should render correctly when responsive=false 1`]
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -29488,7 +31154,7 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
   padding-right: calc(48px / 6);
 }
 
-.c16 {
+.c17 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -29518,21 +31184,21 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
   font-weight: 400;
 }
 
-.c16:first-of-type {
+.c17:first-of-type {
   padding-left: calc(48px / 2);
 }
 
-.c16:last-child {
+.c17:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c16 div:first-child {
+.c17 div:first-child {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.c15 {
+.c16 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -29553,11 +31219,14 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
   color: rgba(0,0,0,.87);
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -29572,13 +31241,13 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
   color: rgba(0,0,0,.87);
 }
 
-.c14:not(:first-child) {
+.c15:not(:first-child) {
   border-top-style: solid;
   border-top-width: 1px;
   border-top-color: rgba(0,0,0,.12);
 }
 
-.c11 {
+.c12 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -29606,15 +31275,15 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
   min-width: 100px;
 }
 
-.c11:first-of-type {
+.c12:first-of-type {
   padding-left: calc(48px / 2);
 }
 
-.c11:last-child {
+.c12:last-child {
   padding-right: calc(48px / 2);
 }
 
-.c12 {
+.c13 {
   color: rgba(0,0,0,.54);
   font-size: 12px;
   font-weight: 500;
@@ -29634,8 +31303,8 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
   user-select: none;
 }
 
-.c12 span.__rdt_custom_sort_icon__ i,
-.c12 span.__rdt_custom_sort_icon__ svg {
+.c13 span.__rdt_custom_sort_icon__ i,
+.c13 span.__rdt_custom_sort_icon__ svg {
   opacity: 0;
   color: inherit;
   font-size: 18px !important;
@@ -29653,8 +31322,8 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
   transition-property: transform;
 }
 
-.c12 span.__rdt_custom_sort_icon__.asc i,
-.c12 span.__rdt_custom_sort_icon__.asc svg {
+.c13 span.__rdt_custom_sort_icon__.asc i,
+.c13 span.__rdt_custom_sort_icon__.asc svg {
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
@@ -29759,7 +31428,7 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
   margin-left: 5px;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -29782,11 +31451,25 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
   height: 100%;
 }
 
+.c11 {
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 10px;
+  position: absolute;
+}
+
 <div
   class="c0"
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -29807,24 +31490,43 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
     class="c6"
   >
     <div
+      aria-colcount="2"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c10"
+            role="columnheader"
             style="flex: 0 0 48px;"
-          />
+          >
+            <span
+              class="c11"
+            >
+              Row Selector
+            </span>
+          </div>
           <div
-            class="c11 rdt_TableCol"
+            class="c12 rdt_TableCol"
+            role="columnheader"
           >
             <div
-              class="c12 rdt_TableCol_Sortable"
-              id="column-some.name"
+              class="c13 rdt_TableCol_Sortable"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -29835,15 +31537,21 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
         </div>
       </div>
       <div
-        class="c13 rdt_TableBody"
+        class="c14 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
-          class="c14 rdt_TableRow"
-          id="row-1"
+          aria-rowindex="2"
+          class="c15 rdt_TableRow"
+          id="dt-row-1"
+          role="row"
         >
           <div
-            class="c15 rdt_TableCell"
+            aria-colindex="1"
+            class="c16 rdt_TableCell"
+            id="dt-selector-1"
+            role="cell"
           >
             <input
               aria-label="select-row-1"
@@ -29853,9 +31561,11 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
             />
           </div>
           <div
-            class="c16 rdt_TableCell"
+            aria-colindex="2"
+            class="c17 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -29865,11 +31575,16 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
           </div>
         </div>
         <div
-          class="c14 rdt_TableRow"
-          id="row-2"
+          aria-rowindex="3"
+          class="c15 rdt_TableRow"
+          id="dt-row-2"
+          role="row"
         >
           <div
-            class="c15 rdt_TableCell"
+            aria-colindex="1"
+            class="c16 rdt_TableCell"
+            id="dt-selector-2"
+            role="cell"
           >
             <input
               aria-label="select-row-2"
@@ -29879,9 +31594,11 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
             />
           </div>
           <div
-            class="c16 rdt_TableCell"
+            aria-colindex="2"
+            class="c17 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -30007,6 +31724,9 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -30262,6 +31982,7 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -30282,13 +32003,23 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
     class="c6"
   >
     <div
+      aria-colcount="2"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
@@ -30302,10 +32033,11 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
           </div>
           <div
             class="c11 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c12 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -30318,13 +32050,19 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
+            id="dt-selector-1"
+            role="cell"
           >
             <input
               aria-label="select-row-1"
@@ -30334,9 +32072,11 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
             />
           </div>
           <div
+            aria-colindex="2"
             class="c16 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -30346,11 +32086,16 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c14 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
+            id="dt-selector-2"
+            role="cell"
           >
             <input
               aria-label="select-row-2"
@@ -30360,9 +32105,11 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
             />
           </div>
           <div
+            aria-colindex="2"
             class="c16 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-2"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -30467,6 +32214,9 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -30715,6 +32465,7 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -30735,20 +32486,31 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -30766,15 +32528,20 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -30784,13 +32551,17 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c14 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -30895,6 +32666,9 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -31146,6 +32920,7 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -31166,20 +32941,31 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -31197,15 +32983,20 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -31215,13 +33006,17 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c14 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -31326,6 +33121,9 @@ exports[`DataTable::sorting should render correctly and not be sorted when a col
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -31555,6 +33353,7 @@ exports[`DataTable::sorting should render correctly and not be sorted when a col
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -31575,20 +33374,31 @@ exports[`DataTable::sorting should render correctly and not be sorted when a col
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -31601,15 +33411,20 @@ exports[`DataTable::sorting should render correctly and not be sorted when a col
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -31619,13 +33434,17 @@ exports[`DataTable::sorting should render correctly and not be sorted when a col
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -31730,6 +33549,9 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -31978,6 +33800,7 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -31998,20 +33821,31 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -32029,15 +33863,20 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -32047,13 +33886,17 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c14 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -32158,6 +34001,9 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -32406,6 +34252,7 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -32426,20 +34273,31 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -32457,15 +34315,20 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -32475,13 +34338,17 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c14 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -32586,6 +34453,9 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -32821,6 +34691,7 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -32841,20 +34712,31 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -32874,15 +34756,20 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -32892,13 +34779,17 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -33007,6 +34898,9 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon and c
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -33246,6 +35140,7 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon and c
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -33266,20 +35161,31 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon and c
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <span
@@ -33299,15 +35205,20 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon and c
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -33317,13 +35228,17 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon and c
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -33432,6 +35347,9 @@ exports[`DataTable::sorting should render correctly with a default sort field an
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -33684,6 +35602,7 @@ exports[`DataTable::sorting should render correctly with a default sort field an
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -33704,20 +35623,31 @@ exports[`DataTable::sorting should render correctly with a default sort field an
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <span
@@ -33735,15 +35665,20 @@ exports[`DataTable::sorting should render correctly with a default sort field an
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -33753,13 +35688,17 @@ exports[`DataTable::sorting should render correctly with a default sort field an
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c14 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -33864,6 +35803,9 @@ exports[`DataTable::sorting should render correctly with a default sort field an
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -34112,6 +36054,7 @@ exports[`DataTable::sorting should render correctly with a default sort field an
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -34132,20 +36075,31 @@ exports[`DataTable::sorting should render correctly with a default sort field an
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -34163,15 +36117,20 @@ exports[`DataTable::sorting should render correctly with a default sort field an
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -34181,13 +36140,17 @@ exports[`DataTable::sorting should render correctly with a default sort field an
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c14 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -34292,6 +36255,9 @@ exports[`DataTable::sorting should render correctly with a defaultSortAsc = fals
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -34543,6 +36509,7 @@ exports[`DataTable::sorting should render correctly with a defaultSortAsc = fals
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -34563,20 +36530,31 @@ exports[`DataTable::sorting should render correctly with a defaultSortAsc = fals
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -34594,15 +36572,20 @@ exports[`DataTable::sorting should render correctly with a defaultSortAsc = fals
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -34612,13 +36595,17 @@ exports[`DataTable::sorting should render correctly with a defaultSortAsc = fals
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -34723,6 +36710,9 @@ exports[`DataTable::striped should render correctly when striped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -34956,6 +36946,7 @@ exports[`DataTable::striped should render correctly when striped 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -34976,20 +36967,31 @@ exports[`DataTable::striped should render correctly when striped 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -35002,15 +37004,20 @@ exports[`DataTable::striped should render correctly when striped 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -35020,13 +37027,17 @@ exports[`DataTable::striped should render correctly when striped 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -35131,6 +37142,9 @@ exports[`DataTable::subHeader should render correctly when a subheader is enable
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -35386,6 +37400,7 @@ exports[`DataTable::subHeader should render correctly when a subheader is enable
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -35411,20 +37426,32 @@ exports[`DataTable::subHeader should render correctly when a subheader is enable
     class="c7"
   >
     <div
+      aria-colcount="1"
+      aria-describedby="dt-subheader"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c8 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c9 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c10 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c11 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c12 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -35437,15 +37464,20 @@ exports[`DataTable::subHeader should render correctly when a subheader is enable
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -35455,13 +37487,17 @@ exports[`DataTable::subHeader should render correctly when a subheader is enable
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c14 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -35566,6 +37602,9 @@ exports[`DataTable::subHeader should render correctly with center align 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -35821,6 +37860,7 @@ exports[`DataTable::subHeader should render correctly with center align 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -35846,20 +37886,32 @@ exports[`DataTable::subHeader should render correctly with center align 1`] = `
     class="c7"
   >
     <div
+      aria-colcount="1"
+      aria-describedby="dt-subheader"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c8 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c9 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c10 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c11 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c12 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -35872,15 +37924,20 @@ exports[`DataTable::subHeader should render correctly with center align 1`] = `
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -35890,13 +37947,17 @@ exports[`DataTable::subHeader should render correctly with center align 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c14 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -36001,6 +38062,9 @@ exports[`DataTable::subHeader should render correctly with left align 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -36256,6 +38320,7 @@ exports[`DataTable::subHeader should render correctly with left align 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -36281,20 +38346,32 @@ exports[`DataTable::subHeader should render correctly with left align 1`] = `
     class="c7"
   >
     <div
+      aria-colcount="1"
+      aria-describedby="dt-subheader"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c8 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c9 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c10 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c11 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c12 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -36307,15 +38384,20 @@ exports[`DataTable::subHeader should render correctly with left align 1`] = `
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -36325,13 +38407,17 @@ exports[`DataTable::subHeader should render correctly with left align 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c14 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -36436,6 +38522,9 @@ exports[`DataTable::subHeader should render correctly with right align 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -36691,6 +38780,7 @@ exports[`DataTable::subHeader should render correctly with right align 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -36716,20 +38806,32 @@ exports[`DataTable::subHeader should render correctly with right align 1`] = `
     class="c7"
   >
     <div
+      aria-colcount="1"
+      aria-describedby="dt-subheader"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c8 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c9 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c10 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c11 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c12 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -36742,15 +38844,20 @@ exports[`DataTable::subHeader should render correctly with right align 1`] = `
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -36760,13 +38867,17 @@ exports[`DataTable::subHeader should render correctly with right align 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c14 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -36871,6 +38982,9 @@ exports[`DataTable::subHeader should render when subHeaderWrap is false 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -37126,6 +39240,7 @@ exports[`DataTable::subHeader should render when subHeaderWrap is false 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -37151,20 +39266,32 @@ exports[`DataTable::subHeader should render when subHeaderWrap is false 1`] = `
     class="c7"
   >
     <div
+      aria-colcount="1"
+      aria-describedby="dt-subheader"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c8 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c9 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c10 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c11 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c12 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -37177,15 +39304,20 @@ exports[`DataTable::subHeader should render when subHeaderWrap is false 1`] = `
       <div
         class="c13 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c14 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -37195,13 +39327,17 @@ exports[`DataTable::subHeader should render when subHeaderWrap is false 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c14 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c15 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -37306,6 +39442,9 @@ exports[`data prop changes should update state if the data prop changes 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -37535,6 +39674,7 @@ exports[`data prop changes should update state if the data prop changes 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -37555,20 +39695,31 @@ exports[`data prop changes should update state if the data prop changes 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="2"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -37581,15 +39732,20 @@ exports[`data prop changes should update state if the data prop changes 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -37669,6 +39825,9 @@ exports[`should not show the TableHead when noTableHead is true 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -37816,6 +39975,7 @@ exports[`should not show the TableHead when noTableHead is true 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -37836,20 +39996,30 @@ exports[`should not show the TableHead when noTableHead is true 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c10 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -37859,13 +40029,17 @@ exports[`should not show the TableHead when noTableHead is true 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="2"
           class="c9 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c10 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -38032,6 +40206,7 @@ exports[`should render and empty table correctly 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -38052,7 +40227,12 @@ exports[`should render and empty table correctly 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="0"
+      aria-labelledby="dt-header"
+      aria-rowcount="-1"
       class="c7 rdt_Table"
+      id="dt"
+      role="table"
     >
       <div
         class="c8"
@@ -38156,6 +40336,9 @@ exports[`should render correctly when disabled 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -38385,6 +40568,7 @@ exports[`should render correctly when disabled 1`] = `
 >
   <header
     class="c1 rdt_TableHeader"
+    id="dt-header"
   >
     <div
       class="c2"
@@ -38405,21 +40589,32 @@ exports[`should render correctly when disabled 1`] = `
     class="c6"
   >
     <div
+      aria-colcount="1"
+      aria-labelledby="dt-header"
+      aria-rowcount="3"
       class="c7 rdt_Table"
       disabled=""
+      id="dt"
+      role="table"
     >
       <div
         class="c8 rdt_TableHead"
+        id="dt-thead"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="1"
           class="c9 rdt_TableHeadRow"
+          id="dt-thead-row"
+          role="row"
         >
           <div
             class="c10 rdt_TableCol"
+            role="columnheader"
           >
             <div
               class="c11 rdt_TableCol_Sortable"
-              id="column-some.name"
+              id="dt-column-some.name"
               role="button"
             >
               <div>
@@ -38432,15 +40627,20 @@ exports[`should render correctly when disabled 1`] = `
       <div
         class="c12 rdt_TableBody"
         offset="250px"
+        role="rowgroup"
       >
         <div
+          aria-rowindex="2"
           class="c13 rdt_TableRow"
-          id="row-1"
+          id="dt-row-1"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-1"
+            id="dt-cell-1-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"
@@ -38450,13 +40650,17 @@ exports[`should render correctly when disabled 1`] = `
           </div>
         </div>
         <div
+          aria-rowindex="3"
           class="c13 rdt_TableRow"
-          id="row-2"
+          id="dt-row-2"
+          role="row"
         >
           <div
+            aria-colindex="1"
             class="c14 rdt_TableCell"
             data-tag="___react-data-table-allow-propagation___"
-            id="cell-1-2"
+            id="dt-cell-2-1"
+            role="cell"
           >
             <div
               data-tag="___react-data-table-allow-propagation___"

--- a/src/test-helpers.js
+++ b/src/test-helpers.js
@@ -6,4 +6,3 @@ import theme from './themes/default';
 
 export const renderWithTheme = (tree, ...args) =>
   render(<ThemeProvider theme={theme()}>{tree}</ThemeProvider>, ...args);
-


### PR DESCRIPTION
 - Add unique id to all elements so multiple data tables can exists on the same page
 - Added better aria attribute support to help with a11y -- including  screen reader only labels for selector and expander headers.
 - Moved ExpanderRow into parent TableRow so it will semantically be considered a cell by screen readers.
- Updated tests to handle new id strategy.