### PR TITLE
fix(onRowExpandToggled): Make onRowExpandToggled prop optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,7 +59,7 @@ export interface IDataTableProps<T> {
   expandableRowsComponent?: React.ReactNode;
   expandOnRowClicked?: boolean;
   expandOnRowDoubleClicked?: boolean;
-  onRowExpandToggled: (expanded: boolean, row: T) => void;
+  onRowExpandToggled?: (expanded: boolean, row: T) => void;
   expandableRowExpanded?: (row: T) => boolean;
   expandableRowDisabled?: (row: T) => boolean;
   selectableRows?: boolean;


### PR DESCRIPTION
See: 8cb74a878f1a2f9cc9be4f34ee672c3d935a6dda

Not sure if it was intentional or not, but the `onRowExpandToggled` prop is currently not optional.

My IDE's TypeScript tooling is yelling at me to include it where I do not think I should have to.

This commit makes it's inclusion as a property optional.