### PR TITLE
add missing typing for expandableIcon

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -64,6 +64,7 @@ export interface IDataTableProps<T> {
   onRowExpandToggled?: (expanded: boolean, row: T) => void;
   expandableRowExpanded?: (row: T) => boolean;
   expandableRowDisabled?: (row: T) => boolean;
+  expandableIcon?: IExpandableIcon;
   selectableRows?: boolean;
   selectableRowSelected?: (row: T) => boolean;
   selectableRowDisabled?: (row: T) => boolean;
@@ -87,7 +88,7 @@ export interface IDataTableProps<T> {
 }
 
 export interface IDataTableColumn<T> {
-  name?: string;
+  name: string;
   selector: string | ((row: T) => React.ReactNode);
   sortable?: boolean;
   format?: (row: T) => React.ReactNode;
@@ -174,6 +175,11 @@ export interface IDataTablePaginationOptions {
   noRowsPerPage?: boolean;
   rowsPerPageText?: string;
   rangeSeparatorText?: string;
+}
+
+export interface IExpandableIcon {
+  collapsed: React.ReactNode;
+  expanded: React.ReactNode;
 }
 
 export interface IContextMessage<T> {


### PR DESCRIPTION
* fixed missing typing
* column.name will now be optional as intended
* fixes #410 