### PR TITLE
Apply row & column className to TableCell

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ root = true
 # Change these settings to your own preference
 indent_style = space
 indent_size = 2
+quote_type = single
 
 # We recommend you to keep these unchanged
 end_of_line = lf

--- a/src/DataTable/TableCell.js
+++ b/src/DataTable/TableCell.js
@@ -24,8 +24,19 @@ const TableCell = memo(({ id, column, row }) => {
   }
 
   // apply a tag that TableRow will use to stop event propagation when TableCell is clicked
-  const dataTag = column.ignoreRowClick || column.button ? null : '___react-data-table-allow-propagation___';
-  const extendedCellStyle = getConditionalStyle(row, column.conditionalCellStyles);
+  const dataTag =
+    column.ignoreRowClick || column.button
+      ? null
+      : '___react-data-table-allow-propagation___';
+  const extendedCellStyle = getConditionalStyle(
+    row,
+    column.conditionalCellStyles
+  );
+
+  // apply row & column className
+  let className = 'rdt_TableCell';
+  if (row.className) className += ' ' + row.className;
+  if (column.className) className += ' ' + column.className;
 
   return (
     <TableCellStyle
@@ -33,7 +44,7 @@ const TableCell = memo(({ id, column, row }) => {
       role="cell"
       column={column}
       data-tag={dataTag}
-      className="rdt_TableCell"
+      className={className}
       extendedCellStyle={extendedCellStyle}
     >
       {!column.cell && (
@@ -49,7 +60,7 @@ const TableCell = memo(({ id, column, row }) => {
 TableCell.propTypes = {
   id: PropTypes.string.isRequired,
   column: PropTypes.object.isRequired,
-  row: PropTypes.object.isRequired,
+  row: PropTypes.object.isRequired
 };
 
 export default TableCell;


### PR DESCRIPTION
I needed specific class attribute for some cells.

Now each [column definition](https://github.com/jbetancur/react-data-table-component#columns) can have a `className` attribute that will be passed to the TableCell.

PS: indentation diffs because of Prettier + .editorconfig to match quotes style