### PR TITLE
Updated Table component style

### DIFF
--- a/src/DataTable/Table.js
+++ b/src/DataTable/Table.js
@@ -11,7 +11,6 @@ const TableStyle = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
   max-width: 100%;
   ${props => props.disabled && disabled};
   ${props => props.theme.table.style};


### PR DESCRIPTION
Removed height style since:
- Component's height is implicitly defined by its children
- It makes the pagination div jumpy/hidden (especially when zooming-in in the browser)