### PR TITLE
Property for being able to have expandable buttons column as last column

### DIFF
--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -83,6 +83,7 @@ const DataTable = memo(({
   contextActions,
   contextComponent,
   expandableRows,
+  expandableColumnAtLast,
   onRowClicked,
   onRowDoubleClicked,
   sortIcon,
@@ -327,7 +328,7 @@ const DataTable = memo(({
                         ? <CellBase style={{ flex: '0 0 48px' }} role="columnheader" />
                         : <TableColCheckbox role="columnheader" />
                     )}
-                    {expandableRows && !expandableRowsHideExpander && (
+                    {expandableRows && !expandableRowsHideExpander && !expandableColumnAtLast && (
                       <TableColExpander />
                     )}
                     {columnsMemo.map(column => (
@@ -337,6 +338,9 @@ const DataTable = memo(({
                         sortIcon={sortIcon}
                       />
                     ))}
+                    {expandableRows && !expandableRowsHideExpander && expandableColumnAtLast && (
+                      <TableColExpander />
+                    )}
                   </TableHeadRow>
                 </TableHead>
               )}
@@ -399,6 +403,7 @@ const DataTable = memo(({
                         conditionalRowStyles={conditionalRowStyles}
                         selected={selected}
                         selectableRowsHighlight={selectableRowsHighlight}
+                        expandableColumnAtLast={expandableColumnAtLast}
                       />
                     );
                   })}

--- a/src/DataTable/TableRow.js
+++ b/src/DataTable/TableRow.js
@@ -60,6 +60,7 @@ const TableRow = memo(({
   onRowExpandToggled,
   selected,
   selectableRowsHighlight,
+  expandableColumnAtLast
 }) => {
   const [expanded, setExpanded] = useState(defaultExpanded);
   useEffect(() => {
@@ -120,7 +121,7 @@ const TableRow = memo(({
           />
         )}
 
-        {expandableRows && !expandableRowsHideExpander && (
+        {expandableRows && !expandableRowsHideExpander && !expandableColumnAtLast && (
           <TableCellExpander
             expanded={expanded}
             row={row}
@@ -137,6 +138,15 @@ const TableRow = memo(({
             row={row}
           />
         ))}
+
+        {expandableRows && !expandableRowsHideExpander && expandableColumnAtLast && (
+          <TableCellExpander
+            expanded={expanded}
+            row={row}
+            onRowExpandToggled={handleExpanded}
+            disabled={defaultExpanderDisabled}
+          />
+        )}
       </TableRowStyle>
 
       {expandableRows && expanded && (


### PR DESCRIPTION
Added property to data table and data row to be able to have the expandable buttons column as the last column of the grid, you can still have it in the first column if the property is not specified
Tests ran successfully #582 