### PR TITLE
Changed Pagination to use totalRows instead of data.length

### DIFF
--- a/src/DataTable/Pagination.js
+++ b/src/DataTable/Pagination.js
@@ -68,7 +68,6 @@ const Pagination = ({
   currentPage,
 }) => {
   const {
-    data,
     direction,
     paginationRowsPerPageOptions,
     paginationIconLastPage,
@@ -110,7 +109,7 @@ const Pagination = ({
       (
         <option
           key={-1}
-          value={data.length}
+          value={rowCount}
         >
           {options.selectAllRowsItemText}
         </option>


### PR DESCRIPTION
When using server-side pagination, the data.length is the length of one page and not appropriate for  calculating the value of 'All' in the paginator.