### PR TITLE
Improve typing for onRowClicked and onRowDoubleClicked props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,8 +14,8 @@ export interface IDataTableProps<T> {
   style?: CSSProperties;
   responsive?: boolean;
   disabled?: boolean;
-  onRowClicked?: (row: T) => void;
-  onRowDoubleClicked?: (row: T) => void;
+  onRowClicked?: (row: T, e: MouseEvent) => void;
+  onRowDoubleClicked?: (row: T, e: MouseEvent) => void;
   overflowY?: boolean;
   overflowYOffset?: string;
   dense?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -115,7 +115,7 @@ export interface IDataTableColumn<T> {
   right?: boolean;
   center?: boolean;
   compact?: boolean;
-  ignoreOnRowClick?: boolean;
+  ignoreRowClick?: boolean;
   button?: boolean;
   wrap?: boolean;
   allowOverflow?: boolean;


### PR DESCRIPTION
A mouse event is passed as a 2nd paramater both times, but they were missing from the interface declaration.