### PR TITLE
Adding override for showSelectAll

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
-import * as React from "react";
-import { CSSProperties } from "styled-components";
+import * as React from 'react';
+import { CSSProperties } from 'styled-components';
 
 export interface IDataTableProps<T> {
   title?: React.ReactNode;
@@ -23,11 +23,11 @@ export interface IDataTableProps<T> {
   defaultSortField?: string;
   defaultSortAsc?: boolean;
   sortIcon?: React.ReactNode;
-  onSort?: (column: IDataTableColumn<T>, sortDirection: "asc" | "desc") => void;
+  onSort?: (column: IDataTableColumn<T>, sortDirection: 'asc' | 'desc') => void;
   sortFunction?: (
     rows: T[],
     field: string,
-    sortDirection: "asc" | "desc"
+    sortDirection: 'asc' | 'desc'
   ) => T[];
   sortServer?: boolean;
   pagination?: boolean;
@@ -95,7 +95,7 @@ export interface IDataTableProps<T> {
   customStyles?: IDataTableStyles;
   theme?: string;
   conditionalRowStyles?: IDataTableConditionalRowStyles<T>[];
-  direction?: "ltr" | "rtl" | "auto";
+  direction?: 'ltr' | 'rtl' | 'auto';
 }
 
 export interface IDataTableColumn<T> {
@@ -116,7 +116,7 @@ export interface IDataTableColumn<T> {
   button?: boolean;
   wrap?: boolean;
   allowOverflow?: boolean;
-  hide?: number | "sm" | "md" | "lg";
+  hide?: number | 'sm' | 'md' | 'lg';
   omit?: boolean;
   style?: CSSProperties;
   conditionalCellStyles?: IDataTableConditionalCellStyles<T>[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import { CSSProperties } from 'styled-components';
+import * as React from "react";
+import { CSSProperties } from "styled-components";
 
 export interface IDataTableProps<T> {
   title?: React.ReactNode;
@@ -23,14 +23,11 @@ export interface IDataTableProps<T> {
   defaultSortField?: string;
   defaultSortAsc?: boolean;
   sortIcon?: React.ReactNode;
-  onSort?: (
-    column: IDataTableColumn<T>,
-    sortDirection: 'asc' | 'desc'
-  ) => void;
+  onSort?: (column: IDataTableColumn<T>, sortDirection: "asc" | "desc") => void;
   sortFunction?: (
     rows: T[],
     field: string,
-    sortDirection: 'asc' | 'desc'
+    sortDirection: "asc" | "desc"
   ) => T[];
   sortServer?: boolean;
   pagination?: boolean;
@@ -73,6 +70,7 @@ export interface IDataTableProps<T> {
   selectableRowsComponentProps?: {};
   selectableRowsHighlight?: boolean;
   selectableRowsVisibleOnly?: boolean;
+  showSelectAllOverride?: boolean;
   selectableRowSelected?: (row: T) => boolean;
   selectableRowDisabled?: (row: T) => boolean;
   selectableRowsNoSelectAll?: boolean;
@@ -97,7 +95,7 @@ export interface IDataTableProps<T> {
   customStyles?: IDataTableStyles;
   theme?: string;
   conditionalRowStyles?: IDataTableConditionalRowStyles<T>[];
-  direction?: 'ltr' | 'rtl' | 'auto';
+  direction?: "ltr" | "rtl" | "auto";
 }
 
 export interface IDataTableColumn<T> {
@@ -118,7 +116,7 @@ export interface IDataTableColumn<T> {
   button?: boolean;
   wrap?: boolean;
   allowOverflow?: boolean;
-  hide?: number | 'sm' | 'md' | 'lg';
+  hide?: number | "sm" | "md" | "lg";
   omit?: boolean;
   style?: CSSProperties;
   conditionalCellStyles?: IDataTableConditionalCellStyles<T>[];

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -1,441 +1,523 @@
-import React, { memo, useReducer, useMemo, useCallback, useEffect } from 'react';
-import { ThemeProvider } from 'styled-components';
-import { DataTableProvider } from './DataTableContext';
-import { tableReducer } from './tableReducer';
-import Table from './Table';
-import TableHead from './TableHead';
-import TableHeadRow from './TableHeadRow';
-import TableRow from './TableRow';
-import TableCol from './TableCol';
-import TableColCheckbox from './TableColCheckbox';
-import TableHeader from './TableHeader';
-import TableSubheader from './TableSubheader';
-import TableBody from './TableBody';
-import ResponsiveWrapper from './ResponsiveWrapper';
-import ProgressWrapper from './ProgressWrapper';
-import TableWrapper from './TableWrapper';
-import TableColExpander from './TableColExpander';
-import { CellBase } from './Cell';
-import NoData from './NoDataWrapper';
-import NativePagination from './Pagination';
-import useDidUpdateEffect from '../hooks/useDidUpdateEffect';
-import { propTypes, defaultProps } from './propTypes';
-import { isEmpty, sort, decorateColumns, getSortDirection, getNumberOfPages, recalculatePage, isRowSelected } from './util';
-import { createStyles } from './styles';
+import React, {
+  memo,
+  useReducer,
+  useMemo,
+  useCallback,
+  useEffect,
+} from "react";
+import { ThemeProvider } from "styled-components";
+import { DataTableProvider } from "./DataTableContext";
+import { tableReducer } from "./tableReducer";
+import Table from "./Table";
+import TableHead from "./TableHead";
+import TableHeadRow from "./TableHeadRow";
+import TableRow from "./TableRow";
+import TableCol from "./TableCol";
+import TableColCheckbox from "./TableColCheckbox";
+import TableHeader from "./TableHeader";
+import TableSubheader from "./TableSubheader";
+import TableBody from "./TableBody";
+import ResponsiveWrapper from "./ResponsiveWrapper";
+import ProgressWrapper from "./ProgressWrapper";
+import TableWrapper from "./TableWrapper";
+import TableColExpander from "./TableColExpander";
+import { CellBase } from "./Cell";
+import NoData from "./NoDataWrapper";
+import NativePagination from "./Pagination";
+import useDidUpdateEffect from "../hooks/useDidUpdateEffect";
+import { propTypes, defaultProps } from "./propTypes";
+import {
+  isEmpty,
+  sort,
+  decorateColumns,
+  getSortDirection,
+  getNumberOfPages,
+  recalculatePage,
+  isRowSelected,
+} from "./util";
+import { createStyles } from "./styles";
 
-const DataTable = memo(({
-  data,
-  columns,
-  title,
-  actions,
-  keyField,
-  striped,
-  highlightOnHover,
-  pointerOnHover,
-  dense,
-  selectableRows,
-  selectableRowsHighlight,
-  selectableRowsNoSelectAll,
-  selectableRowsVisibleOnly,
-  selectableRowSelected,
-  selectableRowDisabled,
-  selectableRowsComponent,
-  selectableRowsComponentProps,
-  onRowExpandToggled,
-  onSelectedRowsChange,
-  expandableIcon,
-  onChangeRowsPerPage,
-  onChangePage,
-  paginationServer,
-  paginationServerOptions,
-  paginationTotalRows,
-  paginationDefaultPage,
-  paginationResetDefaultPage,
-  paginationPerPage,
-  paginationRowsPerPageOptions,
-  paginationIconLastPage,
-  paginationIconFirstPage,
-  paginationIconNext,
-  paginationIconPrevious,
-  paginationComponent,
-  paginationComponentOptions,
-  className,
-  style,
-  responsive,
-  overflowY,
-  overflowYOffset,
-  progressPending,
-  progressComponent,
-  persistTableHead,
-  noDataComponent,
-  disabled,
-  noTableHead,
-  noHeader,
-  fixedHeader,
-  fixedHeaderScrollHeight,
-  pagination,
-  subHeader,
-  subHeaderAlign,
-  subHeaderWrap,
-  subHeaderComponent,
-  noContextMenu,
-  contextMessage,
-  contextActions,
-  contextComponent,
-  expandableRows,
-  onRowClicked,
-  onRowDoubleClicked,
-  sortIcon,
-  onSort,
-  sortFunction,
-  sortServer,
-  expandableRowsComponent,
-  expandableRowDisabled,
-  expandableRowsHideExpander,
-  expandOnRowClicked,
-  expandOnRowDoubleClicked,
-  expandableRowExpanded,
-  expandableInheritConditionalStyles,
-  defaultSortField,
-  defaultSortAsc,
-  clearSelectedRows,
-  conditionalRowStyles,
-  theme,
-  customStyles,
-  direction,
-}) => {
-  const initialState = {
-    allSelected: false,
-    selectedCount: 0,
-    selectedRows: [],
-    sortColumn: defaultSortField,
-    selectedColumn: {},
-    sortDirection: getSortDirection(defaultSortAsc),
-    currentPage: paginationDefaultPage,
-    rowsPerPage: paginationPerPage,
-  };
-
-  const [{
-    rowsPerPage,
-    currentPage,
-    selectedRows,
-    allSelected,
-    selectedCount,
-    sortColumn,
-    selectedColumn,
-    sortDirection,
-  }, dispatch] = useReducer(tableReducer, initialState);
-  const { persistSelectedOnSort, persistSelectedOnPageChange } = paginationServerOptions;
-  const mergeSelections = paginationServer && (persistSelectedOnPageChange || persistSelectedOnSort);
-  const enabledPagination = pagination && !progressPending && data.length > 0;
-  const Pagination = paginationComponent || NativePagination;
-  const columnsMemo = useMemo(() => decorateColumns(columns), [columns]);
-  const currentTheme = useMemo(() => createStyles(customStyles, theme), [customStyles, theme]);
-  const expandableRowsComponentMemo = useMemo(() => expandableRowsComponent, [expandableRowsComponent]);
-  const wrapperProps = useMemo(() => ({ ...direction !== 'auto' && ({ dir: direction }) }), [direction]);
-  const handleRowClicked = useCallback((row, e) => onRowClicked(row, e), [onRowClicked]);
-  const handleRowDoubleClicked = useCallback((row, e) => onRowDoubleClicked(row, e), [onRowDoubleClicked]);
-  const handleChangePage = page => dispatch({
-    type: 'CHANGE_PAGE',
-    page,
-    paginationServer,
-    visibleOnly: selectableRowsVisibleOnly,
-    persistSelectedOnPageChange,
-  });
-
-  useDidUpdateEffect(() => {
-    onSelectedRowsChange({ allSelected, selectedCount, selectedRows });
-  }, [selectedCount]);
-
-  useDidUpdateEffect(() => {
-    onChangePage(currentPage, paginationTotalRows || data.length);
-  }, [currentPage]);
-
-  useDidUpdateEffect(() => {
-    onChangeRowsPerPage(rowsPerPage, currentPage);
-  }, [rowsPerPage]);
-
-  useDidUpdateEffect(() => {
-    onSort(selectedColumn, sortDirection);
-  }, [sortColumn, sortDirection]);
-
-  useEffect(() => {
-    dispatch({ type: 'CLEAR_SELECTED_ROWS', selectedRowsFlag: clearSelectedRows });
-  }, [clearSelectedRows]);
-
-  useDidUpdateEffect(() => {
-    handleChangePage(paginationDefaultPage);
-  }, [paginationDefaultPage, paginationResetDefaultPage]);
-
-  useEffect(() => {
-    if (selectableRowSelected) {
-      const preSelectedRows = data.filter(row => selectableRowSelected(row));
-
-      dispatch({ type: 'SELECT_MULTIPLE_ROWS', selectedRows: preSelectedRows, rows: data, mergeSelections });
-    }
-    // We only want to re-render if the data changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data]);
-
-  useDidUpdateEffect(() => {
-    if (pagination && paginationServer && paginationTotalRows > 0) {
-      const updatedPage = getNumberOfPages(paginationTotalRows, rowsPerPage);
-      const recalculatedPage = recalculatePage(currentPage, updatedPage);
-      if (currentPage !== recalculatedPage) {
-        handleChangePage(recalculatedPage);
-      }
-    }
-  }, [paginationTotalRows]);
-
-  const columnsBySelector = useMemo(() => {
-    return columns.reduce((acc, item) => ({ ...acc, [item.selector]: item }), {});
-  }, [columns]);
-
-  const sortedData = useMemo(() => {
-    // server-side sorting bypasses internal sorting
-    if (sortServer) {
-      return data;
-    }
-
-    // use general sorting function when columns has no sort function on it's own
-    const column = sortColumn && columnsBySelector[sortColumn];
-    if (!column || !column.sortFunction) {
-      return sort(data, sortColumn, sortDirection, sortFunction);
-    }
-
-    // use column's custom sorting function
-    const customSortFunction = sortDirection === 'asc'
-      ? column.sortFunction
-      : (a, b) => column.sortFunction(a, b) * -1;
-
-    return [...data].sort(customSortFunction);
-  }, [sortServer, sortColumn, columnsBySelector, sortDirection, data, sortFunction]);
-
-  const calculatedRows = useMemo(() => {
-    if (pagination && !paginationServer) {
-      // when using client-side pagination we can just slice the data set
-      const lastIndex = currentPage * rowsPerPage;
-      const firstIndex = lastIndex - rowsPerPage;
-
-      return sortedData.slice(firstIndex, lastIndex);
-    }
-
-    return sortedData;
-  }, [currentPage, pagination, paginationServer, rowsPerPage, sortedData]);
-
-  // recalculate the pagination and currentPage if the data length changes
-  if (pagination && !paginationServer && data.length > 0 && calculatedRows.length === 0) {
-    const updatedPage = getNumberOfPages(data.length, rowsPerPage);
-    const recalculatedPage = recalculatePage(currentPage, updatedPage);
-
-    handleChangePage(recalculatedPage);
-  }
-
-  const handleChangeRowsPerPage = newRowsPerPage => {
-    const rowCount = paginationTotalRows || calculatedRows.length;
-    const updatedPage = getNumberOfPages(rowCount, newRowsPerPage);
-    const recalculatedPage = recalculatePage(currentPage, updatedPage);
-
-    // update the currentPage for client-side pagination
-    // server - side should be handled by onChangeRowsPerPage
-    if (!paginationServer) {
-      handleChangePage(recalculatedPage);
-    }
-
-    dispatch({ type: 'CHANGE_ROWS_PER_PAGE', page: recalculatedPage, rowsPerPage: newRowsPerPage });
-  };
-
-  const init = {
-    dispatch,
-    data: selectableRowsVisibleOnly ? calculatedRows : data,
-    allSelected,
-    selectedRows,
-    selectedCount,
-    sortColumn,
-    sortDirection,
+const DataTable = memo(
+  ({
+    data,
+    columns,
+    title,
+    actions,
     keyField,
-    contextMessage,
-    contextActions,
-    contextComponent,
-    sortServer,
+    striped,
+    highlightOnHover,
+    pointerOnHover,
+    dense,
+    selectableRows,
+    selectableRowsHighlight,
+    selectableRowsNoSelectAll,
     selectableRowsVisibleOnly,
     selectableRowSelected,
     selectableRowDisabled,
     selectableRowsComponent,
     selectableRowsComponentProps,
-    persistSelectedOnSort,
+    onRowExpandToggled,
+    onSelectedRowsChange,
     expandableIcon,
-    pagination,
+    onChangeRowsPerPage,
+    onChangePage,
     paginationServer,
     paginationServerOptions,
     paginationTotalRows,
+    paginationDefaultPage,
+    paginationResetDefaultPage,
+    paginationPerPage,
     paginationRowsPerPageOptions,
     paginationIconLastPage,
     paginationIconFirstPage,
     paginationIconNext,
     paginationIconPrevious,
+    paginationComponent,
     paginationComponentOptions,
+    className,
+    style,
+    responsive,
+    overflowY,
+    overflowYOffset,
+    progressPending,
+    progressComponent,
+    persistTableHead,
+    noDataComponent,
+    disabled,
+    noTableHead,
+    noHeader,
+    fixedHeader,
+    fixedHeaderScrollHeight,
+    pagination,
+    subHeader,
+    subHeaderAlign,
+    subHeaderWrap,
+    subHeaderComponent,
+    noContextMenu,
+    contextMessage,
+    contextActions,
+    contextComponent,
+    expandableRows,
+    onRowClicked,
+    onRowDoubleClicked,
+    sortIcon,
+    onSort,
+    sortFunction,
+    sortServer,
+    expandableRowsComponent,
+    expandableRowDisabled,
+    expandableRowsHideExpander,
+    expandOnRowClicked,
+    expandOnRowDoubleClicked,
+    expandableRowExpanded,
+    expandableInheritConditionalStyles,
+    defaultSortField,
+    defaultSortAsc,
+    clearSelectedRows,
+    conditionalRowStyles,
+    theme,
+    customStyles,
     direction,
-    mergeSelections,
-  };
+    showSelectAllOverride,
+  }) => {
+    const initialState = {
+      allSelected: false,
+      selectedCount: 0,
+      selectedRows: [],
+      sortColumn: defaultSortField,
+      selectedColumn: {},
+      sortDirection: getSortDirection(defaultSortAsc),
+      currentPage: paginationDefaultPage,
+      rowsPerPage: paginationPerPage,
+    };
 
-  const showTableHead = () => {
-    if (noTableHead) {
-      return false;
+    const [
+      {
+        rowsPerPage,
+        currentPage,
+        selectedRows,
+        allSelected,
+        selectedCount,
+        sortColumn,
+        selectedColumn,
+        sortDirection,
+      },
+      dispatch,
+    ] = useReducer(tableReducer, initialState);
+    const {
+      persistSelectedOnSort,
+      persistSelectedOnPageChange,
+    } = paginationServerOptions;
+    const mergeSelections =
+      paginationServer &&
+      (persistSelectedOnPageChange || persistSelectedOnSort);
+    const enabledPagination = pagination && !progressPending && data.length > 0;
+    const Pagination = paginationComponent || NativePagination;
+    const columnsMemo = useMemo(() => decorateColumns(columns), [columns]);
+    const currentTheme = useMemo(() => createStyles(customStyles, theme), [
+      customStyles,
+      theme,
+    ]);
+    const expandableRowsComponentMemo = useMemo(() => expandableRowsComponent, [
+      expandableRowsComponent,
+    ]);
+    const wrapperProps = useMemo(
+      () => ({ ...(direction !== "auto" && { dir: direction }) }),
+      [direction]
+    );
+    const handleRowClicked = useCallback((row, e) => onRowClicked(row, e), [
+      onRowClicked,
+    ]);
+    const handleRowDoubleClicked = useCallback(
+      (row, e) => onRowDoubleClicked(row, e),
+      [onRowDoubleClicked]
+    );
+    const handleChangePage = (page) =>
+      dispatch({
+        type: "CHANGE_PAGE",
+        page,
+        paginationServer,
+        visibleOnly: selectableRowsVisibleOnly,
+        persistSelectedOnPageChange,
+      });
+
+    useDidUpdateEffect(() => {
+      ({ allSelected, selectedCount, selectedRows });
+    }, [selectedCount]);
+
+    useDidUpdateEffect(() => {
+      onChangePage(currentPage, paginationTotalRows || data.length);
+    }, [currentPage]);
+
+    useDidUpdateEffect(() => {
+      onChangeRowsPerPage(rowsPerPage, currentPage);
+    }, [rowsPerPage]);
+
+    useDidUpdateEffect(() => {
+      onSort(selectedColumn, sortDirection);
+    }, [sortColumn, sortDirection]);
+
+    useEffect(() => {
+      dispatch({
+        type: "CLEAR_SELECTED_ROWS",
+        selectedRowsFlag: clearSelectedRows,
+      });
+    }, [clearSelectedRows]);
+
+    useDidUpdateEffect(() => {
+      handleChangePage(paginationDefaultPage);
+    }, [paginationDefaultPage, paginationResetDefaultPage]);
+
+    useEffect(() => {
+      if (selectableRowSelected) {
+        const preSelectedRows = data.filter((row) =>
+          selectableRowSelected(row)
+        );
+
+        dispatch({
+          type: "SELECT_MULTIPLE_ROWS",
+          selectedRows: preSelectedRows,
+          rows: data,
+          mergeSelections,
+        });
+      }
+      // We only want to re-render if the data changes
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [data]);
+
+    useDidUpdateEffect(() => {
+      if (pagination && paginationServer && paginationTotalRows > 0) {
+        const updatedPage = getNumberOfPages(paginationTotalRows, rowsPerPage);
+        const recalculatedPage = recalculatePage(currentPage, updatedPage);
+        if (currentPage !== recalculatedPage) {
+          handleChangePage(recalculatedPage);
+        }
+      }
+    }, [paginationTotalRows]);
+
+    const columnsBySelector = useMemo(() => {
+      return columns.reduce(
+        (acc, item) => ({ ...acc, [item.selector]: item }),
+        {}
+      );
+    }, [columns]);
+
+    const sortedData = useMemo(() => {
+      // server-side sorting bypasses internal sorting
+      if (sortServer) {
+        return data;
+      }
+
+      // use general sorting function when columns has no sort function on it's own
+      const column = sortColumn && columnsBySelector[sortColumn];
+      if (!column || !column.sortFunction) {
+        return sort(data, sortColumn, sortDirection, sortFunction);
+      }
+
+      // use column's custom sorting function
+      const customSortFunction =
+        sortDirection === "asc"
+          ? column.sortFunction
+          : (a, b) => column.sortFunction(a, b) * -1;
+
+      return [...data].sort(customSortFunction);
+    }, [
+      sortServer,
+      sortColumn,
+      columnsBySelector,
+      sortDirection,
+      data,
+      sortFunction,
+    ]);
+
+    const calculatedRows = useMemo(() => {
+      if (pagination && !paginationServer) {
+        // when using client-side pagination we can just slice the data set
+        const lastIndex = currentPage * rowsPerPage;
+        const firstIndex = lastIndex - rowsPerPage;
+
+        return sortedData.slice(firstIndex, lastIndex);
+      }
+
+      return sortedData;
+    }, [currentPage, pagination, paginationServer, rowsPerPage, sortedData]);
+
+    // recalculate the pagination and currentPage if the data length changes
+    if (
+      pagination &&
+      !paginationServer &&
+      data.length > 0 &&
+      calculatedRows.length === 0
+    ) {
+      const updatedPage = getNumberOfPages(data.length, rowsPerPage);
+      const recalculatedPage = recalculatePage(currentPage, updatedPage);
+
+      handleChangePage(recalculatedPage);
     }
 
-    if (persistTableHead) {
-      return true;
-    }
+    const handleChangeRowsPerPage = (newRowsPerPage) => {
+      const rowCount = paginationTotalRows || calculatedRows.length;
+      const updatedPage = getNumberOfPages(rowCount, newRowsPerPage);
+      const recalculatedPage = recalculatePage(currentPage, updatedPage);
 
-    return data.length > 0 && !progressPending;
-  };
+      // update the currentPage for client-side pagination
+      // server - side should be handled by onChangeRowsPerPage
+      if (!paginationServer) {
+        handleChangePage(recalculatedPage);
+      }
 
-  const showSelectAll = persistSelectedOnPageChange || selectableRowsNoSelectAll;
+      dispatch({
+        type: "CHANGE_ROWS_PER_PAGE",
+        page: recalculatedPage,
+        rowsPerPage: newRowsPerPage,
+      });
+    };
 
-  return (
-    <ThemeProvider theme={currentTheme}>
-      <DataTableProvider initialState={init}>
-        <ResponsiveWrapper
-          responsive={responsive}
-          className={className}
-          style={style}
-          overflowYOffset={overflowYOffset}
-          overflowY={overflowY}
-          {...wrapperProps}
-        >
-          {!noHeader && (
-            <TableHeader
-              title={title}
-              actions={actions}
-              showMenu={!noContextMenu}
-            />
-          )}
+    const init = {
+      dispatch,
+      data: selectableRowsVisibleOnly ? calculatedRows : data,
+      allSelected,
+      selectedRows,
+      selectedCount,
+      sortColumn,
+      sortDirection,
+      keyField,
+      contextMessage,
+      contextActions,
+      contextComponent,
+      sortServer,
+      selectableRowsVisibleOnly,
+      selectableRowSelected,
+      selectableRowDisabled,
+      selectableRowsComponent,
+      selectableRowsComponentProps,
+      persistSelectedOnSort,
+      expandableIcon,
+      pagination,
+      paginationServer,
+      paginationServerOptions,
+      paginationTotalRows,
+      paginationRowsPerPageOptions,
+      paginationIconLastPage,
+      paginationIconFirstPage,
+      paginationIconNext,
+      paginationIconPrevious,
+      paginationComponentOptions,
+      direction,
+      mergeSelections,
+    };
 
-          {subHeader && (
-            <TableSubheader
-              align={subHeaderAlign}
-              wrapContent={subHeaderWrap}
-            >
-              {subHeaderComponent}
-            </TableSubheader>
-          )}
+    const showTableHead = () => {
+      if (noTableHead) {
+        return false;
+      }
 
-          <TableWrapper>
-            {progressPending && !persistTableHead && (
-              <ProgressWrapper>
-                {progressComponent}
-              </ProgressWrapper>
+      if (persistTableHead) {
+        return true;
+      }
+
+      return data.length > 0 && !progressPending;
+    };
+
+    const showSelectAll = showSelectAllOverride
+      ? false
+      : persistSelectedOnPageChange || selectableRowsNoSelectAll;
+
+    return (
+      <ThemeProvider theme={currentTheme}>
+        <DataTableProvider initialState={init}>
+          <ResponsiveWrapper
+            responsive={responsive}
+            className={className}
+            style={style}
+            overflowYOffset={overflowYOffset}
+            overflowY={overflowY}
+            {...wrapperProps}
+          >
+            {!noHeader && (
+              <TableHeader
+                title={title}
+                actions={actions}
+                showMenu={!noContextMenu}
+              />
             )}
 
-            <Table disabled={disabled} className="rdt_Table" role="table">
-              {showTableHead() && (
-                <TableHead className="rdt_TableHead" role="rowgroup">
-                  <TableHeadRow
-                    className="rdt_TableHeadRow"
-                    role="row"
-                    dense={dense}
-                    disabled={progressPending || data.length === 0}
+            {subHeader && (
+              <TableSubheader
+                align={subHeaderAlign}
+                wrapContent={subHeaderWrap}
+              >
+                {subHeaderComponent}
+              </TableSubheader>
+            )}
+
+            <TableWrapper>
+              {progressPending && !persistTableHead && (
+                <ProgressWrapper>{progressComponent}</ProgressWrapper>
+              )}
+
+              <Table disabled={disabled} className="rdt_Table" role="table">
+                {showTableHead() && (
+                  <TableHead className="rdt_TableHead" role="rowgroup">
+                    <TableHeadRow
+                      className="rdt_TableHeadRow"
+                      role="row"
+                      dense={dense}
+                      disabled={progressPending || data.length === 0}
+                    >
+                      {selectableRows &&
+                        (showSelectAll ? (
+                          <CellBase
+                            style={{ flex: "0 0 48px" }}
+                            role="columnheader"
+                          />
+                        ) : (
+                          <TableColCheckbox
+                            role="columnheader"
+                            showSelectAllOverride={showSelectAllOverride}
+                          />
+                        ))}
+                      {expandableRows && !expandableRowsHideExpander && (
+                        <TableColExpander />
+                      )}
+                      {columnsMemo.map((column) => (
+                        <TableCol
+                          key={column.id}
+                          column={column}
+                          sortIcon={sortIcon}
+                        />
+                      ))}
+                    </TableHeadRow>
+                  </TableHead>
+                )}
+
+                {!data.length > 0 && !progressPending && (
+                  <NoData>{noDataComponent}</NoData>
+                )}
+
+                {progressPending && persistTableHead && (
+                  <ProgressWrapper>{progressComponent}</ProgressWrapper>
+                )}
+
+                {!progressPending && data.length > 0 && (
+                  <TableBody
+                    fixedHeader={fixedHeader}
+                    fixedHeaderScrollHeight={fixedHeaderScrollHeight}
+                    hasOffset={overflowY}
+                    offset={overflowYOffset}
+                    className="rdt_TableBody"
+                    role="rowgroup"
                   >
-                    {selectableRows && (
-                      showSelectAll
-                        ? <CellBase style={{ flex: '0 0 48px' }} role="columnheader" />
-                        : <TableColCheckbox role="columnheader" />
-                    )}
-                    {expandableRows && !expandableRowsHideExpander && (
-                      <TableColExpander />
-                    )}
-                    {columnsMemo.map(column => (
-                      <TableCol
-                        key={column.id}
-                        column={column}
-                        sortIcon={sortIcon}
-                      />
-                    ))}
-                  </TableHeadRow>
-                </TableHead>
-              )}
+                    {calculatedRows.map((row, i) => {
+                      const id = isEmpty(row[keyField]) ? i : row[keyField];
+                      const selected = isRowSelected(
+                        row,
+                        selectedRows,
+                        keyField
+                      );
+                      const expanderExpander =
+                        expandableRows &&
+                        expandableRowExpanded &&
+                        expandableRowExpanded(row);
 
-              {!data.length > 0 && !progressPending && (
-                <NoData>
-                  {noDataComponent}
-                </NoData>
-              )}
+                      const expanderDisabled =
+                        expandableRows &&
+                        expandableRowDisabled &&
+                        expandableRowDisabled(row);
 
-              {progressPending && persistTableHead && (
-                <ProgressWrapper>
-                  {progressComponent}
-                </ProgressWrapper>
-              )}
+                      return (
+                        <TableRow
+                          id={id}
+                          key={id}
+                          keyField={keyField}
+                          row={row}
+                          columns={columnsMemo}
+                          selectableRows={selectableRows}
+                          expandableRows={expandableRows}
+                          striped={striped}
+                          highlightOnHover={highlightOnHover}
+                          pointerOnHover={pointerOnHover}
+                          dense={dense}
+                          expandOnRowClicked={expandOnRowClicked}
+                          expandOnRowDoubleClicked={expandOnRowDoubleClicked}
+                          expandableRowsComponent={expandableRowsComponentMemo}
+                          expandableRowsHideExpander={
+                            expandableRowsHideExpander
+                          }
+                          onRowExpandToggled={onRowExpandToggled}
+                          defaultExpanderDisabled={expanderDisabled}
+                          defaultExpanded={expanderExpander}
+                          inheritConditionalStyles={
+                            expandableInheritConditionalStyles
+                          }
+                          onRowClicked={handleRowClicked}
+                          onRowDoubleClicked={handleRowDoubleClicked}
+                          conditionalRowStyles={conditionalRowStyles}
+                          selected={selected}
+                          selectableRowsHighlight={selectableRowsHighlight}
+                        />
+                      );
+                    })}
+                  </TableBody>
+                )}
+              </Table>
+            </TableWrapper>
 
-              {!progressPending && data.length > 0 && (
-                <TableBody
-                  fixedHeader={fixedHeader}
-                  fixedHeaderScrollHeight={fixedHeaderScrollHeight}
-                  hasOffset={overflowY}
-                  offset={overflowYOffset}
-                  className="rdt_TableBody"
-                  role="rowgroup"
-                >
-                  {calculatedRows.map((row, i) => {
-                    const id = isEmpty(row[keyField]) ? i : row[keyField];
-                    const selected = isRowSelected(row, selectedRows, keyField);
-                    const expanderExpander = expandableRows
-                      && expandableRowExpanded
-                      && expandableRowExpanded(row);
-
-                    const expanderDisabled = expandableRows
-                      && expandableRowDisabled
-                      && expandableRowDisabled(row);
-
-                    return (
-                      <TableRow
-                        id={id}
-                        key={id}
-                        keyField={keyField}
-                        row={row}
-                        columns={columnsMemo}
-                        selectableRows={selectableRows}
-                        expandableRows={expandableRows}
-                        striped={striped}
-                        highlightOnHover={highlightOnHover}
-                        pointerOnHover={pointerOnHover}
-                        dense={dense}
-                        expandOnRowClicked={expandOnRowClicked}
-                        expandOnRowDoubleClicked={expandOnRowDoubleClicked}
-                        expandableRowsComponent={expandableRowsComponentMemo}
-                        expandableRowsHideExpander={expandableRowsHideExpander}
-                        onRowExpandToggled={onRowExpandToggled}
-                        defaultExpanderDisabled={expanderDisabled}
-                        defaultExpanded={expanderExpander}
-                        inheritConditionalStyles={expandableInheritConditionalStyles}
-                        onRowClicked={handleRowClicked}
-                        onRowDoubleClicked={handleRowDoubleClicked}
-                        conditionalRowStyles={conditionalRowStyles}
-                        selected={selected}
-                        selectableRowsHighlight={selectableRowsHighlight}
-                      />
-                    );
-                  })}
-                </TableBody>
-              )}
-            </Table>
-          </TableWrapper>
-
-          {enabledPagination && (
-            <Pagination
-              onChangePage={handleChangePage}
-              onChangeRowsPerPage={handleChangeRowsPerPage}
-              rowCount={paginationTotalRows || data.length}
-              currentPage={currentPage}
-              rowsPerPage={rowsPerPage}
-            />
-          )}
-        </ResponsiveWrapper>
-      </DataTableProvider>
-    </ThemeProvider>
-  );
-});
+            {enabledPagination && (
+              <Pagination
+                onChangePage={handleChangePage}
+                onChangeRowsPerPage={handleChangeRowsPerPage}
+                rowCount={paginationTotalRows || data.length}
+                currentPage={currentPage}
+                rowsPerPage={rowsPerPage}
+              />
+            )}
+          </ResponsiveWrapper>
+        </DataTableProvider>
+      </ThemeProvider>
+    );
+  }
+);
 
 DataTable.propTypes = propTypes;
 DataTable.defaultProps = defaultProps;

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -4,28 +4,28 @@ import React, {
   useMemo,
   useCallback,
   useEffect,
-} from "react";
-import { ThemeProvider } from "styled-components";
-import { DataTableProvider } from "./DataTableContext";
-import { tableReducer } from "./tableReducer";
-import Table from "./Table";
-import TableHead from "./TableHead";
-import TableHeadRow from "./TableHeadRow";
-import TableRow from "./TableRow";
-import TableCol from "./TableCol";
-import TableColCheckbox from "./TableColCheckbox";
-import TableHeader from "./TableHeader";
-import TableSubheader from "./TableSubheader";
-import TableBody from "./TableBody";
-import ResponsiveWrapper from "./ResponsiveWrapper";
-import ProgressWrapper from "./ProgressWrapper";
-import TableWrapper from "./TableWrapper";
-import TableColExpander from "./TableColExpander";
-import { CellBase } from "./Cell";
-import NoData from "./NoDataWrapper";
-import NativePagination from "./Pagination";
-import useDidUpdateEffect from "../hooks/useDidUpdateEffect";
-import { propTypes, defaultProps } from "./propTypes";
+} from 'react';
+import { ThemeProvider } from 'styled-components';
+import { DataTableProvider } from './DataTableContext';
+import { tableReducer } from './tableReducer';
+import Table from './Table';
+import TableHead from './TableHead';
+import TableHeadRow from './TableHeadRow';
+import TableRow from './TableRow';
+import TableCol from './TableCol';
+import TableColCheckbox from './TableColCheckbox';
+import TableHeader from './TableHeader';
+import TableSubheader from './TableSubheader';
+import TableBody from './TableBody';
+import ResponsiveWrapper from './ResponsiveWrapper';
+import ProgressWrapper from './ProgressWrapper';
+import TableWrapper from './TableWrapper';
+import TableColExpander from './TableColExpander';
+import { CellBase } from './Cell';
+import NoData from './NoDataWrapper';
+import NativePagination from './Pagination';
+import useDidUpdateEffect from '../hooks/useDidUpdateEffect';
+import { propTypes, defaultProps } from './propTypes';
 import {
   isEmpty,
   sort,
@@ -34,8 +34,8 @@ import {
   getNumberOfPages,
   recalculatePage,
   isRowSelected,
-} from "./util";
-import { createStyles } from "./styles";
+} from './util';
+import { createStyles } from './styles';
 
 const DataTable = memo(
   ({
@@ -162,7 +162,7 @@ const DataTable = memo(
       expandableRowsComponent,
     ]);
     const wrapperProps = useMemo(
-      () => ({ ...(direction !== "auto" && { dir: direction }) }),
+      () => ({ ...(direction !== 'auto' && { dir: direction }) }),
       [direction]
     );
     const handleRowClicked = useCallback((row, e) => onRowClicked(row, e), [
@@ -174,7 +174,7 @@ const DataTable = memo(
     );
     const handleChangePage = (page) =>
       dispatch({
-        type: "CHANGE_PAGE",
+        type: 'CHANGE_PAGE',
         page,
         paginationServer,
         visibleOnly: selectableRowsVisibleOnly,
@@ -199,7 +199,7 @@ const DataTable = memo(
 
     useEffect(() => {
       dispatch({
-        type: "CLEAR_SELECTED_ROWS",
+        type: 'CLEAR_SELECTED_ROWS',
         selectedRowsFlag: clearSelectedRows,
       });
     }, [clearSelectedRows]);
@@ -215,7 +215,7 @@ const DataTable = memo(
         );
 
         dispatch({
-          type: "SELECT_MULTIPLE_ROWS",
+          type: 'SELECT_MULTIPLE_ROWS',
           selectedRows: preSelectedRows,
           rows: data,
           mergeSelections,
@@ -256,7 +256,7 @@ const DataTable = memo(
 
       // use column's custom sorting function
       const customSortFunction =
-        sortDirection === "asc"
+        sortDirection === 'asc'
           ? column.sortFunction
           : (a, b) => column.sortFunction(a, b) * -1;
 
@@ -307,7 +307,7 @@ const DataTable = memo(
       }
 
       dispatch({
-        type: "CHANGE_ROWS_PER_PAGE",
+        type: 'CHANGE_ROWS_PER_PAGE',
         page: recalculatedPage,
         rowsPerPage: newRowsPerPage,
       });
@@ -400,23 +400,23 @@ const DataTable = memo(
                 {showTableHead() && (
                   <TableHead className="rdt_TableHead" role="rowgroup">
                     <TableHeadRow
-                      className="rdt_TableHeadRow"
-                      role="row"
+                      className='rdt_TableHeadRow'
+                      role='row'
                       dense={dense}
                       disabled={progressPending || data.length === 0}
                     >
                       {selectableRows &&
                         (showSelectAll ? (
                           <CellBase
-                            style={{ flex: "0 0 48px" }}
-                            role="columnheader"
+                            style={{ flex: '0 0 48px' }}
+                            role='columnheader'
                           />
                         ) : (
-                          <TableColCheckbox
-                            role="columnheader"
-                            showSelectAllOverride={showSelectAllOverride}
-                          />
-                        ))}
+                            <TableColCheckbox
+                              role='columnheader'
+                              showSelectAllOverride={showSelectAllOverride}
+                            />
+                          ))}
                       {expandableRows && !expandableRowsHideExpander && (
                         <TableColExpander />
                       )}
@@ -445,8 +445,8 @@ const DataTable = memo(
                     fixedHeaderScrollHeight={fixedHeaderScrollHeight}
                     hasOffset={overflowY}
                     offset={overflowYOffset}
-                    className="rdt_TableBody"
-                    role="rowgroup"
+                    className='rdt_TableBody'
+                    role='rowgroup'
                   >
                     {calculatedRows.map((row, i) => {
                       const id = isEmpty(row[keyField]) ? i : row[keyField];

--- a/src/DataTable/TableColCheckbox.js
+++ b/src/DataTable/TableColCheckbox.js
@@ -35,7 +35,7 @@ const TableColCheckbox = ({ head }) => {
 
   var selectAllOverride = false;
   if (showSelectAllOverride) {
-    if (!selectedRows.length == 0) {
+    if (!selectedRows.length === 0) {
       for (var i = 0; i < data.length; i++) {
         let selected = selectedRows.some((item) => {
           if (data[i]) {
@@ -54,7 +54,7 @@ const TableColCheckbox = ({ head }) => {
   const handleSelectAll = useCallback(
     () =>
       dispatch({
-        type: "SELECT_ALL_ROWS",
+        type: 'SELECT_ALL_ROWS',
         rows,
         rowCount,
         mergeSelections,
@@ -64,9 +64,9 @@ const TableColCheckbox = ({ head }) => {
   );
 
   return (
-    <TableColStyle className="rdt_TableCol" head={head} noPadding>
+    <TableColStyle className='rdt_TableCol' head={head} noPadding>
       <Checkbox
-        name="select-all-rows"
+        name='select-all-rows'
         component={selectableRowsComponent}
         componentOptions={selectableRowsComponentProps}
         onClick={handleSelectAll}

--- a/src/DataTable/TableColCheckbox.js
+++ b/src/DataTable/TableColCheckbox.js
@@ -1,9 +1,9 @@
-import React, { useCallback } from 'react';
-import PropTypes from 'prop-types';
-import styled from 'styled-components';
-import { useTableContext } from './DataTableContext';
-import { CellBase } from './Cell';
-import Checkbox from './Checkbox';
+import React, { useCallback } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { useTableContext } from "./DataTableContext";
+import { CellBase } from "./Cell";
+import Checkbox from "./Checkbox";
 
 const TableColStyle = styled(CellBase)`
   flex: 0 0 48px;
@@ -24,19 +24,44 @@ const TableColCheckbox = ({ head }) => {
     selectableRowDisabled,
     keyField,
     mergeSelections,
+    showSelectAllOverride,
   } = useTableContext();
   const indeterminate = selectedRows.length > 0 && !allSelected;
-  const rows = selectableRowDisabled ? data.filter(row => !selectableRowDisabled(row)) : data;
+  const rows = selectableRowDisabled
+    ? data.filter((row) => !selectableRowDisabled(row))
+    : data;
   const isDisabled = rows.length === 0;
   const rowCount = data.length;
 
-  const handleSelectAll = useCallback(() => dispatch({
-    type: 'SELECT_ALL_ROWS',
-    rows,
-    rowCount,
-    mergeSelections,
-    keyField,
-  }), [dispatch, keyField, mergeSelections, rowCount, rows]);
+  var selectAllOverride = false;
+  if (showSelectAllOverride) {
+    if (!selectedRows.length == 0) {
+      for (var i = 0; i < data.length; i++) {
+        let selected = selectedRows.some((item) => {
+          if (data[i]) {
+            return item._id === data[i]._id;
+          }
+          return false;
+        });
+        if (!selected) {
+          selectAllOverride = false;
+          break;
+        }
+      }
+    }
+  }
+
+  const handleSelectAll = useCallback(
+    () =>
+      dispatch({
+        type: "SELECT_ALL_ROWS",
+        rows,
+        rowCount,
+        mergeSelections,
+        keyField,
+      }),
+    [dispatch, keyField, mergeSelections, rowCount, rows]
+  );
 
   return (
     <TableColStyle className="rdt_TableCol" head={head} noPadding>
@@ -45,7 +70,7 @@ const TableColCheckbox = ({ head }) => {
         component={selectableRowsComponent}
         componentOptions={selectableRowsComponentProps}
         onClick={handleSelectAll}
-        checked={allSelected}
+        checked={showSelectAllOverride ? selectAllOverride : allSelected}
         indeterminate={indeterminate}
         disabled={isDisabled}
       />


### PR DESCRIPTION
I was previously using this library for one of my projects. We used the "paginationServerOptions" prop to have our selected rows persist when switching between pages. However, this caused the selectAll checkbox to not be available. I have added a prop called "showSelectAllOverride". It allows the selectAll checkbox to be available once again. 

This is my first open source contribution so any feedback would be greatly appreciated! 