### PR TITLE
adds passAdjacentKeyFields option

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ When the breakpoint is reached the column will be hidden. These are the built-in
 | noTableHead | bool | no | false | hides the the sort columns and titles (TableHead) - this will obviously negate sorting |
 | persistTableHead | bool | no |  | Show the table head (columns) even when `progressPending` is true. Note that the `noTableHead` will always hide the table head (columns) even when using  `persistTableHead` |
 | direction | string | no | auto | Accepts: `ltr, rtl, or auto`. When set to `auto` (default), RDT will attempt to detect direction by checking the HTML and DIV tags. For cases where you need to force rtl, or ltr just set this option manually (i.e. SSR) |
+| passAdjacentKeyFields | bool | no | false | Adds `prevKeyField` and `nextKeyField` properties to the row object, containing the keyField value for the adjacent rows, if any |
 
 #### Row Selection
 

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -103,6 +103,7 @@ const DataTable = memo(({
   theme,
   customStyles,
   direction,
+  passAdjacentKeyFields,
 }) => {
   const initialState = {
     allSelected: false,
@@ -387,6 +388,12 @@ const DataTable = memo(({
                     const expanderDisabled = expandableRows
                       && expandableRowDisabled
                       && expandableRowDisabled(row);
+
+
+                    if ( passAdjacentKeyFields ) {
+                       row.prevKeyField = typeof(calculatedRows[i-1]) != "undefined" ? calculatedRows[i-1][keyField] : false;
+                       row.nextKeyField = typeof(calculatedRows[i+1]) != "undefined" ? calculatedRows[i+1][keyField] : false;
+                    }
 
                     return (
                       <TableRow


### PR DESCRIPTION
This can be used as a workaround to implement feature #669. Instead of passing adjacent rows, we optionally add prevKeyField and nextKeyField properties to the row object. This can then be used to display more details and cycle from one row to another