### PR TITLE
Switch sorting identifier to ID instead of selector

### DIFF
--- a/src/DataTable/TableCol.js
+++ b/src/DataTable/TableCol.js
@@ -63,14 +63,14 @@ const TableCol = memo(({
       let direction = sortDirection;
       // change sort direction only if sortColumn (currently selected column) is === the newly clicked column
       // otherwise, retain sort direction if the column is switched
-      if (sortColumn === column.selector) {
+      if (sortColumn === column.id) {
         direction = sortDirection === 'asc' ? 'desc' : 'asc';
       }
 
       dispatch({
         type: 'SORT_CHANGE',
         sortDirection: direction,
-        sortColumn: column.selector,
+        sortColumn: column.id,
         sortServer,
         selectedColumn: column,
         pagination,
@@ -101,7 +101,7 @@ const TableCol = memo(({
     </span>
   );
 
-  const sortActive = column.sortable && sortColumn === column.selector;
+  const sortActive = column.sortable && sortColumn === column.id;
   const nativeSortIconLeft = column.sortable && !sortIcon && !column.right;
   const nativeSortIconRight = column.sortable && !sortIcon && column.right;
   const customSortIconLeft = column.sortable && sortIcon && !column.right;
@@ -115,7 +115,7 @@ const TableCol = memo(({
     >
       {column.name && (
         <ColumnSortable
-          id={`column-${column.selector}`}
+          id={`column-${column.id}`}
           role="columnheader"
           tabIndex={0}
           className="rdt_TableCol_Sortable"

--- a/src/DataTable/__tests__/DataTable.test.js
+++ b/src/DataTable/__tests__/DataTable.test.js
@@ -14,7 +14,7 @@ jest.mock('shortid', () => {
 // eslint-disable-next-line arrow-body-style
 const dataMock = colProps => {
   return {
-    columns: [{ name: 'Test', selector: 'some.name', ...colProps }],
+    columns: [{ name: 'Test', id: 'some.name', selector: 'some.name', ...colProps }],
     data: [{ id: 1, some: { name: 'Apple' } }, { id: 2, some: { name: 'Zuchinni' } }],
   };
 };
@@ -398,7 +398,7 @@ describe('DataTable:RowClicks', () => {
       />,
     );
 
-    fireEvent.click(container.querySelector('div[id="cell-1-1"]'));
+    fireEvent.click(container.querySelector('div[id="cell-some.name-1"]'));
     expect(onRowClickedMock).not.toBeCalled();
   });
 
@@ -413,7 +413,7 @@ describe('DataTable:RowClicks', () => {
       />,
     );
 
-    fireEvent.click(container.querySelector('div[id="cell-1-1"]'));
+    fireEvent.click(container.querySelector('div[id="cell-some.name-1"]'));
     expect(onRowClickedMock).not.toBeCalled();
   });
 
@@ -428,7 +428,7 @@ describe('DataTable:RowClicks', () => {
       />,
     );
 
-    fireEvent.click(container.querySelector('div[id="cell-1-1"]'));
+    fireEvent.click(container.querySelector('div[id="cell-some.name-1"]'));
     expect(onRowDoubleClickedMock).not.toBeCalled();
   });
 
@@ -443,7 +443,7 @@ describe('DataTable:RowClicks', () => {
       />,
     );
 
-    fireEvent.click(container.querySelector('div[id="cell-1-1"]'));
+    fireEvent.click(container.querySelector('div[id="cell-some.name-1"]'));
     expect(onRowDoubleClickedMock).not.toBeCalled();
   });
 });

--- a/src/DataTable/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/DataTable/__tests__/__snapshots__/DataTable.test.js.snap
@@ -1275,7 +1275,7 @@ exports[`DataTable::Header should render without a header if noHeader is true 1`
           <div
             class="c10 c6 c11 rdt_TableCell"
             data-tag="allowRowEvents"
-            id="cell-1-1"
+            id="cell-some.name-1"
             role="gridcell"
           >
             <div
@@ -1293,7 +1293,7 @@ exports[`DataTable::Header should render without a header if noHeader is true 1`
           <div
             class="c10 c6 c11 rdt_TableCell"
             data-tag="allowRowEvents"
-            id="cell-1-2"
+            id="cell-some.name-2"
             role="gridcell"
           >
             <div
@@ -2038,7 +2038,7 @@ exports[`DataTable::Pagination should change the page position when using pagina
             <div
               class="c16 c12 c17 rdt_TableCell"
               data-tag="allowRowEvents"
-              id="cell-1-1"
+              id="cell-some.name-1"
               role="gridcell"
             >
               <div


### PR DESCRIPTION
In TableCol I switched it to identify sorted column by ID instead of selector, as per [this issue](https://github.com/jbetancur/react-data-table-component/issues/704).

Since selectors can often be functions, I also removed them from the ID of the column, substituting it for ID as well. That required me to make changes to the tests as well.