### PR TITLE
Added new prop persistCurrentPageOnSort for paginationServerOptions 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -152,6 +152,7 @@ export interface IDataTableProps<T = any> {
   paginationServerOptions?: {
     persistSelectedOnSort?: boolean;
     persistSelectedOnPageChange?: boolean;
+    persistCurrentPageOnSort?: boolean;
   };
   paginationDefaultPage?: number;
   paginationResetDefaultPage?: boolean;

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -125,7 +125,7 @@ const DataTable = memo(({
     selectedColumn,
     sortDirection,
   }, dispatch] = useReducer(tableReducer, initialState);
-  const { persistSelectedOnSort, persistSelectedOnPageChange } = paginationServerOptions;
+  const { persistSelectedOnSort, persistSelectedOnPageChange, persistCurrentPageOnSort } = paginationServerOptions;
   const mergeSelections = paginationServer && (persistSelectedOnPageChange || persistSelectedOnSort);
   const enabledPagination = pagination && !progressPending && data.length > 0;
   const Pagination = paginationComponent || NativePagination;
@@ -275,6 +275,7 @@ const DataTable = memo(({
     paginationIconNext,
     paginationIconPrevious,
     paginationComponentOptions,
+    persistCurrentPageOnSort,
     direction,
     mergeSelections,
   };

--- a/src/DataTable/TableCol.js
+++ b/src/DataTable/TableCol.js
@@ -52,7 +52,7 @@ const TableCol = memo(({
   column,
   sortIcon,
 }) => {
-  const { dispatch, pagination, paginationServer, sortColumn, sortDirection, sortServer, selectableRowsVisibleOnly, persistSelectedOnSort } = useTableContext();
+  const { dispatch, pagination, paginationServer, sortColumn, sortDirection, sortServer, selectableRowsVisibleOnly, persistSelectedOnSort, persistCurrentPageOnSort } = useTableContext();
 
   if (column.omit) {
     return null;
@@ -77,6 +77,7 @@ const TableCol = memo(({
         paginationServer,
         visibleOnly: selectableRowsVisibleOnly,
         persistSelectedOnSort,
+        persistCurrentPageOnSort,
       });
     }
   };

--- a/src/DataTable/propTypes.js
+++ b/src/DataTable/propTypes.js
@@ -119,6 +119,7 @@ export const propTypes = {
   paginationServerOptions: PropTypes.shape({
     persistSelectedOnSort: PropTypes.bool,
     persistSelectedOnPageChange: PropTypes.bool,
+    persistCurrentPageOnSort: PropTypes.bool,
   }),
   paginationDefaultPage: PropTypes.number,
   paginationResetDefaultPage: PropTypes.bool,
@@ -234,6 +235,7 @@ export const defaultProps = {
   paginationServerOptions: {
     persistSelectedOnSort: false,
     persistSelectedOnPageChange: false,
+    persistCurrentPageOnSort: false,
   },
   paginationDefaultPage: 1,
   paginationResetDefaultPage: false,

--- a/src/DataTable/tableReducer.js
+++ b/src/DataTable/tableReducer.js
@@ -73,15 +73,16 @@ export function tableReducer(state, action) {
     }
 
     case 'SORT_CHANGE': {
-      const { sortColumn, sortDirection, sortServer, selectedColumn, pagination, paginationServer, visibleOnly, persistSelectedOnSort } = action;
+      const { sortColumn, sortDirection, sortServer, selectedColumn, pagination, paginationServer, visibleOnly, persistSelectedOnSort, persistCurrentPageOnSort } = action;
       const clearSelectedOnSort = (pagination && paginationServer && !persistSelectedOnSort) || sortServer || visibleOnly;
+      const keepPage = pagination && paginationServer && persistCurrentPageOnSort;
 
       return {
         ...state,
         sortColumn,
         selectedColumn,
         sortDirection,
-        currentPage: 1,
+        currentPage: keepPage ? state.currentPage : 1,
         // when using server-side paging reset selected row counts when sorting
         ...clearSelectedOnSort && ({
           allSelected: false,


### PR DESCRIPTION
Added new prop persistCurrentPageOnSort for paginationServerOptions to keep currentPage on sort_change event.