### PR TITLE
Change table header to use sticky positioning

### DIFF
--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -328,7 +328,7 @@ const DataTable = memo(({
               </ProgressWrapper>
             )}
 
-            <Table disabled={disabled} className="rdt_Table" role="table">
+            <Table disabled={disabled} fixedHeader={fixedHeader} fixedHeaderScrollHeight={fixedHeaderScrollHeight} hasOffset={overflowY} offset={overflowYOffset}  className="rdt_Table" role="table">
               {showTableHead() && (
                 <TableHead className="rdt_TableHead" role="rowgroup">
                   <TableHeadRow

--- a/src/DataTable/Table.js
+++ b/src/DataTable/Table.js
@@ -13,6 +13,11 @@ const TableStyle = styled.div`
   width: 100%;
   height: 100%;
   max-width: 100%;
+  overflow-y: auto;
+  ${({ fixedHeader, hasOffset, offset, fixedHeaderScrollHeight }) => fixedHeader && css`
+    max-height: ${hasOffset ? `calc(${fixedHeaderScrollHeight} - ${offset})` : fixedHeaderScrollHeight};
+    -webkit-overflow-scrolling: touch;
+  `};
   ${props => props.disabled && disabled};
   ${props => props.theme.table.style};
 `;

--- a/src/DataTable/TableBody.js
+++ b/src/DataTable/TableBody.js
@@ -3,11 +3,6 @@ import styled, { css } from 'styled-components';
 const TableBody = styled.div`
   display: flex;
   flex-direction: column;
-  ${({ fixedHeader, hasOffset, offset, fixedHeaderScrollHeight }) => fixedHeader && css`
-    max-height: ${hasOffset ? `calc(${fixedHeaderScrollHeight} - ${offset})` : fixedHeaderScrollHeight};
-    overflow-y: scroll;
-    -webkit-overflow-scrolling: touch;
-  `};
 `;
 
 TableBody.defaultProps = {

--- a/src/DataTable/TableHead.js
+++ b/src/DataTable/TableHead.js
@@ -3,6 +3,10 @@ import styled from 'styled-components';
 const TableHead = styled.div`
   display: flex;
   text-align: left;
+  position: sticky;
+  top: 0;
+  background-color: rgb(255, 255, 255);
+  z-index: 2;
   ${props => props.theme.head.style};
 `;
 

--- a/src/DataTable/TableHeadRow.js
+++ b/src/DataTable/TableHeadRow.js
@@ -8,6 +8,7 @@ const TableHeadRow = styled.div`
   display: flex;
   align-items: stretch;
   width: 100%;
+  background-color: unset;
   ${props => props.theme.headRow.style};
   ${props => (props.dense && props.theme.headRow.denseStyle)};
   ${props => props.disabled && disabled};


### PR DESCRIPTION
I have changed the table header to use the position: sticky attribute as per [this issue ](https://github.com/jbetancur/react-data-table-component/issues/422)