### PR TITLE
Forcefully Enable Table Head Row Even No Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ When the breakpoint is reached the column will be hidden. These are the built-in
 | dense           | bool   | no | false | compacts the row height. can be overridden via theming `rows.denseHeight`. <br /><br />**Note** that if any custom elements exceed the dense height then the row will only compact to the tallest element any of your cells |
 | noTableHead | bool | no | false | hides the the sort columns and titles (TableHead) - this will obviously negate sorting |
 | persistTableHead | bool | no |  | Show the table head (columns) even when `progressPending` is true. <br /><br />**Note** that the `noTableHead` will always hide the table head (columns) even when using  `persistTableHead` |
+| forceEnableTableHeadRow | bool | no | false | Use the table head action/filters even when `progressPending` is true or records are zero.|
 | direction | string | no | auto | Accepts: `ltr, rtl, or auto`. When set to `auto` (default), RDT will attempt to detect direction by checking the HTML and DIV tags. For cases where you need to force rtl, or ltr just set this option manually (i.e. SSR) |
 
 #### Row Selection

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -336,7 +336,7 @@ const DataTable = memo(({
                     className="rdt_TableHeadRow"
                     role="row"
                     dense={dense}
-                    disabled={forceEnableTableHeadRow ? false : (progressPending || data.length === 0) }
+                    disabled={forceEnableTableHeadRow ? false : (progressPending || data.length === 0)}
                   >
                     {selectableRows && (
                       showSelectAll

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -66,6 +66,7 @@ const DataTable = memo(({
   overflowYOffset,
   progressPending,
   progressComponent,
+  forceEnableTableHeadRow,
   persistTableHead,
   noDataComponent,
   disabled,
@@ -335,7 +336,7 @@ const DataTable = memo(({
                     className="rdt_TableHeadRow"
                     role="row"
                     dense={dense}
-                    disabled={progressPending || data.length === 0}
+                    disabled={forceEnableTableHeadRow ? false : (progressPending || data.length === 0) }
                   >
                     {selectableRows && (
                       showSelectAll

--- a/src/DataTable/propTypes.js
+++ b/src/DataTable/propTypes.js
@@ -43,6 +43,7 @@ export const propTypes = {
     PropTypes.func,
   ]),
   persistTableHead: PropTypes.bool,
+  forceEnableTableHeadRow: PropTypes.bool,
   expandableRowsComponent: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
@@ -192,6 +193,7 @@ export const defaultProps = {
   progressPending: false,
   progressComponent: <div style={{ fontSize: '24px', fontWeight: 700, padding: '24px' }}>Loading...</div>,
   persistTableHead: false,
+  forceEnableTableHeadRow: false,
   expandableRowsComponent: <div style={{ padding: '24px' }}>Add a custom expander component. Use props.data for row data</div>,
   expandableIcon: {
     collapsed: <ExpanderCollapsedIcon />,

--- a/stories/DataTable/Basic/ForceEnableHeadRow.stories.js
+++ b/stories/DataTable/Basic/ForceEnableHeadRow.stories.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import DataTable from '../../../src/index';
+
+const columns = [
+  {
+    name: 'Title',
+    selector: 'title',
+    sortable: true,
+  },
+  {
+    name: 'Director',
+    selector: 'director',
+    sortable: true,
+  },
+  {
+    name: 'Year',
+    selector: 'year',
+    sortable: true,
+  },
+];
+
+const BasicHeaderWithNoData = () => (
+  <DataTable
+    title="Display Interactive Header When no Data"
+    columns={columns}
+    data={[]}
+    persistTableHead
+    forceEnableTableHeadRow
+  />
+);
+
+storiesOf('General', module)
+  .add('Persists Interactive Header When No Data', BasicHeaderWithNoData);


### PR DESCRIPTION
Currently, DataTable disables the header, When we apply some custom filters (filter option on the header column) and there is no data after filtering but we need to allow the user to interact with the header so the user can change the filter.