### PR TITLE
Fixed scrollbars appearing when they're not needed

### DIFF
--- a/src/DataTable/TableBody.js
+++ b/src/DataTable/TableBody.js
@@ -5,7 +5,7 @@ const TableBody = styled.div`
   flex-direction: column;
   ${({ fixedHeader, hasOffset, offset, fixedHeaderScrollHeight }) => fixedHeader && css`
     max-height: ${hasOffset ? `calc(${fixedHeaderScrollHeight} - ${offset})` : fixedHeaderScrollHeight};
-    overflow-y: scroll;
+    overflow-y: auto;
     -webkit-overflow-scrolling: touch;
   `};
 `;


### PR DESCRIPTION
When a table has `fixedHeader` enabled and not enough entries to fill it's `max-height`, a disabled scrollbar appears.
I fixed this by replacing `overflow-y: scroll` with `overflow-y: auto` so the scrollbar only appears when it's necessary.

I've tested a few other configurations to see if this change breaks anything,
I'm not aware of any negative impact this could have.
Please let me know if I missed anything.