### PR TITLE
Add onRowHovered event callback

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -93,6 +93,7 @@ function DataTable<T extends RowRecord>(props: TableProps<T>): JSX.Element {
 		expandableRows = defaultProps.expandableRows,
 		onRowClicked = defaultProps.onRowClicked,
 		onRowDoubleClicked = defaultProps.onRowDoubleClicked,
+		onRowHovered = defaultProps.onRowHovered,
 		sortIcon = defaultProps.sortIcon,
 		onSort = defaultProps.onSort,
 		sortFunction = defaultProps.sortFunction,
@@ -182,6 +183,8 @@ function DataTable<T extends RowRecord>(props: TableProps<T>): JSX.Element {
 	const handleRowClicked = React.useCallback((row, e) => onRowClicked(row, e), [onRowClicked]);
 
 	const handleRowDoubleClicked = React.useCallback((row, e) => onRowDoubleClicked(row, e), [onRowDoubleClicked]);
+
+	const handleRowHovered = React.useCallback((row, e) => onRowHovered(row, e), [onRowHovered]);
 
 	const handleChangePage = (page: number) =>
 		dispatch({
@@ -423,6 +426,7 @@ function DataTable<T extends RowRecord>(props: TableProps<T>): JSX.Element {
 											onRowExpandToggled={onRowExpandToggled}
 											onRowClicked={handleRowClicked}
 											onRowDoubleClicked={handleRowDoubleClicked}
+											onRowHovered={handleRowHovered}
 											onSelectedRow={handleSelectedRow}
 										/>
 									);

--- a/src/DataTable/TableRow.tsx
+++ b/src/DataTable/TableRow.tsx
@@ -61,6 +61,7 @@ type DProps<T> = Pick<
 	| 'keyField'
 	| 'onRowClicked'
 	| 'onRowDoubleClicked'
+	| 'onRowHovered'
 	| 'onRowExpandToggled'
 	| 'pointerOnHover'
 	| 'selectableRowDisabled'
@@ -100,6 +101,7 @@ function TableRow<T extends RowRecord>({
 	expandableInheritConditionalStyles,
 	keyField = defaultProps.keyField,
 	onRowClicked = noop,
+	onRowHovered = noop,
 	onRowDoubleClicked = noop,
 	onRowExpandToggled = noop,
 	onSelectedRow = noop,
@@ -154,6 +156,13 @@ function TableRow<T extends RowRecord>({
 		[defaultExpanderDisabled, expandOnRowDoubleClicked, expandableRows, handleExpanded, onRowDoubleClicked, row],
 	);
 
+	const handleRowHovered = React.useCallback(
+		e => {
+			onRowHovered(row, e);
+		},
+		[onRowHovered, row],
+	);
+
 	const extendedRowStyle = getConditionalStyle(row, conditionalRowStyles);
 	const hightlightSelected = selectableRowsHighlight && selected;
 	const inheritStyles = expandableInheritConditionalStyles ? extendedRowStyle : {};
@@ -170,6 +179,7 @@ function TableRow<T extends RowRecord>({
 				dense={dense}
 				onClick={handleRowClick}
 				onDoubleClick={handleRowDoubleClick}
+				onMouseEnter={handleRowHovered}
 				className="rdt_TableRow"
 				selected={hightlightSelected}
 				style={extendedRowStyle}

--- a/src/DataTable/__tests__/DataTable.test.tsx
+++ b/src/DataTable/__tests__/DataTable.test.tsx
@@ -307,6 +307,17 @@ describe('DataTable::columns', () => {
 	});
 });
 
+describe('DataTable:RowHover', () => {
+	test('should call onRowHovered callback when row is hoovered', () => {
+		const onRowHoveredMock = jest.fn();
+		const mock = dataMock({});
+		const { container } = render(<DataTable data={mock.data} columns={mock.columns} onRowHovered={onRowHoveredMock} />);
+
+		fireEvent.mouseEnter(container.querySelector('div.rdt_TableRow') as HTMLElement);
+		expect(onRowHoveredMock).toHaveBeenCalled();
+	});
+});
+
 describe('DataTable:RowClicks', () => {
 	test('should not call onRowClicked when ignoreRowClick = true', () => {
 		const onRowClickedMock = jest.fn();

--- a/src/DataTable/__tests__/DataTable.test.tsx
+++ b/src/DataTable/__tests__/DataTable.test.tsx
@@ -308,7 +308,7 @@ describe('DataTable::columns', () => {
 });
 
 describe('DataTable:RowHover', () => {
-	test('should call onRowHovered callback when row is hoovered', () => {
+	test('should call onRowHovered callback when row is hovered', () => {
 		const onRowHoveredMock = jest.fn();
 		const mock = dataMock({});
 		const { container } = render(<DataTable data={mock.data} columns={mock.columns} onRowHovered={onRowHoveredMock} />);

--- a/src/DataTable/defaultProps.tsx
+++ b/src/DataTable/defaultProps.tsx
@@ -91,6 +91,7 @@ export const defaultProps = {
 	onChangeRowsPerPage: noop,
 	onRowClicked: noop,
 	onRowDoubleClicked: noop,
+	onRowHovered: noop,
 	onRowExpandToggled: noop,
 	onSelectedRowsChange: noop,
 	onSort: noop,

--- a/src/DataTable/types.ts
+++ b/src/DataTable/types.ts
@@ -1,6 +1,5 @@
 import { Alignment, Direction, Media } from './constants';
 import { CSSObject } from 'styled-components';
-import React from 'react';
 
 export type ChangePage = (page: number, totalRows: number) => void;
 export type ChangeRowsPerPage = (currentRowsPerPage: number, currentPage: number) => void;

--- a/src/DataTable/types.ts
+++ b/src/DataTable/types.ts
@@ -1,5 +1,6 @@
 import { Alignment, Direction, Media } from './constants';
 import { CSSObject } from 'styled-components';
+import React from 'react';
 
 export type ChangePage = (page: number, totalRows: number) => void;
 export type ChangeRowsPerPage = (currentRowsPerPage: number, currentPage: number) => void;
@@ -52,6 +53,7 @@ export type TableProps<T = RowRecord> = {
 	onChangePage?: ChangePage;
 	onChangeRowsPerPage?: ChangeRowsPerPage;
 	onRowClicked?: (row: T, e: React.MouseEvent) => void;
+	onRowHovered?: (row: T, e: React.MouseEvent) => void;
 	onRowDoubleClicked?: (row: T, e: React.MouseEvent) => void;
 	onRowExpandToggled?: ExpandRowToggled<T>;
 	onSelectedRowsChange?: (selected: { allSelected: boolean; selectedCount: number; selectedRows: T[] }) => void;


### PR DESCRIPTION
This PR just adds a callback to allow actions to be taken when a row is hovered.

Our use-case was to prefetch data that that is normally requested when a user clicks on a row.