### PR TITLE
change hooks order execution when sorting

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -247,16 +247,16 @@ function DataTable<T extends RowRecord>(props: TableProps<T>): JSX.Element {
 	}, [selectedCount]);
 
 	useDidUpdateEffect(() => {
+		onSort(selectedColumn, sortDirection);
+	}, [selectedColumn, sortDirection]);
+
+	useDidUpdateEffect(() => {
 		onChangePage(currentPage, paginationTotalRows || rows.length);
 	}, [currentPage]);
 
 	useDidUpdateEffect(() => {
 		onChangeRowsPerPage(rowsPerPage, currentPage);
 	}, [rowsPerPage]);
-
-	useDidUpdateEffect(() => {
-		onSort(selectedColumn, sortDirection);
-	}, [selectedColumn, sortDirection]);
 
 	useDidUpdateEffect(() => {
 		handleChangePage(paginationDefaultPage);


### PR DESCRIPTION
When you sort and you are in some page, the sort action reset the currentPage to 1 always.
Right now I don't want to add some logic to keep the currentPage, but I prefer to know first the sorting and then the changePage event, otherwise I don't know if the changePage is triggered by the pagination or by the sort.

Changing the useDidUpdateEffect order resolves this.