### PR TITLE
Fixed typo by replacing `Selected` to `onSelectedRowsChange` in README.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,2 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=lf
-
-# Ignore any binary files
-* binary

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ class MyComponent extends Component {
           data={data}
           selectableRows // add for checkbox selection
           Clicked
-          Selected={handleChange}
+          onSelectedRowsChange={handleChange}
         />
     )
   }


### PR DESCRIPTION
I think `onSelectedRowsChange` is the correct property to use to access the selected rows (rather than `Selected`).

Also, I removed the `* binary` in .gitattributes since it was preventing me from seeing text file diffs. I think the `* binary` line was intended for .gitignore. When used in .gitattributes, it means all files get checked out as type binary and git doesn't show diffs for binary files.

