### PR TITLE
update README to remove XML declaration on ExpandableComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ class MyComponent extends Component {
         sortIcon={<FontIcon>arrow_downward</FontIcon>}
         onSelectedRowsChange={handleChange}
         expandableRows
-        expandableRowsComponent={<ExpandableComponent />}
+        expandableRowsComponent={ExpandableComponent}
       />
     )
   }
@@ -693,7 +693,7 @@ class MyComponent extends Component {
         onSelectedRowsChange={handleChange}
         expandableRows
         expandableRowDisabled={row => row.disabled}
-        expandableRowsComponent={<ExpandableComponent />}
+        expandableRowsComponent={ExpandableComponent}
       />
     )
   }


### PR DESCRIPTION
remove XML declaration on ExpandableComponent as document metioned that it must be passed as ExpandableComponent not <ExpandableComponent />