### PR TITLE
Make column name optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export interface IDataTableConditionalCellStyles<T = any> {
 
 export interface IDataTableColumn<T = any> {
   id?: string | number;
-  name: string | number | React.ReactNode;
+  name?: string | number | React.ReactNode;
   selector?: string | ((row: T, rowIndex: number) => React.ReactNode);
   sortable?: boolean;
   sortFunction?: (a: T, b: T) => number;


### PR DESCRIPTION
Make column name optional (as documented) so typescript projects don't demand this property