### PR TITLE
Fix typo in examples

### DIFF
--- a/stories/simpleExamples.stories.mdx
+++ b/stories/simpleExamples.stories.mdx
@@ -26,7 +26,7 @@ const data = [
   	{
 		id: 1,
 		title: 'Beetlejuice',
-		year: '1988',,
+		year: '1988',
 	},
 	{
 		id: 2,
@@ -69,7 +69,7 @@ const data = [
   	{
 		id: 1,
 		title: 'Beetlejuice',
-		year: '1988',,
+		year: '1988',
 	},
 	{
 		id: 2,
@@ -110,7 +110,7 @@ const data = [
   	{
 		id: 1,
 		title: 'Beetlejuice',
-		year: '1988',,
+		year: '1988',
 	},
 	{
 		id: 2,
@@ -155,7 +155,7 @@ const data = [
   	{
 		id: 1,
 		title: 'Beetlejuice',
-		year: '1988',,
+		year: '1988',
 	},
 	{
 		id: 2,


### PR DESCRIPTION
`,,` -> `,`