### PR TITLE
Update types.ts

### DIFF
--- a/src/DataTable/types.ts
+++ b/src/DataTable/types.ts
@@ -1,12 +1,12 @@
-import { Alignment, Direction, Media } from './constants';
 import { CSSObject } from 'styled-components';
+import { Alignment, Direction, Media } from './constants';
 
 export enum SortOrder {
 	ASC = 'asc',
 	DESC = 'desc',
 }
 
-export type Primitive = string | number | boolean | bigint;
+export type Primitive = string | number | boolean | bigint | null | undefined;
 export type ColumnSortFunction<T> = (a: T, b: T) => number;
 export type ExpandRowToggled<T> = (expanded: boolean, row: T) => void;
 export type Format<T> = (row: T, rowIndex: number) => React.ReactNode;

--- a/src/DataTable/util.ts
+++ b/src/DataTable/util.ts
@@ -1,5 +1,5 @@
 import { CSSObject } from 'styled-components';
-import { ConditionalStyles, TableColumn, Format, TableRow, Selector, SortOrder, SortFunction } from './types';
+import { ConditionalStyles, Format, Selector, SortFunction, SortOrder, TableColumn, TableRow } from './types';
 
 export function prop<T, K extends keyof T>(obj: T, key: K): T[K] {
 	return obj[key];
@@ -42,6 +42,14 @@ export function sort<T>(
 		}
 
 		if (direction === 'asc') {
+			if (aValue == null) {
+				return -1;
+			}
+
+			if (bValue == null) {
+				return 1;
+			}
+
 			if (aValue < bValue) {
 				return -1;
 			}
@@ -52,6 +60,14 @@ export function sort<T>(
 		}
 
 		if (direction === 'desc') {
+			if (aValue == null) {
+				return 1;
+			}
+
+			if (bValue == null) {
+				return -1;
+			}
+
 			if (aValue > bValue) {
 				return -1;
 			}


### PR DESCRIPTION
Since 7.4.0 (e0236e0b3e129859e1bc974db9f0be4e4f79d61f), Primitive type was introduced which didn't allow data to have optional/undefined fields or have null values in a typescript project. This PR addresses this issue.

EDIT: Had to add some logic to the sort function to handle undefined/null values.