### PR TITLE
Fix mistyping for attribute #954

### DIFF
--- a/stories/DataTable/selectableRows/preDisabled.mdx
+++ b/stories/DataTable/selectableRows/preDisabled.mdx
@@ -14,7 +14,7 @@ function MyComponent() {
       columns={columns}
       data={data}
       selectableRows
-      selectableRowSelected={rowDisabledCriteria}
+      selectableRowDisabled={rowDisabledCriteria}
     />
   );
 }


### PR DESCRIPTION
Correctly call the attribute to pre disable rows

Issue: Mistyping in Docs: Selectable/Pre Disabled Rows #954