### PR TITLE
Fix: Update pagination data in footer

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -307,7 +307,8 @@ function DataTable<T>(props: TableProps<T>): JSX.Element {
 
 	// When paginationPerPage value changes, update in reducer so it displays the correct values on footer
 	React.useEffect(() => {
-		handleChangeRowsPerPage(paginationPerPage)
+		handleChangeRowsPerPage(paginationPerPage);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [paginationPerPage]);
 
 	React.useEffect(() => {

--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -305,6 +305,11 @@ function DataTable<T>(props: TableProps<T>): JSX.Element {
 		dispatch({ type: 'CLEAR_SELECTED_ROWS', selectedRowsFlag: clearSelectedRows });
 	}, [selectableRowsSingle, clearSelectedRows]);
 
+	// When paginationPerPage value changes, update in reducer so it displays the correct values on footer
+	React.useEffect(() => {
+		handleChangeRowsPerPage(paginationPerPage)
+	}, [paginationPerPage]);
+
 	React.useEffect(() => {
 		if (!selectableRowSelected) {
 			return;


### PR DESCRIPTION
This PR fixes the issue #1030 by listening to the changes to the `paginationPerPage`'s value.