### PR TITLE
Fix a couple typos and wording in columns doc

### DIFF
--- a/stories/columns.stories.mdx
+++ b/stories/columns.stories.mdx
@@ -58,7 +58,7 @@ const columns = [
 
 # Column ID's
 
-Internally, `columns` require an `id` property. Particularly, if you use the `defaultSortFieldId` property and you want to defined a pre sorted columns by `id`. If you omit `id` from a column object RDT will auto genereate id's starting at 1, 2, 3 and so on... It is however recommended that you use your own `id`, which can be wither a `string` or a `number`.
+Internally, `columns` require an `id` property. Particularly, the `id` property is required if you use the `defaultSortFieldId` property and you want to define presorted columns by `id`. If you omit `id` from a column object, RDT will autogenerate `id` values starting at 1, 2, 3 and so on. It is, however, recommended that you use your own `id`, which can be either a `string` or a `number`.
 
 ```js
 const columns = [


### PR DESCRIPTION
I spotted a couple obvious typos, and tried to clean up the paragraph's wording a little while I was at it.