### PR TITLE
Adding className prop to ResponsiveWrapper

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -115,6 +115,7 @@ function DataTable<T>(props: TableProps<T>): JSX.Element {
 		customStyles = defaultProps.customStyles,
 		direction = defaultProps.direction,
 		onColumnOrderChange = defaultProps.onColumnOrderChange,
+		className,
 	} = props;
 
 	const {
@@ -361,6 +362,7 @@ function DataTable<T>(props: TableProps<T>): JSX.Element {
 				responsive={responsive}
 				fixedHeader={fixedHeader}
 				fixedHeaderScrollHeight={fixedHeaderScrollHeight}
+				className={className}
 				{...wrapperProps}
 			>
 				<Wrapper>


### PR DESCRIPTION
The className prop is defined in TableProps but it's not used in the table at all, which makes editing the style of the table via CSS requires wrapping the table with another wrapper. this is fixed by passing down the className that already exists on TableProps to ResponsiveWrapper.