### PR TITLE
Fix typo in pagination component options story

### DIFF
--- a/stories/DataTable/pagination/options.mdx
+++ b/stories/DataTable/pagination/options.mdx
@@ -7,7 +7,7 @@ import { Story, Canvas } from '@storybook/addon-docs';
 | Property              | Type    | Description                                           |
 | --------------------- | ------- | ----------------------------------------------------- |
 | noRowsPerPage         | boolean | hide the rows per page dropdown                       |
-| rowsPerPageText       | string  | chan ge the page per fors text                        |
+| rowsPerPageText       | string  | change the rows per page text                         |
 | rangeSeparatorText    | string  | change the seperator text e.g. 1 - 10 'of' 100 rows   |
 | selectAllRowsItem     | boolean | show 'All' as an option in the rows per page dropdown |
 | selectAllRowsItemText | string  | change the rows per page text                         |


### PR DESCRIPTION
## Fix typo in pagination component options story, rowsPerPageText prop description.

- Before fixing
![image](https://user-images.githubusercontent.com/41548444/223502370-fa0b70e8-a82d-4d27-9d30-e2790634b9ef.png)

- After fixing
![image](https://user-images.githubusercontent.com/41548444/223503087-29a9282a-333f-486b-8cc5-0794d724f110.png)

