### PR TITLE
Add `paginationComponentOptions.minWindowWidth` (defaults to `SMALL == 599`)

### DIFF
--- a/src/DataTable/Pagination.tsx
+++ b/src/DataTable/Pagination.tsx
@@ -95,7 +95,9 @@ function Pagination({
 }: PaginationProps): JSX.Element {
 	const windowSize = useWindowSize();
 	const isRTL = useRTL(direction);
-	const shouldShow = windowSize.width && windowSize.width > SMALL;
+	const { minWindowWidth = SMALL } = paginationComponentOptions;
+	const windowWidth = windowSize.width;
+	const shouldShow = !minWindowWidth || (windowWidth && windowWidth > minWindowWidth);
 	// const isRTL = detectRTL(direction);
 	const numPages = getNumberOfPages(rowCount, rowsPerPage);
 	const lastIndex = currentPage * rowsPerPage;

--- a/src/DataTable/types.ts
+++ b/src/DataTable/types.ts
@@ -218,6 +218,10 @@ export interface TableStyles {
 
 export interface PaginationOptions {
 	noRowsPerPage?: boolean;
+	// If non-null, the "rows per page" dropdown will be hidden when the window width is less than
+	// this value. SMALL == 599 is the default (if this property is undefined); pass `null` to always
+	// show the dropdown (useful for ensuring SSR matches client).
+	minWindowWidth?: number | null;
 	rowsPerPageText?: string;
 	rangeSeparatorText?: string;
 	selectAllRowsItem?: boolean;


### PR DESCRIPTION
## [Conditional rendering in `Pagination`](https://github.com/jbetancur/react-data-table-component/blob/v7.6.2/src/DataTable/Pagination.tsx#L98) causes SSR hydration errors in Next.js apps
- Repro repo [runsascoded/react-data-table-hydration-bug](https://github.com/runsascoded/react-data-table-hydration-bug)
- [Live demo](https://react-data-table-hydration-bug.runsascoded.com/) (refresh with different windows widths, dev console shows error iff  `window.innerWidth ≥ 599`).
- [Local dev mode](https://github.com/runsascoded/react-data-table-hydration-bug?tab=readme-ov-file#local-repro) gives more details:
  [![error](https://github.com/jbetancur/react-data-table-component/assets/465045/f94296d0-a1ce-4d40-9b7f-1430d9a7a56f)](https://github.com/runsascoded/react-data-table-hydration-bug/blob/main/public/error.gif)
- The same error is described by #649 and [this StackOverflow post](https://stackoverflow.com/q/75068071).

## Workaround / Fix
This PR adds the ability to pass `paginationComponentOptions={{ minWindowWidth: null }}` to `DataTable`, to always render the "rows per page" and "page range" parts of the pagination footer, which ensures server and client DOMs will match.