### PR TITLE
Add support for a footer row

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -1,37 +1,41 @@
 import * as React from 'react';
 import { ThemeProvider } from 'styled-components';
-import { tableReducer } from './tableReducer';
-import Table from './Table';
-import Head from './TableHead';
-import HeadRow from './TableHeadRow';
-import Row from './TableRow';
-import Column from './TableCol';
-import ColumnCheckbox from './TableColCheckbox';
-import Header from './TableHeader';
-import Subheader from './TableSubheader';
-import Body from './TableBody';
-import ResponsiveWrapper from './ResponsiveWrapper';
-import ProgressWrapper from './ProgressWrapper';
-import Wrapper from './TableWrapper';
-import ColumnExpander from './TableColExpander';
+import useColumns from '../hooks/useColumns';
+import useDidUpdateEffect from '../hooks/useDidUpdateEffect';
 import { CellBase } from './Cell';
 import NoData from './NoDataWrapper';
 import NativePagination from './Pagination';
-import useDidUpdateEffect from '../hooks/useDidUpdateEffect';
-import { prop, getNumberOfPages, sort, isEmpty, isRowSelected, recalculatePage } from './util';
+import ProgressWrapper from './ProgressWrapper';
+import ResponsiveWrapper from './ResponsiveWrapper';
+import Table from './Table';
+import Body from './TableBody';
+import Column from './TableCol';
+import ColumnCheckbox from './TableColCheckbox';
+import ColumnExpander from './TableColExpander';
+import Foot from './TableFoot';
+import FootRow from './TableFootRow';
+import TableFooterCell from './TableFooterCell';
+import Head from './TableHead';
+import HeadRow from './TableHeadRow';
+import Header from './TableHeader';
+import Row from './TableRow';
+import Subheader from './TableSubheader';
+import Wrapper from './TableWrapper';
 import { defaultProps } from './defaultProps';
 import { createStyles } from './styles';
+import { tableReducer } from './tableReducer';
 import {
 	Action,
 	AllRowsAction,
 	SingleRowAction,
-	TableRow,
 	SortAction,
-	TableProps,
-	TableState,
 	SortOrder,
+	TableProps,
+	TableRow,
+	TableState,
 } from './types';
-import useColumns from '../hooks/useColumns';
+import { getNumberOfPages, isEmpty, isRowSelected, prop, recalculatePage, sort } from './util';
+import { STOP_PROP_TAG } from './constants';
 
 function DataTable<T>(props: TableProps<T>): JSX.Element {
 	const {
@@ -81,6 +85,7 @@ function DataTable<T>(props: TableProps<T>): JSX.Element {
 		noHeader = defaultProps.noHeader,
 		fixedHeader = defaultProps.fixedHeader,
 		fixedHeaderScrollHeight = defaultProps.fixedHeaderScrollHeight,
+		showFooter = defaultProps.showFooter,
 		pagination = defaultProps.pagination,
 		subHeader = defaultProps.subHeader,
 		subHeaderAlign = defaultProps.subHeaderAlign,
@@ -278,6 +283,14 @@ function DataTable<T>(props: TableProps<T>): JSX.Element {
 		}
 
 		return false;
+	};
+
+	const showTableFoot = () => {
+		if (!showFooter) {
+			return false;
+		}
+
+		return sortedData.length > 0 && !progressPending;
 	};
 
 	// recalculate the pagination and currentPage if the rows length changes
@@ -488,6 +501,30 @@ function DataTable<T>(props: TableProps<T>): JSX.Element {
 									);
 								})}
 							</Body>
+						)}
+
+						{showTableFoot() && (
+							<Foot className="rdt_TableFoot" role="rowgroup">
+								<FootRow className="rdt_TableFootRow" role="row" $dense={dense}>
+									{selectableRows && <CellBase style={{ flex: '0 0 48px' }} />}
+									{showFooter &&
+										tableColumns.map(column => (
+											<TableFooterCell<T>
+												id={column.id as string}
+												key={column.id}
+												dataTag={column.ignoreRowClick || column.button ? null : STOP_PROP_TAG}
+												column={column}
+												rows={tableRows}
+												isDragging={false}
+												onDragStart={handleDragStart}
+												onDragOver={handleDragOver}
+												onDragEnd={handleDragEnd}
+												onDragEnter={handleDragEnter}
+												onDragLeave={handleDragLeave}
+											/>
+										))}
+								</FootRow>
+							</Foot>
 						)}
 					</Table>
 				</Wrapper>

--- a/src/DataTable/TableFoot.tsx
+++ b/src/DataTable/TableFoot.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const Foot = styled.div`
+	display: flex;
+	width: 100%;
+	${({ theme }) => theme.foot.style};
+`;
+
+export default Foot;

--- a/src/DataTable/TableFootRow.tsx
+++ b/src/DataTable/TableFootRow.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+const FootRow = styled.div<{
+	$dense?: boolean;
+}>`
+	display: flex;
+	align-items: stretch;
+	width: 100%;
+	${({ theme }) => theme.footRow.style};
+	${({ $dense, theme }) => $dense && theme.footRow.denseStyle};
+`;
+
+export default FootRow;

--- a/src/DataTable/TableFooterCell.tsx
+++ b/src/DataTable/TableFooterCell.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import styled, { css, CSSObject } from 'styled-components';
+import { CellExtended } from './Cell';
+import { getFooterProperty } from './util';
+import { TableColumn } from './types';
+
+interface FooterCellStyleProps {
+	$renderAsCell: boolean | undefined;
+	$wrapCell: boolean | undefined;
+	$allowOverflow: boolean | undefined;
+	$cellStyle: CSSObject | undefined;
+	$isDragging: boolean;
+}
+
+const overflowCSS = css<FooterCellStyleProps>`
+	div:first-child {
+		white-space: ${({ $wrapCell }) => ($wrapCell ? 'normal' : 'nowrap')};
+		overflow: ${({ $allowOverflow }) => ($allowOverflow ? 'visible' : 'hidden')};
+		text-overflow: ellipsis;
+	}
+`;
+
+const FooterCellStyle = styled(CellExtended).attrs(props => ({
+	style: props.style,
+}))<FooterCellStyleProps>`
+	${({ $renderAsCell }) => !$renderAsCell && overflowCSS};
+	${({ theme, $isDragging }) => $isDragging && theme.cells.draggingStyle};
+	${({ $cellStyle }) => $cellStyle};
+`;
+
+interface FooterCellProps<T> {
+	id: string;
+	dataTag: string | null;
+	column: TableColumn<T>;
+	rows: Array<T>;
+	isDragging: boolean;
+	onDragStart: (e: React.DragEvent<HTMLDivElement>) => void;
+	onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
+	onDragEnd: (e: React.DragEvent<HTMLDivElement>) => void;
+	onDragEnter: (e: React.DragEvent<HTMLDivElement>) => void;
+	onDragLeave: (e: React.DragEvent<HTMLDivElement>) => void;
+}
+
+function FooterCell<T>({
+	id,
+	column,
+	rows,
+	dataTag,
+	isDragging,
+	onDragStart,
+	onDragOver,
+	onDragEnd,
+	onDragEnter,
+	onDragLeave,
+}: FooterCellProps<T>): JSX.Element {
+	return (
+		<FooterCellStyle
+			id={id}
+			data-column-id={column.id}
+			role="cell"
+			className="rdt_TableFooterCell"
+			data-tag={dataTag}
+			$cellStyle={column.style}
+			$renderAsCell={!!column.cell}
+			$allowOverflow={column.allowOverflow}
+			button={column.button}
+			center={column.center}
+			compact={column.compact}
+			grow={column.grow}
+			hide={column.hide}
+			maxWidth={column.maxWidth}
+			minWidth={column.minWidth}
+			right={column.right}
+			width={column.width}
+			$wrapCell={column.wrap}
+			$isDragging={isDragging}
+			onDragStart={onDragStart}
+			onDragOver={onDragOver}
+			onDragEnd={onDragEnd}
+			onDragEnter={onDragEnter}
+			onDragLeave={onDragLeave}
+		>
+			<div data-tag={dataTag}>{getFooterProperty(rows, column.footerContent)}</div>
+		</FooterCellStyle>
+	);
+}
+
+export default React.memo(FooterCell) as typeof FooterCell;

--- a/src/DataTable/__tests__/DataTable.test.tsx
+++ b/src/DataTable/__tests__/DataTable.test.tsx
@@ -2178,6 +2178,24 @@ describe('DataTable::fixedHeader', () => {
 	});
 });
 
+describe('DataTable::footer', () => {
+	test('should render correctly when a footer is enabled', () => {
+		const mock = dataMock();
+		const { container } = render(<DataTable data={mock.data} columns={mock.columns} showFooter />);
+
+		expect(container.firstChild).toMatchSnapshot();
+	});
+
+	test('should render correctly when a footer is enabled and footer cells contain content', () => {
+		const mock = dataMock({
+			footerContent: () => `footer`,
+		});
+		const { container } = render(<DataTable data={mock.data} columns={mock.columns} showFooter />);
+
+		expect(container.firstChild).toMatchSnapshot();
+	});
+});
+
 describe('DataTable::striped', () => {
 	test('should render correctly when striped', () => {
 		const mock = dataMock();

--- a/src/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -1,37 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTable::Header header should not display with no title 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -61,6 +30,68 @@ exports[`DataTable::Header header should not display with no title 1`] = `
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -84,37 +115,6 @@ exports[`DataTable::Header header should not display with no title 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -784,37 +784,6 @@ exports[`DataTable::Header should render the default context menu when using sel
 `;
 
 exports[`DataTable::Header should render without a header if noHeader is true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -844,6 +813,68 @@ exports[`DataTable::Header should render without a header if noHeader is true 1`
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -867,37 +898,6 @@ exports[`DataTable::Header should render without a header if noHeader is true 1`
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -1080,37 +1080,6 @@ exports[`DataTable::Header title should render correctly 1`] = `
 `;
 
 exports[`DataTable::Pagination should change the page position when using paginationServer if the last item is removed from a page 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -1138,68 +1107,6 @@ exports[`DataTable::Pagination should change the page position when using pagina
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
-}
-
-.c12 div:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.c10 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
-  width: 100%;
-  box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-  min-height: 48px;
-}
-
-.c10:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
-}
-
-.c1 {
-  position: relative;
-  width: 100%;
-  display: table;
 }
 
 .c17 {
@@ -1320,6 +1227,99 @@ exports[`DataTable::Pagination should change the page position when using pagina
 
 .c15 {
   margin: 0 4px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c12 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c10 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c10:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+}
+
+.c1 {
+  position: relative;
+  width: 100%;
+  display: table;
 }
 
 @media screen and (max-width: 599px) {
@@ -1555,37 +1555,6 @@ exports[`DataTable::Pagination should change the page position when using pagina
 `;
 
 exports[`DataTable::Pagination should have the correct amount of rows when paging backward 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -1615,6 +1584,68 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -1638,37 +1669,6 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -1751,37 +1751,6 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
 `;
 
 exports[`DataTable::Pagination should have the correct amount of rows when paging backward to the first page 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -1811,6 +1780,68 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -1834,37 +1865,6 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -1947,37 +1947,6 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
 `;
 
 exports[`DataTable::Pagination should have the correct amount of rows when paging forward 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -2007,6 +1976,68 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -2030,37 +2061,6 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -2143,37 +2143,6 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
 `;
 
 exports[`DataTable::Pagination should have the correct amount of rows when paging to the last page 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -2203,6 +2172,68 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -2226,37 +2257,6 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -2339,37 +2339,6 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
 `;
 
 exports[`DataTable::Pagination should navigate to page 1 if the table is sorted 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -2399,29 +2368,30 @@ exports[`DataTable::Pagination should navigate to page 1 if the table is sorted 
   min-width: 100px;
 }
 
-.c13 div:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
 }
 
-.c11 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
-  width: 100%;
+.c2 {
+  position: relative;
   box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
-  min-height: 48px;
 }
 
-.c11:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
+.c10 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c9 {
@@ -2469,18 +2439,48 @@ exports[`DataTable::Pagination should navigate to page 1 if the table is sorted 
   text-overflow: ellipsis;
 }
 
-.c10 {
+.c3 {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c0 {
-  position: relative;
+.c4 {
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c13 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c11 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c11:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
 }
 
 .c1 {
@@ -2567,37 +2567,6 @@ exports[`DataTable::Pagination should navigate to page 1 if the table is sorted 
 `;
 
 exports[`DataTable::Pagination should recalculate pagination position if there is only 1 item and it is removed from the data 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -2627,6 +2596,68 @@ exports[`DataTable::Pagination should recalculate pagination position if there i
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -2650,37 +2681,6 @@ exports[`DataTable::Pagination should recalculate pagination position if there i
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -2763,37 +2763,6 @@ exports[`DataTable::Pagination should recalculate pagination position if there i
 `;
 
 exports[`DataTable::Pagination should render correctly if pagination is enabled 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -2823,6 +2792,68 @@ exports[`DataTable::Pagination should render correctly if pagination is enabled 
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -2846,37 +2877,6 @@ exports[`DataTable::Pagination should render correctly if pagination is enabled 
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -2978,37 +2978,6 @@ exports[`DataTable::Pagination should render correctly if pagination is enabled 
 `;
 
 exports[`DataTable::Pagination should render correctly when a paginationComponentOptions are passed 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -3038,6 +3007,68 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -3061,37 +3092,6 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -3193,37 +3193,6 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
 `;
 
 exports[`DataTable::Pagination should render correctly when a paginationComponentOptions selectAllRowsItem is true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -3253,6 +3222,68 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -3276,37 +3307,6 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -3408,37 +3408,6 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
 `;
 
 exports[`DataTable::Pagination should render correctly when a paginationComponentOptions selectAllRowsItem is true and selectAllRowsItemText is provided 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -3468,6 +3437,68 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -3491,37 +3522,6 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -3623,37 +3623,6 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
 `;
 
 exports[`DataTable::Pagination should render correctly when a paginationComponentOptions to hide the per page dropdown are passed 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -3683,6 +3652,68 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -3706,37 +3737,6 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -3838,37 +3838,6 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
 `;
 
 exports[`DataTable::Pagination should render correctly when paginationResetDefaultPage is toggled 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -3898,6 +3867,68 @@ exports[`DataTable::Pagination should render correctly when paginationResetDefau
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -3921,37 +3952,6 @@ exports[`DataTable::Pagination should render correctly when paginationResetDefau
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -4034,37 +4034,6 @@ exports[`DataTable::Pagination should render correctly when paginationResetDefau
 `;
 
 exports[`DataTable::Theming should render correctly when a custom style is applied 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -4094,6 +4063,68 @@ exports[`DataTable::Theming should render correctly when a custom style is appli
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -4117,37 +4148,6 @@ exports[`DataTable::Theming should render correctly when a custom style is appli
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -4245,37 +4245,6 @@ exports[`DataTable::Theming should render correctly when a custom style is appli
 `;
 
 exports[`DataTable::column.style should render correctly when a style is set on a column 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -4305,6 +4274,68 @@ exports[`DataTable::column.style should render correctly when a style is set on 
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 {
   background-color: rgba(63, 195, 128, 0.9);
 }
@@ -4332,37 +4363,6 @@ exports[`DataTable::column.style should render correctly when a style is set on 
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -4460,37 +4460,6 @@ exports[`DataTable::column.style should render correctly when a style is set on 
 `;
 
 exports[`DataTable::columns should render correctly if column.center 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -4521,6 +4490,68 @@ exports[`DataTable::columns should render correctly if column.center 1`] = `
   justify-content: center;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -4544,37 +4575,6 @@ exports[`DataTable::columns should render correctly if column.center 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -4672,37 +4672,6 @@ exports[`DataTable::columns should render correctly if column.center 1`] = `
 `;
 
 exports[`DataTable::columns should render correctly if column.hide is an integer 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -4732,6 +4701,68 @@ exports[`DataTable::columns should render correctly if column.hide is an integer
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -4755,37 +4786,6 @@ exports[`DataTable::columns should render correctly if column.hide is an integer
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -4892,37 +4892,6 @@ exports[`DataTable::columns should render correctly if column.hide is an integer
 `;
 
 exports[`DataTable::columns should render correctly if column.hide lg 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -4952,6 +4921,68 @@ exports[`DataTable::columns should render correctly if column.hide lg 1`] = `
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -4975,37 +5006,6 @@ exports[`DataTable::columns should render correctly if column.hide lg 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -5112,37 +5112,6 @@ exports[`DataTable::columns should render correctly if column.hide lg 1`] = `
 `;
 
 exports[`DataTable::columns should render correctly if column.hide md 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -5172,6 +5141,68 @@ exports[`DataTable::columns should render correctly if column.hide md 1`] = `
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -5195,37 +5226,6 @@ exports[`DataTable::columns should render correctly if column.hide md 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -5332,37 +5332,6 @@ exports[`DataTable::columns should render correctly if column.hide md 1`] = `
 `;
 
 exports[`DataTable::columns should render correctly if column.hide sm 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -5392,6 +5361,68 @@ exports[`DataTable::columns should render correctly if column.hide sm 1`] = `
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -5415,37 +5446,6 @@ exports[`DataTable::columns should render correctly if column.hide sm 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -5552,37 +5552,6 @@ exports[`DataTable::columns should render correctly if column.hide sm 1`] = `
 `;
 
 exports[`DataTable::columns should render correctly if column.maxWidth 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -5612,6 +5581,68 @@ exports[`DataTable::columns should render correctly if column.maxWidth 1`] = `
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -5635,37 +5666,6 @@ exports[`DataTable::columns should render correctly if column.maxWidth 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -5766,37 +5766,6 @@ exports[`DataTable::columns should render correctly if column.maxWidth 1`] = `
 `;
 
 exports[`DataTable::columns should render correctly if column.minWidth 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -5826,6 +5795,68 @@ exports[`DataTable::columns should render correctly if column.minWidth 1`] = `
   min-width: 200px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -5849,37 +5880,6 @@ exports[`DataTable::columns should render correctly if column.minWidth 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -5980,37 +5980,6 @@ exports[`DataTable::columns should render correctly if column.minWidth 1`] = `
 `;
 
 exports[`DataTable::columns should render correctly if column.omit is true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -6040,6 +6009,68 @@ exports[`DataTable::columns should render correctly if column.omit is true 1`] =
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -6063,37 +6094,6 @@ exports[`DataTable::columns should render correctly if column.omit is true 1`] =
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -6191,37 +6191,6 @@ exports[`DataTable::columns should render correctly if column.omit is true 1`] =
 `;
 
 exports[`DataTable::columns should render correctly if column.right 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -6252,6 +6221,68 @@ exports[`DataTable::columns should render correctly if column.right 1`] = `
   justify-content: flex-end;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -6275,37 +6306,6 @@ exports[`DataTable::columns should render correctly if column.right 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -6403,37 +6403,6 @@ exports[`DataTable::columns should render correctly if column.right 1`] = `
 `;
 
 exports[`DataTable::columns should render correctly if column.width 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -6465,6 +6434,68 @@ exports[`DataTable::columns should render correctly if column.width 1`] = `
   max-width: 200px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -6488,37 +6519,6 @@ exports[`DataTable::columns should render correctly if column.width 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -6619,37 +6619,6 @@ exports[`DataTable::columns should render correctly if column.width 1`] = `
 `;
 
 exports[`DataTable::columns should render correctly when column.allowOverflow = true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -6679,6 +6648,68 @@ exports[`DataTable::columns should render correctly when column.allowOverflow = 
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: visible;
@@ -6702,37 +6733,6 @@ exports[`DataTable::columns should render correctly when column.allowOverflow = 
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -6830,37 +6830,6 @@ exports[`DataTable::columns should render correctly when column.allowOverflow = 
 `;
 
 exports[`DataTable::columns should render correctly when column.button = true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -6892,29 +6861,30 @@ exports[`DataTable::columns should render correctly when column.button = true 1`
   padding: 0;
 }
 
-.c13 div:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
 }
 
-.c11 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
-  width: 100%;
+.c2 {
+  position: relative;
   box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
-  min-height: 48px;
 }
 
-.c11:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
+.c10 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c7 {
@@ -6938,18 +6908,48 @@ exports[`DataTable::columns should render correctly when column.button = true 1`
   text-overflow: ellipsis;
 }
 
-.c10 {
+.c3 {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c0 {
-  position: relative;
+.c4 {
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c13 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c11 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c11:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
 }
 
 .c1 {
@@ -7041,37 +7041,6 @@ exports[`DataTable::columns should render correctly when column.button = true 1`
 `;
 
 exports[`DataTable::columns should render correctly when column.cell is set to a component 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -7101,23 +7070,30 @@ exports[`DataTable::columns should render correctly when column.cell is set to a
   min-width: 100px;
 }
 
-.c10 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
+.c0 {
+  position: relative;
   width: 100%;
-  box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-  min-height: 48px;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
 }
 
-.c10:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c7 {
@@ -7137,18 +7113,42 @@ exports[`DataTable::columns should render correctly when column.cell is set to a
   text-overflow: ellipsis;
 }
 
-.c9 {
+.c3 {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c0 {
-  position: relative;
+.c4 {
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c10 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c10:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
 }
 
 .c1 {
@@ -7242,37 +7242,6 @@ exports[`DataTable::columns should render correctly when column.cell is set to a
 `;
 
 exports[`DataTable::columns should render correctly when column.compact = true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -7303,6 +7272,68 @@ exports[`DataTable::columns should render correctly when column.compact = true 1
   padding: 0;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -7326,37 +7357,6 @@ exports[`DataTable::columns should render correctly when column.compact = true 1
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -7454,37 +7454,6 @@ exports[`DataTable::columns should render correctly when column.compact = true 1
 `;
 
 exports[`DataTable::columns should render correctly when column.sortable = true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -7514,29 +7483,30 @@ exports[`DataTable::columns should render correctly when column.sortable = true 
   min-width: 100px;
 }
 
-.c13 div:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
 }
 
-.c11 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
-  width: 100%;
+.c2 {
+  position: relative;
   box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
-  min-height: 48px;
 }
 
-.c11:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
+.c10 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c9 {
@@ -7596,18 +7566,48 @@ exports[`DataTable::columns should render correctly when column.sortable = true 
   text-overflow: ellipsis;
 }
 
-.c10 {
+.c3 {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c0 {
-  position: relative;
+.c4 {
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c13 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c11 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c11:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
 }
 
 .c1 {
@@ -7709,37 +7709,6 @@ exports[`DataTable::columns should render correctly when column.sortable = true 
 `;
 
 exports[`DataTable::columns should render correctly when column.wrap = true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -7769,6 +7738,68 @@ exports[`DataTable::columns should render correctly when column.wrap = true 1`] 
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: normal;
   overflow: hidden;
@@ -7792,37 +7823,6 @@ exports[`DataTable::columns should render correctly when column.wrap = true 1`] 
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -7920,37 +7920,6 @@ exports[`DataTable::columns should render correctly when column.wrap = true 1`] 
 `;
 
 exports[`DataTable::columns should render correctly when ignoreRowClick = true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -7980,6 +7949,68 @@ exports[`DataTable::columns should render correctly when ignoreRowClick = true 1
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -8003,37 +8034,6 @@ exports[`DataTable::columns should render correctly when ignoreRowClick = true 1
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -8125,37 +8125,6 @@ exports[`DataTable::columns should render correctly when ignoreRowClick = true 1
 `;
 
 exports[`DataTable::columns should render correctly with columns/data 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -8185,6 +8154,68 @@ exports[`DataTable::columns should render correctly with columns/data 1`] = `
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -8208,37 +8239,6 @@ exports[`DataTable::columns should render correctly with columns/data 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -8336,37 +8336,6 @@ exports[`DataTable::columns should render correctly with columns/data 1`] = `
 `;
 
 exports[`DataTable::conditionalCellStyles should render correctly when conditionalCellStyles is defined and there is a match 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -8396,6 +8365,68 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -8419,37 +8450,6 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -8548,37 +8548,6 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
 `;
 
 exports[`DataTable::conditionalCellStyles should render correctly when conditionalCellStyles is defined and there is no match 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -8608,6 +8577,68 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -8631,37 +8662,6 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -8759,37 +8759,6 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
 `;
 
 exports[`DataTable::conditionalCellStyles should render correctly when conditionalCellStyles style is a function 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -8819,6 +8788,68 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -8842,37 +8873,6 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -8971,37 +8971,6 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
 `;
 
 exports[`DataTable::conditionalCellStyles should render correctly when conditionalCellStyles with classNames is defined and there is a match 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -9031,6 +9000,68 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -9054,37 +9085,6 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -9182,37 +9182,6 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
 `;
 
 exports[`DataTable::conditionalRowStyles should render correctly when conditionalRowStyles are an empty array 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -9242,6 +9211,68 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -9265,37 +9296,6 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -9393,37 +9393,6 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
 `;
 
 exports[`DataTable::conditionalRowStyles should render correctly when conditionalRowStyles is defined and there is a match 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -9451,6 +9420,68 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
 }
 
 .c12 div:first-child {
@@ -9501,37 +9532,6 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -9629,37 +9629,6 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
 `;
 
 exports[`DataTable::conditionalRowStyles should render correctly when conditionalRowStyles is defined and there is no match 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -9689,6 +9658,68 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -9712,37 +9743,6 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -9840,38 +9840,6 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
 `;
 
 exports[`DataTable::dense should render correctly when dense 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-  min-height: 32px;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -9901,6 +9869,69 @@ exports[`DataTable::dense should render correctly when dense 1`] = `
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+  min-height: 32px;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -9925,37 +9956,6 @@ exports[`DataTable::dense should render correctly when dense 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -10053,37 +10053,6 @@ exports[`DataTable::dense should render correctly when dense 1`] = `
 `;
 
 exports[`DataTable::direction should render correctly when direction is auto 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -10113,6 +10082,68 @@ exports[`DataTable::direction should render correctly when direction is auto 1`]
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -10136,37 +10167,6 @@ exports[`DataTable::direction should render correctly when direction is auto 1`]
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -10268,37 +10268,6 @@ exports[`DataTable::direction should render correctly when direction is auto 1`]
 `;
 
 exports[`DataTable::direction should render correctly when direction is ltr 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -10328,6 +10297,68 @@ exports[`DataTable::direction should render correctly when direction is ltr 1`] 
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -10351,37 +10382,6 @@ exports[`DataTable::direction should render correctly when direction is ltr 1`] 
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -10484,37 +10484,6 @@ exports[`DataTable::direction should render correctly when direction is ltr 1`] 
 `;
 
 exports[`DataTable::direction should render correctly when direction is rtl 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -10544,6 +10513,68 @@ exports[`DataTable::direction should render correctly when direction is rtl 1`] 
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -10567,37 +10598,6 @@ exports[`DataTable::direction should render correctly when direction is rtl 1`] 
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -10700,37 +10700,6 @@ exports[`DataTable::direction should render correctly when direction is rtl 1`] 
 `;
 
 exports[`DataTable::direction should render correctly when direction is rtl when using a context menu 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -10783,6 +10752,77 @@ exports[`DataTable::direction should render correctly when direction is rtl when
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c11 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c9 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c10 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c6 {
+  flex: 0 0 48px;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+  white-space: nowrap;
+  font-size: unset;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c16 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -10815,46 +10855,6 @@ exports[`DataTable::direction should render correctly when direction is rtl when
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c9 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c10 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c6 {
-  flex: 0 0 48px;
-  justify-content: center;
-  align-items: center;
-  user-select: none;
-  white-space: nowrap;
-  font-size: unset;
-}
-
-.c11 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -10983,37 +10983,6 @@ exports[`DataTable::direction should render correctly when direction is rtl when
 `;
 
 exports[`DataTable::expandableRows should expand a row if expandableRows is true and expandOnRowClicked is true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -11053,6 +11022,73 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c11 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c9 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c10 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c6 {
+  white-space: nowrap;
+  flex: 0 0 48px;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
 }
 
 .c16 div:first-child {
@@ -11136,46 +11172,10 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   cursor: pointer;
 }
 
-.c9 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c10 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c11 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
-}
-
 .c1 {
   position: relative;
   width: 100%;
   display: table;
-}
-
-.c6 {
-  white-space: nowrap;
-  flex: 0 0 48px;
 }
 
 <div
@@ -11337,37 +11337,6 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
 `;
 
 exports[`DataTable::expandableRows should expand a row if expandableRows is true and expandOnRowDoubleClicked is true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -11407,6 +11376,73 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c11 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c9 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c10 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c6 {
+  white-space: nowrap;
+  flex: 0 0 48px;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
 }
 
 .c16 div:first-child {
@@ -11490,46 +11526,10 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
   cursor: pointer;
 }
 
-.c9 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c10 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c11 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
-}
-
 .c1 {
   position: relative;
   width: 100%;
   display: table;
-}
-
-.c6 {
-  white-space: nowrap;
-  flex: 0 0 48px;
 }
 
 <div
@@ -11691,37 +11691,6 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
 `;
 
 exports[`DataTable::expandableRows should not expand a row if the expander row is disabled and expandOnRowClicked is true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -11761,6 +11730,73 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c11 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c9 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c10 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c6 {
+  white-space: nowrap;
+  flex: 0 0 48px;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
 }
 
 .c16 div:first-child {
@@ -11856,46 +11892,10 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
   cursor: pointer;
 }
 
-.c9 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c10 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c11 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
-}
-
 .c1 {
   position: relative;
   width: 100%;
   display: table;
-}
-
-.c6 {
-  white-space: nowrap;
-  flex: 0 0 48px;
 }
 
 <div
@@ -12047,37 +12047,6 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
 `;
 
 exports[`DataTable::expandableRows should not render expandableRows expandableRows is missing 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -12107,6 +12076,68 @@ exports[`DataTable::expandableRows should not render expandableRows expandableRo
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -12130,37 +12161,6 @@ exports[`DataTable::expandableRows should not render expandableRows expandableRo
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -12258,37 +12258,6 @@ exports[`DataTable::expandableRows should not render expandableRows expandableRo
 `;
 
 exports[`DataTable::expandableRows should render correctly when expandableRowExpanded changes on render 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c15 {
   position: relative;
   display: flex;
@@ -12341,6 +12310,77 @@ exports[`DataTable::expandableRows should render correctly when expandableRowExp
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c11 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c9 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c10 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c6 {
+  flex: 0 0 48px;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+  white-space: nowrap;
+  font-size: unset;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c16 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -12373,46 +12413,6 @@ exports[`DataTable::expandableRows should render correctly when expandableRowExp
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c9 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c10 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c6 {
-  flex: 0 0 48px;
-  justify-content: center;
-  align-items: center;
-  user-select: none;
-  white-space: nowrap;
-  font-size: unset;
-}
-
-.c11 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -12540,37 +12540,6 @@ exports[`DataTable::expandableRows should render correctly when expandableRowExp
 `;
 
 exports[`DataTable::expandableRows should render correctly when expandableRowExpanded is true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -12610,6 +12579,73 @@ exports[`DataTable::expandableRows should render correctly when expandableRowExp
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c11 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c9 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c10 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c6 {
+  white-space: nowrap;
+  flex: 0 0 48px;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
 }
 
 .c16 div:first-child {
@@ -12689,46 +12725,10 @@ exports[`DataTable::expandableRows should render correctly when expandableRowExp
   border-bottom-color: rgba(0,0,0,.12);
 }
 
-.c9 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c10 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c11 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
-}
-
 .c1 {
   position: relative;
   width: 100%;
   display: table;
-}
-
-.c6 {
-  white-space: nowrap;
-  flex: 0 0 48px;
 }
 
 <div
@@ -12890,37 +12890,6 @@ exports[`DataTable::expandableRows should render correctly when expandableRowExp
 `;
 
 exports[`DataTable::expandableRows should render correctly when expandableRows is true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -12960,6 +12929,73 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c11 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c9 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c10 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c6 {
+  white-space: nowrap;
+  flex: 0 0 48px;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
 }
 
 .c16 div:first-child {
@@ -13032,46 +13068,10 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   border-bottom-color: rgba(0,0,0,.12);
 }
 
-.c9 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c10 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c11 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
-}
-
 .c1 {
   position: relative;
   width: 100%;
   display: table;
-}
-
-.c6 {
-  white-space: nowrap;
-  flex: 0 0 48px;
 }
 
 <div
@@ -13222,37 +13222,6 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
 `;
 
 exports[`DataTable::expandableRows should render correctly when expandableRows is true and the row is toggled 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -13292,6 +13261,73 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c11 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c9 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c10 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c6 {
+  white-space: nowrap;
+  flex: 0 0 48px;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
 }
 
 .c16 div:first-child {
@@ -13371,46 +13407,10 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
   border-bottom-color: rgba(0,0,0,.12);
 }
 
-.c9 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c10 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c11 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
-}
-
 .c1 {
   position: relative;
   width: 100%;
   display: table;
-}
-
-.c6 {
-  white-space: nowrap;
-  flex: 0 0 48px;
 }
 
 <div
@@ -13572,37 +13572,6 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
 `;
 
 exports[`DataTable::expandableRows should render correctly when expandableRowsHideExpander is true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -13632,6 +13601,68 @@ exports[`DataTable::expandableRows should render correctly when expandableRowsHi
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -13655,37 +13686,6 @@ exports[`DataTable::expandableRows should render correctly when expandableRowsHi
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -13783,41 +13783,6 @@ exports[`DataTable::expandableRows should render correctly when expandableRowsHi
 `;
 
 exports[`DataTable::fixedHeader should render correctly when fixedHeader 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  position: sticky;
-  position: -webkit-sticky;
-  top: 0;
-  z-index: 1;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -13847,6 +13812,74 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader 1`] = `
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: auto;
+  min-height: 0;
+  max-height: 100vh;
+  -webkit-overflow-scrolling: touch;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  position: sticky;
+  position: -webkit-sticky;
+  top: 0;
+  z-index: 1;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -13870,39 +13903,6 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: auto;
-  min-height: 0;
-  max-height: 100vh;
-  -webkit-overflow-scrolling: touch;
 }
 
 .c1 {
@@ -14000,41 +14000,6 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader 1`] = `
 `;
 
 exports[`DataTable::fixedHeader should render correctly when fixedHeader and fixedHeaderScrollHeight 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  position: sticky;
-  position: -webkit-sticky;
-  top: 0;
-  z-index: 1;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -14064,6 +14029,74 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader and fix
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: auto;
+  min-height: 0;
+  max-height: 100px;
+  -webkit-overflow-scrolling: touch;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  position: sticky;
+  position: -webkit-sticky;
+  top: 0;
+  z-index: 1;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -14087,39 +14120,6 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader and fix
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: auto;
-  min-height: 0;
-  max-height: 100px;
-  -webkit-overflow-scrolling: touch;
 }
 
 .c1 {
@@ -14216,38 +14216,7 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader and fix
 </div>
 `;
 
-exports[`DataTable::highlightOnHover should render correctly when highlightOnHover 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
+exports[`DataTable::footer should render correctly when a footer is enabled 1`] = `
 .c5 {
   position: relative;
   display: flex;
@@ -14275,6 +14244,584 @@ exports[`DataTable::highlightOnHover should render correctly when highlightOnHov
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c13 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c14 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-top-width: 1px;
+  border-top-color: rgba(0,0,0,.12);
+  border-top-style: solid;
+}
+
+.c15 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c12 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c10 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c10:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+}
+
+.c1 {
+  position: relative;
+  width: 100%;
+  display: table;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2 rdt_Table"
+      role="table"
+    >
+      <div
+        class="c3 rdt_TableHead"
+        role="rowgroup"
+      >
+        <div
+          class="c4 rdt_TableHeadRow"
+          role="row"
+        >
+          <div
+            class="c5 c6 rdt_TableCol"
+            data-column-id="1"
+          >
+            <div
+              class="c7 rdt_TableCol_Sortable"
+              data-column-id="1"
+              data-sort-id="1"
+              disabled=""
+              role="columnheader"
+              tabindex="0"
+            >
+              <div
+                class="c8"
+                data-column-id="1"
+              >
+                Test
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="c9 rdt_TableBody"
+        role="rowgroup"
+      >
+        <div
+          class="c10 rdt_TableRow"
+          id="row-1"
+          role="row"
+        >
+          <div
+            class="c11 c6 c12 rdt_TableCell"
+            data-column-id="1"
+            data-tag="allowRowEvents"
+            id="cell-1-1"
+            role="cell"
+          >
+            <div
+              data-tag="allowRowEvents"
+            >
+              Apple
+            </div>
+          </div>
+        </div>
+        <div
+          class="c10 rdt_TableRow"
+          id="row-2"
+          role="row"
+        >
+          <div
+            class="c11 c6 c12 rdt_TableCell"
+            data-column-id="1"
+            data-tag="allowRowEvents"
+            id="cell-1-2"
+            role="cell"
+          >
+            <div
+              data-tag="allowRowEvents"
+            >
+              Zuchinni
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="c13 rdt_TableFoot"
+        role="rowgroup"
+      >
+        <div
+          class="c14 rdt_TableFootRow"
+          role="row"
+        >
+          <div
+            class="c11 c6 c15 rdt_TableFooterCell"
+            data-column-id="1"
+            data-tag="allowRowEvents"
+            id="1"
+            role="cell"
+          >
+            <div
+              data-tag="allowRowEvents"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataTable::footer should render correctly when a footer is enabled and footer cells contain content 1`] = `
+.c5 {
+  position: relative;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.c11 {
+  position: relative;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: 16px;
+  padding-right: 16px;
+  word-break: break-word;
+}
+
+.c6 {
+  flex-grow: 1;
+  flex-shrink: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c13 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c14 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-top-width: 1px;
+  border-top-color: rgba(0,0,0,.12);
+  border-top-style: solid;
+}
+
+.c15 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c12 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c10 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c10:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+}
+
+.c1 {
+  position: relative;
+  width: 100%;
+  display: table;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2 rdt_Table"
+      role="table"
+    >
+      <div
+        class="c3 rdt_TableHead"
+        role="rowgroup"
+      >
+        <div
+          class="c4 rdt_TableHeadRow"
+          role="row"
+        >
+          <div
+            class="c5 c6 rdt_TableCol"
+            data-column-id="1"
+          >
+            <div
+              class="c7 rdt_TableCol_Sortable"
+              data-column-id="1"
+              data-sort-id="1"
+              disabled=""
+              role="columnheader"
+              tabindex="0"
+            >
+              <div
+                class="c8"
+                data-column-id="1"
+              >
+                Test
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="c9 rdt_TableBody"
+        role="rowgroup"
+      >
+        <div
+          class="c10 rdt_TableRow"
+          id="row-1"
+          role="row"
+        >
+          <div
+            class="c11 c6 c12 rdt_TableCell"
+            data-column-id="1"
+            data-tag="allowRowEvents"
+            id="cell-1-1"
+            role="cell"
+          >
+            <div
+              data-tag="allowRowEvents"
+            >
+              Apple
+            </div>
+          </div>
+        </div>
+        <div
+          class="c10 rdt_TableRow"
+          id="row-2"
+          role="row"
+        >
+          <div
+            class="c11 c6 c12 rdt_TableCell"
+            data-column-id="1"
+            data-tag="allowRowEvents"
+            id="cell-1-2"
+            role="cell"
+          >
+            <div
+              data-tag="allowRowEvents"
+            >
+              Zuchinni
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="c13 rdt_TableFoot"
+        role="rowgroup"
+      >
+        <div
+          class="c14 rdt_TableFootRow"
+          role="row"
+        >
+          <div
+            class="c11 c6 c15 rdt_TableFooterCell"
+            data-column-id="1"
+            data-tag="allowRowEvents"
+            id="1"
+            role="cell"
+          >
+            <div
+              data-tag="allowRowEvents"
+            >
+              footer
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataTable::highlightOnHover should render correctly when highlightOnHover 1`] = `
+.c5 {
+  position: relative;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.c11 {
+  position: relative;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: 16px;
+  padding-right: 16px;
+  word-break: break-word;
+}
+
+.c6 {
+  flex-grow: 1;
+  flex-shrink: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
 }
 
 .c12 div:first-child {
@@ -14311,37 +14858,6 @@ exports[`DataTable::highlightOnHover should render correctly when highlightOnHov
   outline-style: solid;
   outline-width: 1px;
   outline-color: #FFFFFF;
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -14439,37 +14955,6 @@ exports[`DataTable::highlightOnHover should render correctly when highlightOnHov
 `;
 
 exports[`DataTable::pointerOnHover should render correctly when pointerOnHover 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -14499,6 +14984,68 @@ exports[`DataTable::pointerOnHover should render correctly when pointerOnHover 1
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -14526,37 +15073,6 @@ exports[`DataTable::pointerOnHover should render correctly when pointerOnHover 1
 
 .c10:hover {
   cursor: pointer;
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -14654,14 +15170,14 @@ exports[`DataTable::pointerOnHover should render correctly when pointerOnHover 1
 `;
 
 exports[`DataTable::progress/nodata should only show Loading if progressPending prop changes 1`] = `
-.c3 {
+.c2 {
   position: relative;
   box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
   width: 100%;
   height: 100%;
-  max-width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
 }
@@ -14675,14 +15191,14 @@ exports[`DataTable::progress/nodata should only show Loading if progressPending 
   min-height: 0;
 }
 
-.c2 {
+.c3 {
   position: relative;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
   width: 100%;
   height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
 }
@@ -14717,14 +15233,14 @@ exports[`DataTable::progress/nodata should only show Loading if progressPending 
 `;
 
 exports[`DataTable::progress/nodata should render correctly when a component is passed that is a react component 1`] = `
-.c3 {
+.c2 {
   position: relative;
   box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
   width: 100%;
   height: 100%;
-  max-width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
 }
@@ -14738,14 +15254,14 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
   min-height: 0;
 }
 
-.c2 {
+.c3 {
   position: relative;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
   width: 100%;
   height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
 }
@@ -14778,14 +15294,14 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
 `;
 
 exports[`DataTable::progress/nodata should render correctly when a component is passed that is a string 1`] = `
-.c3 {
+.c2 {
   position: relative;
   box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
   width: 100%;
   height: 100%;
-  max-width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
 }
@@ -14799,14 +15315,14 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
   min-height: 0;
 }
 
-.c2 {
+.c3 {
   position: relative;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
   width: 100%;
   height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
 }
@@ -14837,14 +15353,13 @@ exports[`DataTable::progress/nodata should render correctly when a component is 
 `;
 
 exports[`DataTable::progress/nodata should render correctly when progressPending is false and there are no row items 1`] = `
-.c2 {
-  position: relative;
+.c3 {
   box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
   width: 100%;
   height: 100%;
-  max-width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
 }
@@ -14858,21 +15373,22 @@ exports[`DataTable::progress/nodata should render correctly when progressPending
   min-height: 0;
 }
 
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
 .c1 {
   position: relative;
   width: 100%;
   display: table;
-}
-
-.c3 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
 }
 
 <div
@@ -14900,14 +15416,14 @@ exports[`DataTable::progress/nodata should render correctly when progressPending
 `;
 
 exports[`DataTable::progress/nodata should render correctly when progressPending is true 1`] = `
-.c3 {
+.c2 {
   position: relative;
   box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
   width: 100%;
   height: 100%;
-  max-width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
 }
@@ -14921,14 +15437,14 @@ exports[`DataTable::progress/nodata should render correctly when progressPending
   min-height: 0;
 }
 
-.c2 {
+.c3 {
   position: relative;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
   width: 100%;
   height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
 }
@@ -14963,14 +15479,14 @@ exports[`DataTable::progress/nodata should render correctly when progressPending
 `;
 
 exports[`DataTable::progress/nodata when noTableHead should only Loading if progressPending prop changes 1`] = `
-.c2 {
+.c3 {
   position: relative;
   box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
   width: 100%;
   height: 100%;
-  max-width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
 }
@@ -14984,14 +15500,14 @@ exports[`DataTable::progress/nodata when noTableHead should only Loading if prog
   min-height: 0;
 }
 
-.c3 {
+.c2 {
   position: relative;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
   width: 100%;
   height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
 }
@@ -15027,6 +15543,44 @@ exports[`DataTable::progress/nodata when noTableHead should only Loading if prog
 `;
 
 exports[`DataTable::progress/nodata when persistTableHead should disable TableHead if no data 1`] = `
+.c5 {
+  position: relative;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  line-height: normal;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.c6 {
+  flex-grow: 1;
+  flex-shrink: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
+}
+
+.c9 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
 .c2 {
   position: relative;
   box-sizing: border-box;
@@ -15037,6 +15591,23 @@ exports[`DataTable::progress/nodata when persistTableHead should disable TableHe
   max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .c3 {
@@ -15058,65 +15629,10 @@ exports[`DataTable::progress/nodata when persistTableHead should disable TableHe
   border-bottom-style: solid;
 }
 
-.c5 {
-  position: relative;
-  display: flex;
-  align-items: center;
-  box-sizing: border-box;
-  line-height: normal;
-  padding-left: 16px;
-  padding-right: 16px;
-}
-
-.c6 {
-  flex-grow: 1;
-  flex-shrink: 0;
-  flex-basis: 0;
-  max-width: 100%;
-  min-width: 100px;
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
-}
-
 .c1 {
   position: relative;
   width: 100%;
   display: table;
-}
-
-.c9 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
 }
 
 <div
@@ -15174,37 +15690,6 @@ exports[`DataTable::progress/nodata when persistTableHead should disable TableHe
 `;
 
 exports[`DataTable::progress/nodata when persistTableHead should disable TableHead if progressPending 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -15221,6 +15706,39 @@ exports[`DataTable::progress/nodata when persistTableHead should disable TableHe
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c9 {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
 }
 
 .c7 {
@@ -15240,25 +15758,23 @@ exports[`DataTable::progress/nodata when persistTableHead should disable TableHe
   text-overflow: ellipsis;
 }
 
-.c0 {
-  position: relative;
+.c3 {
+  display: flex;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c9 {
-  position: relative;
-  box-sizing: border-box;
-  width: 100%;
-  height: 100%;
+.c4 {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  color: rgba(0, 0, 0, 0.87);
+  align-items: stretch;
+  width: 100%;
   background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
 }
 
 .c1 {
@@ -15322,37 +15838,6 @@ exports[`DataTable::progress/nodata when persistTableHead should disable TableHe
 `;
 
 exports[`DataTable::progress/nodata when persistTableHead should only Loading and TableHead if progressPending prop changes 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -15369,6 +15854,39 @@ exports[`DataTable::progress/nodata when persistTableHead should only Loading an
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c9 {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
 }
 
 .c7 {
@@ -15388,25 +15906,23 @@ exports[`DataTable::progress/nodata when persistTableHead should only Loading an
   text-overflow: ellipsis;
 }
 
-.c0 {
-  position: relative;
+.c3 {
+  display: flex;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c9 {
-  position: relative;
-  box-sizing: border-box;
-  width: 100%;
-  height: 100%;
+.c4 {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  color: rgba(0, 0, 0, 0.87);
+  align-items: stretch;
+  width: 100%;
   background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
 }
 
 .c1 {
@@ -15470,37 +15986,6 @@ exports[`DataTable::progress/nodata when persistTableHead should only Loading an
 `;
 
 exports[`DataTable::responsive should render correctly responsive by default 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -15530,6 +16015,68 @@ exports[`DataTable::responsive should render correctly responsive by default 1`]
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -15553,37 +16100,6 @@ exports[`DataTable::responsive should render correctly responsive by default 1`]
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -15681,37 +16197,6 @@ exports[`DataTable::responsive should render correctly responsive by default 1`]
 `;
 
 exports[`DataTable::responsive should render correctly when responsive=false 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -15741,6 +16226,65 @@ exports[`DataTable::responsive should render correctly when responsive=false 1`]
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -15764,34 +16308,6 @@ exports[`DataTable::responsive should render correctly when responsive=false 1`]
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
 }
 
 .c1 {
@@ -15889,37 +16405,6 @@ exports[`DataTable::responsive should render correctly when responsive=false 1`]
 `;
 
 exports[`DataTable::selectableRows should not render a select all checkbox when selectableRowsNoSelectAll is true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -15961,6 +16446,68 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c10 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c8 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c9 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c14 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -15993,37 +16540,6 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c8 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c9 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c10 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -16145,37 +16661,6 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
 `;
 
 exports[`DataTable::selectableRows should render correctly when selectableRows is true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -16228,6 +16713,77 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c11 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c9 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c10 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c6 {
+  flex: 0 0 48px;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+  white-space: nowrap;
+  font-size: unset;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c16 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -16260,46 +16816,6 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c9 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c10 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c6 {
-  flex: 0 0 48px;
-  justify-content: center;
-  align-items: center;
-  user-select: none;
-  white-space: nowrap;
-  font-size: unset;
-}
-
-.c11 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -16427,37 +16943,6 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
 `;
 
 exports[`DataTable::selectableRows should render correctly when selectableRowsHighlight is true and a row is selected 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -16508,6 +16993,77 @@ exports[`DataTable::selectableRows should render correctly when selectableRowsHi
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c11 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c9 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c10 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c6 {
+  flex: 0 0 48px;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+  white-space: nowrap;
+  font-size: unset;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
 }
 
 .c16 div:first-child {
@@ -16567,46 +17123,6 @@ exports[`DataTable::selectableRows should render correctly when selectableRowsHi
   color: rgba(0, 0, 0, 0.87);
   background-color: #e3f2fd;
   border-bottom-color: #FFFFFF;
-}
-
-.c9 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c10 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c6 {
-  flex: 0 0 48px;
-  justify-content: center;
-  align-items: center;
-  user-select: none;
-  white-space: nowrap;
-  font-size: unset;
-}
-
-.c11 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -16734,37 +17250,6 @@ exports[`DataTable::selectableRows should render correctly when selectableRowsHi
 `;
 
 exports[`DataTable::sorting a custom column sorting function is used 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -16794,29 +17279,30 @@ exports[`DataTable::sorting a custom column sorting function is used 1`] = `
   min-width: 100px;
 }
 
-.c13 div:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
 }
 
-.c11 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
-  width: 100%;
+.c2 {
+  position: relative;
   box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
-  min-height: 48px;
 }
 
-.c11:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
+.c10 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c9 {
@@ -16864,18 +17350,48 @@ exports[`DataTable::sorting a custom column sorting function is used 1`] = `
   text-overflow: ellipsis;
 }
 
-.c10 {
+.c3 {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c0 {
-  position: relative;
+.c4 {
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c13 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c11 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c11:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
 }
 
 .c1 {
@@ -16977,37 +17493,6 @@ exports[`DataTable::sorting a custom column sorting function is used 1`] = `
 `;
 
 exports[`DataTable::sorting should render correctly and bypass internal sort when sortServer = true and asc sort 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -17037,29 +17522,30 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
   min-width: 100px;
 }
 
-.c13 div:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
 }
 
-.c11 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
-  width: 100%;
+.c2 {
+  position: relative;
   box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
-  min-height: 48px;
 }
 
-.c11:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
+.c10 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c9 {
@@ -17107,18 +17593,48 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
   text-overflow: ellipsis;
 }
 
-.c10 {
+.c3 {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c0 {
-  position: relative;
+.c4 {
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c13 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c11 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c11:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
 }
 
 .c1 {
@@ -17220,37 +17736,6 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
 `;
 
 exports[`DataTable::sorting should render correctly and bypass internal sort when sortServer = true and desc sort 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -17280,29 +17765,30 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
   min-width: 100px;
 }
 
-.c13 div:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
 }
 
-.c11 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
-  width: 100%;
+.c2 {
+  position: relative;
   box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
-  min-height: 48px;
 }
 
-.c11:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
+.c10 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c9 {
@@ -17350,18 +17836,48 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
   text-overflow: ellipsis;
 }
 
-.c10 {
+.c3 {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c0 {
-  position: relative;
+.c4 {
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c13 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c11 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c11:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
 }
 
 .c1 {
@@ -17463,37 +17979,6 @@ exports[`DataTable::sorting should render correctly and bypass internal sort whe
 `;
 
 exports[`DataTable::sorting should render correctly and not be sorted when a column.sort === false 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -17523,6 +18008,68 @@ exports[`DataTable::sorting should render correctly and not be sorted when a col
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -17546,37 +18093,6 @@ exports[`DataTable::sorting should render correctly and not be sorted when a col
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -17674,37 +18190,6 @@ exports[`DataTable::sorting should render correctly and not be sorted when a col
 `;
 
 exports[`DataTable::sorting should render correctly when a column is sorted from asc to desc 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -17734,29 +18219,30 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
   min-width: 100px;
 }
 
-.c13 div:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
 }
 
-.c11 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
-  width: 100%;
+.c2 {
+  position: relative;
   box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
-  min-height: 48px;
 }
 
-.c11:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
+.c10 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c9 {
@@ -17804,18 +18290,48 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
   text-overflow: ellipsis;
 }
 
-.c10 {
+.c3 {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c0 {
-  position: relative;
+.c4 {
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c13 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c11 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c11:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
 }
 
 .c1 {
@@ -17917,37 +18433,6 @@ exports[`DataTable::sorting should render correctly when a column is sorted from
 `;
 
 exports[`DataTable::sorting should render correctly when a column is sorted in default asc 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -17977,29 +18462,30 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
   min-width: 100px;
 }
 
-.c13 div:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
 }
 
-.c11 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
-  width: 100%;
+.c2 {
+  position: relative;
   box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
-  min-height: 48px;
 }
 
-.c11:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
+.c10 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c9 {
@@ -18047,18 +18533,48 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
   text-overflow: ellipsis;
 }
 
-.c10 {
+.c3 {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c0 {
-  position: relative;
+.c4 {
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c13 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c11 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c11:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
 }
 
 .c1 {
@@ -18160,37 +18676,6 @@ exports[`DataTable::sorting should render correctly when a column is sorted in d
 `;
 
 exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -18220,29 +18705,30 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
   min-width: 100px;
 }
 
-.c12 div:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
 }
 
-.c10 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
-  width: 100%;
+.c2 {
+  position: relative;
   box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
-  min-height: 48px;
 }
 
-.c10:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
+.c9 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c7 {
@@ -18294,18 +18780,48 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
   text-overflow: ellipsis;
 }
 
-.c9 {
+.c3 {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c0 {
-  position: relative;
+.c4 {
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c12 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c10 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c10:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
 }
 
 .c1 {
@@ -18409,37 +18925,6 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon 1`] =
 `;
 
 exports[`DataTable::sorting should render correctly with a custom sortIcon and column.right = true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -18470,29 +18955,30 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon and c
   justify-content: flex-end;
 }
 
-.c12 div:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
 }
 
-.c10 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
-  width: 100%;
+.c2 {
+  position: relative;
   box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
-  min-height: 48px;
 }
 
-.c10:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
+.c9 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c7 {
@@ -18544,18 +19030,48 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon and c
   text-overflow: ellipsis;
 }
 
-.c9 {
+.c3 {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c0 {
-  position: relative;
+.c4 {
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c12 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c10 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c10:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
 }
 
 .c1 {
@@ -18659,37 +19175,6 @@ exports[`DataTable::sorting should render correctly with a custom sortIcon and c
 `;
 
 exports[`DataTable::sorting should render correctly with a default sort field and the icon to the right when column.right = true and the native sort icon 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -18720,29 +19205,30 @@ exports[`DataTable::sorting should render correctly with a default sort field an
   justify-content: flex-end;
 }
 
-.c13 div:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
 }
 
-.c11 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
-  width: 100%;
+.c2 {
+  position: relative;
   box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
-  min-height: 48px;
 }
 
-.c11:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
+.c10 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c8 {
@@ -18802,18 +19288,48 @@ exports[`DataTable::sorting should render correctly with a default sort field an
   text-overflow: ellipsis;
 }
 
-.c10 {
+.c3 {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c0 {
-  position: relative;
+.c4 {
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c13 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c11 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c11:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
 }
 
 .c1 {
@@ -18915,37 +19431,6 @@ exports[`DataTable::sorting should render correctly with a default sort field an
 `;
 
 exports[`DataTable::sorting should render correctly with a default sort field and the native sort icon 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -18975,29 +19460,30 @@ exports[`DataTable::sorting should render correctly with a default sort field an
   min-width: 100px;
 }
 
-.c13 div:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
 }
 
-.c11 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
-  width: 100%;
+.c2 {
+  position: relative;
   box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
-  min-height: 48px;
 }
 
-.c11:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
+.c10 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c9 {
@@ -19057,18 +19543,48 @@ exports[`DataTable::sorting should render correctly with a default sort field an
   text-overflow: ellipsis;
 }
 
-.c10 {
+.c3 {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c0 {
-  position: relative;
+.c4 {
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c13 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c11 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c11:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
 }
 
 .c1 {
@@ -19170,37 +19686,6 @@ exports[`DataTable::sorting should render correctly with a default sort field an
 `;
 
 exports[`DataTable::sorting should render correctly with a defaultSortAsc = false 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -19230,29 +19715,30 @@ exports[`DataTable::sorting should render correctly with a defaultSortAsc = fals
   min-width: 100px;
 }
 
-.c13 div:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
 }
 
-.c11 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
-  width: 100%;
+.c2 {
+  position: relative;
   box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
-  min-height: 48px;
 }
 
-.c11:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
+.c10 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c9 {
@@ -19313,18 +19799,48 @@ exports[`DataTable::sorting should render correctly with a defaultSortAsc = fals
   text-overflow: ellipsis;
 }
 
-.c10 {
+.c3 {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c0 {
-  position: relative;
+.c4 {
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c13 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c11 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c11:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
 }
 
 .c1 {
@@ -19426,37 +19942,6 @@ exports[`DataTable::sorting should render correctly with a defaultSortAsc = fals
 `;
 
 exports[`DataTable::sorting should sort if the column is selected and the Enter key is pressed 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -19486,29 +19971,30 @@ exports[`DataTable::sorting should sort if the column is selected and the Enter 
   min-width: 100px;
 }
 
-.c13 div:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
 }
 
-.c11 {
-  display: flex;
-  align-items: stretch;
-  align-content: stretch;
-  width: 100%;
+.c2 {
+  position: relative;
   box-sizing: border-box;
-  font-size: 13px;
-  font-weight: 400;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
-  min-height: 48px;
 }
 
-.c11:not(:last-of-type) {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
+.c10 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c9 {
@@ -19557,18 +20043,48 @@ exports[`DataTable::sorting should sort if the column is selected and the Enter 
   text-overflow: ellipsis;
 }
 
-.c10 {
+.c3 {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.c0 {
-  position: relative;
+.c4 {
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
+.c13 div:first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c11 {
+  display: flex;
+  align-items: stretch;
+  align-content: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  min-height: 48px;
+}
+
+.c11:not(:last-of-type) {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
 }
 
 .c1 {
@@ -19670,37 +20186,6 @@ exports[`DataTable::sorting should sort if the column is selected and the Enter 
 `;
 
 exports[`DataTable::striped should render correctly when striped 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -19728,6 +20213,68 @@ exports[`DataTable::striped should render correctly when striped 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
 }
 
 .c12 div:first-child {
@@ -19774,37 +20321,6 @@ exports[`DataTable::striped should render correctly when striped 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -20017,37 +20533,6 @@ exports[`DataTable::subHeader should render when subHeaderWrap is false 1`] = `
 `;
 
 exports[`data prop changes should update state if the data prop changes 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -20077,6 +20562,68 @@ exports[`data prop changes should update state if the data prop changes 1`] = `
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -20100,37 +20647,6 @@ exports[`data prop changes should update state if the data prop changes 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -20209,18 +20725,6 @@ exports[`data prop changes should update state if the data prop changes 1`] = `
 `;
 
 exports[`should not show the TableHead when noTableHead is true 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -20238,6 +20742,32 @@ exports[`should not show the TableHead when noTableHead is true 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c3 {
+  display: flex;
+  flex-direction: column;
 }
 
 .c7 div:first-child {
@@ -20263,20 +20793,6 @@ exports[`should not show the TableHead when noTableHead is true 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c3 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -20344,14 +20860,13 @@ exports[`should not show the TableHead when noTableHead is true 1`] = `
 `;
 
 exports[`should render and empty table correctly 1`] = `
-.c2 {
-  position: relative;
+.c3 {
   box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
   width: 100%;
   height: 100%;
-  max-width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
 }
@@ -20365,21 +20880,22 @@ exports[`should render and empty table correctly 1`] = `
   min-height: 0;
 }
 
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
 .c1 {
   position: relative;
   width: 100%;
   display: table;
-}
-
-.c3 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
 }
 
 <div
@@ -20407,37 +20923,6 @@ exports[`should render and empty table correctly 1`] = `
 `;
 
 exports[`should render correctly when conditionalRowStyles is used with an expandableRows an expandableInheritConditionalStyles 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -20477,6 +20962,73 @@ exports[`should render correctly when conditionalRowStyles is used with an expan
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c11 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c9 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c10 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c6 {
+  white-space: nowrap;
+  flex: 0 0 48px;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
 }
 
 .c16 div:first-child {
@@ -20587,46 +21139,10 @@ exports[`should render correctly when conditionalRowStyles is used with an expan
   border-bottom-color: rgba(0,0,0,.12);
 }
 
-.c9 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c10 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c11 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
-}
-
 .c1 {
   position: relative;
   width: 100%;
   display: table;
-}
-
-.c6 {
-  white-space: nowrap;
-  flex: 0 0 48px;
 }
 
 <div
@@ -20788,37 +21304,6 @@ exports[`should render correctly when conditionalRowStyles is used with an expan
 `;
 
 exports[`should render correctly when conditionalRowStyles is used with an expandableRows an expandableInheritConditionalStyles with classNames instead of style 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -20858,6 +21343,73 @@ exports[`should render correctly when conditionalRowStyles is used with an expan
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c11 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c9 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c10 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c6 {
+  white-space: nowrap;
+  flex: 0 0 48px;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
 }
 
 .c16 div:first-child {
@@ -20937,46 +21489,10 @@ exports[`should render correctly when conditionalRowStyles is used with an expan
   border-bottom-color: rgba(0,0,0,.12);
 }
 
-.c9 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c10 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c11 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
-}
-
 .c1 {
   position: relative;
   width: 100%;
   display: table;
-}
-
-.c6 {
-  white-space: nowrap;
-  flex: 0 0 48px;
 }
 
 <div
@@ -21138,37 +21654,6 @@ exports[`should render correctly when conditionalRowStyles is used with an expan
 `;
 
 exports[`should render correctly when conditionalRowStyles with classNames is used and there is a match 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -21198,6 +21683,68 @@ exports[`should render correctly when conditionalRowStyles with classNames is us
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -21221,37 +21768,6 @@ exports[`should render correctly when conditionalRowStyles with classNames is us
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -21349,39 +21865,6 @@ exports[`should render correctly when conditionalRowStyles with classNames is us
 `;
 
 exports[`should render correctly when disabled 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  pointer-events: none;
-  opacity: 0.4;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -21411,6 +21894,70 @@ exports[`should render correctly when disabled 1`] = `
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  pointer-events: none;
+  opacity: 0.4;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -21434,37 +21981,6 @@ exports[`should render correctly when disabled 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -21563,37 +22079,6 @@ exports[`should render correctly when disabled 1`] = `
 `;
 
 exports[`should render the correctly when using selector function 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -21623,6 +22108,68 @@ exports[`should render the correctly when using selector function 1`] = `
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -21646,37 +22193,6 @@ exports[`should render the correctly when using selector function 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {
@@ -21755,37 +22271,6 @@ exports[`should render the correctly when using selector function 1`] = `
 `;
 
 exports[`should render the correctly when using selector function and a format function 1`] = `
-.c2 {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #FFFFFF;
-}
-
-.c3 {
-  display: flex;
-  width: 100%;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.c4 {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  background-color: #FFFFFF;
-  min-height: 52px;
-  border-bottom-width: 1px;
-  border-bottom-color: rgba(0,0,0,.12);
-  border-bottom-style: solid;
-}
-
 .c5 {
   position: relative;
   display: flex;
@@ -21815,6 +22300,68 @@ exports[`should render the correctly when using selector function and a format f
   min-width: 100px;
 }
 
+.c0 {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.c2 {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+}
+
+.c9 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: inherit;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.c8 {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  display: flex;
+  width: 100%;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c4 {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background-color: #FFFFFF;
+  min-height: 52px;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0,0,0,.12);
+  border-bottom-style: solid;
+}
+
 .c12 div:first-child {
   white-space: nowrap;
   overflow: hidden;
@@ -21838,37 +22385,6 @@ exports[`should render the correctly when using selector function and a format f
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: rgba(0,0,0,.12);
-}
-
-.c7 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: inherit;
-  height: 100%;
-  width: 100%;
-  outline: none;
-  user-select: none;
-  overflow: hidden;
-}
-
-.c8 {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: inherit;
-  overflow-x: auto;
-  overflow-y: hidden;
-  min-height: 0;
 }
 
 .c1 {

--- a/src/DataTable/defaultProps.tsx
+++ b/src/DataTable/defaultProps.tsx
@@ -70,6 +70,7 @@ export const defaultProps = {
 	subHeaderComponent: null,
 	fixedHeader: false,
 	fixedHeaderScrollHeight: '100vh',
+	showFooter: false,
 	pagination: false,
 	paginationServer: false,
 	paginationServerOptions: {

--- a/src/DataTable/styles.ts
+++ b/src/DataTable/styles.ts
@@ -164,6 +164,25 @@ export const defaultStyles = (theme: Theme): TableStyles => ({
 			},
 		},
 	},
+	foot: {
+		style: {
+			color: theme.text.primary,
+			fontSize: '12px',
+			fontWeight: 500,
+		},
+	},
+	footRow: {
+		style: {
+			backgroundColor: theme.background.default,
+			minHeight: '52px',
+			borderTopWidth: '1px',
+			borderTopColor: theme.divider.default,
+			borderTopStyle: 'solid',
+		},
+		denseStyle: {
+			minHeight: '32px',
+		},
+	},
 	pagination: {
 		style: {
 			color: theme.text.secondary,

--- a/src/DataTable/types.ts
+++ b/src/DataTable/types.ts
@@ -12,6 +12,7 @@ export type ExpandRowToggled<T> = (expanded: boolean, row: T) => void;
 export type Format<T> = (row: T, rowIndex: number) => React.ReactNode;
 export type RowState<T> = ((row: T) => boolean) | null;
 export type Selector<T> = (row: T, rowIndex?: number) => Primitive;
+export type FooterContent<T> = (rows: T[]) => Primitive;
 export type SortFunction<T> = (rows: T[], field: Selector<T>, sortDirection: SortOrder) => T[];
 export type TableRow = Record<string, unknown>;
 export type ComponentProps = Record<string, unknown>;
@@ -62,6 +63,7 @@ export type TableProps<T> = {
 	noDataComponent?: React.ReactNode;
 	noHeader?: boolean;
 	noTableHead?: boolean;
+	showFooter?: boolean;
 	onChangePage?: PaginationChangePage;
 	onChangeRowsPerPage?: PaginationChangeRowsPerPage;
 	onRowClicked?: (row: T, e: React.MouseEvent) => void;
@@ -144,6 +146,7 @@ export interface TableColumn<T> extends TableColumnBase {
 	conditionalCellStyles?: ConditionalStyles<T>[];
 	format?: Format<T> | undefined;
 	selector?: Selector<T>;
+	footerContent?: FooterContent<T>;
 	sortFunction?: ColumnSortFunction<T>;
 }
 
@@ -179,6 +182,13 @@ export interface TableStyles {
 	headCells?: {
 		style?: CSSObject;
 		draggingStyle?: CSSObject;
+	};
+	foot?: {
+		style: CSSObject;
+	};
+	footRow?: {
+		style: CSSObject;
+		denseStyle?: CSSObject;
 	};
 	contextMenu?: {
 		style?: CSSObject;

--- a/src/DataTable/util.ts
+++ b/src/DataTable/util.ts
@@ -1,5 +1,14 @@
 import { CSSObject } from 'styled-components';
-import { ConditionalStyles, TableColumn, Format, TableRow, Selector, SortOrder, SortFunction } from './types';
+import {
+	ConditionalStyles,
+	FooterContent,
+	Format,
+	Selector,
+	SortFunction,
+	SortOrder,
+	TableColumn,
+	TableRow,
+} from './types';
 
 export function prop<T, K extends keyof T>(obj: T, key: K): T[K] {
 	return obj[key];
@@ -54,6 +63,14 @@ export function sort<T>(
 
 		return 0;
 	});
+}
+
+export function getFooterProperty<T>(rows: T[], footerContent: FooterContent<T> | undefined | null): React.ReactNode {
+	if (!footerContent) {
+		return null;
+	}
+
+	return footerContent(rows);
 }
 
 export function getProperty<T>(

--- a/stories/DataTable/Footer.stories.js
+++ b/stories/DataTable/Footer.stories.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import tableDataItems from '../constants/sampleDesserts';
+import DataTable from '../../src/index';
+
+const columns = [
+	{
+		name: 'Name',
+		selector: row => row.name,
+		sortable: true,
+		fixed: true,
+	},
+	{
+		name: 'Type',
+		selector: row => row.type,
+		sortable: true,
+		fixed: true,
+	},
+	{
+		name: 'Calories (g)',
+		selector: row => row.calories,
+		sortable: true,
+		right: true,
+		footerContent: rows => {
+			const total = rows.reduce((acc, row) => acc + row.calories, 0);
+			return Math.round(total);
+		},
+	},
+	{
+		name: 'Fat (g)',
+		selector: row => row.fat,
+		sortable: true,
+		right: true,
+		footerContent: rows => {
+			const total = rows.reduce((acc, row) => acc + row.fat, 0);
+			return Math.round(total);
+		},
+	},
+	{
+		name: 'Carbs (g)',
+		selector: row => row.carbs,
+		sortable: true,
+		right: true,
+		footerContent: rows => {
+			const total = rows.reduce((acc, row) => acc + row.carbs, 0);
+			return Math.round(total);
+		},
+	},
+	{
+		name: 'Protein (g)',
+		selector: row => row.protein,
+		sortable: true,
+		right: true,
+		footerContent: rows => {
+			const total = rows.reduce((acc, row) => acc + row.protein, 0);
+			return Math.round(total);
+		},
+	},
+	{
+		name: 'Sodium (mg)',
+		selector: row => row.sodium,
+		sortable: true,
+		right: true,
+		footerContent: rows => {
+			const total = rows.reduce((acc, row) => acc + row.sodium, 0);
+			return Math.round(total);
+		},
+	},
+	{
+		name: 'Calcium (%)',
+		selector: row => row.calcium,
+		sortable: true,
+		right: true,
+		footerContent: rows => {
+			const total = rows.reduce((acc, row) => acc + row.calcium, 0);
+			return Math.round(total);
+		},
+	},
+	{
+		name: 'Iron (%)',
+		selector: row => row.iron,
+		sortable: true,
+		right: true,
+		footerContent: rows => {
+			const total = rows.reduce((acc, row) => acc + row.iron, 0);
+			return Math.round(total);
+		},
+	},
+];
+
+export const Footer = () => {
+	return <DataTable title="Movie List" columns={columns} data={tableDataItems} showFooter />;
+};
+
+export default {
+	title: 'Footer/Basic',
+	component: Footer,
+};


### PR DESCRIPTION
## Why
For one of my projects I need to add a footer row to my table and make it configurable by users to display sums, averages and more.
There’s already someone asking for a footer row support in #1208 

## What
This PR aims to enable support for a footer row by accepting a `showFooter` boolean attribute on `DataTable` component.
The content of the footer cells are defined with the `footerContent` function on the columns properties, which receives all visible rows as an argument, making possible to calculate sums, for example.

## Example
```javascript
import tableDataItems from '../constants/sampleDesserts';
import DataTable from '../../src/index';

const columns = [
	{
		name: 'Name',
		selector: row => row.name,
		sortable: true,
		fixed: true,
	},
	{
		name: 'Type',
		selector: row => row.type,
		sortable: true,
		fixed: true,
	},
	{
		name: 'Calories (g)',
		selector: row => row.calories,
		sortable: true,
		right: true,
		footerContent: rows => {
			const total = rows.reduce((acc, row) => acc + row.calories, 0);
			return Math.round(total);
		},
	},
];

export const Footer = () => {
	return <DataTable title="Movie List" columns={columns} data={tableDataItems} showFooter />;
};
```

I hope the quality of code matches your standards as it’s my first contribution.