### PR TITLE
remove Warning on the table

### DIFF
--- a/src/DataTable/TableCell.tsx
+++ b/src/DataTable/TableCell.tsx
@@ -67,9 +67,9 @@ function Cell<T>({
 			$cellStyle={column.style}
 			$renderAsCell={!!column.cell}
 			$allowOverflow={column.allowOverflow}
-			button={column.button}
-			center={column.center}
-			compact={column.compact}
+			button={column.button ? column.button.toString() : undefined}
+			center={column.center ? column.center.toString() : undefined}
+			compact={column.compact ? column.compact.toString() : undefined}
 			grow={column.grow}
 			hide={column.hide}
 			maxWidth={column.maxWidth}

--- a/src/DataTable/TableCol.tsx
+++ b/src/DataTable/TableCol.tsx
@@ -188,14 +188,14 @@ function TableCol<T>({
 			className="rdt_TableCol"
 			$headCell
 			allowOverflow={column.allowOverflow}
-			button={column.button}
-			compact={column.compact}
+			button={column.button ? column.button.toString() : undefined}
+			compact={column.compact ? column.compact.toString() : undefined}
 			grow={column.grow}
 			hide={column.hide}
 			maxWidth={column.maxWidth}
 			minWidth={column.minWidth}
 			right={column.right}
-			center={column.center}
+			center={column.center ? column.center.toString() : undefined}
 			width={column.width}
 			draggable={column.reorder}
 			$isDragging={equalizeId(column.id, draggingColumnId)}

--- a/src/DataTable/types.ts
+++ b/src/DataTable/types.ts
@@ -118,9 +118,9 @@ export type TableProps<T> = {
 
 export type TableColumnBase = {
 	allowOverflow?: boolean;
-	button?: boolean;
-	center?: boolean;
-	compact?: boolean;
+	button?: boolean | string;
+	center?: boolean | string;
+	compact?: boolean | string;
 	reorder?: boolean;
 	grow?: number;
 	hide?: number | ((value: number) => CSSObject) | Media;
@@ -129,9 +129,9 @@ export type TableColumnBase = {
 	maxWidth?: string;
 	minWidth?: string;
 	name?: string | number | React.ReactNode;
-	omit?: boolean;
+	omit?: boolean | string;
 	right?: boolean;
-	sortable?: boolean;
+	sortable?: boolean | string;
 	style?: CSSObject;
 	width?: string;
 	wrap?: boolean;


### PR DESCRIPTION
### Why
---
I want to remove this warning: https://github.com/jbetancur/react-data-table-component/issues/1203

```
VM26934:1 Warning: Received 'true' for a non-boolean attribute 'center'. 
If you want to write it to the DOM, pass a string instead: center="true" or center={value.toString()}.
```

### What
---
Make some change on the types and where is calling so is passing the like a string.

### Example
---

```
const columns = [
	{
		name: 'Name',
		selector: row => row.name,
		sortable: true,
		center: true,
	{
];

```