### PR TITLE
use tabindex="-1" on non-sortable column headers

### DIFF
--- a/src/DataTable/TableCol.tsx
+++ b/src/DataTable/TableCol.tsx
@@ -177,6 +177,7 @@ function TableCol<T>({
 
 	const sortActive = !!(column.sortable && equalizeId(selectedColumn.id, column.id));
 	const disableSort = !column.sortable || disabled;
+	const tabIndex = disableSort ? -1 : 0;
 	const nativeSortIconLeft = column.sortable && !sortIcon && !column.right;
 	const nativeSortIconRight = column.sortable && !sortIcon && column.right;
 	const customSortIconLeft = column.sortable && sortIcon && !column.right;
@@ -210,7 +211,7 @@ function TableCol<T>({
 					data-column-id={column.id}
 					data-sort-id={column.id}
 					role="columnheader"
-					tabIndex={0}
+					tabIndex={tabIndex}
 					className="rdt_TableCol_Sortable"
 					onClick={!disableSort ? handleSortChange : undefined}
 					onKeyPress={!disableSort ? handleKeyPress : undefined}

--- a/src/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`DataTable::Header header should not display with no title 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -934,7 +934,7 @@ exports[`DataTable::Header should render without a header if noHeader is true 1`
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -1358,7 +1358,7 @@ exports[`DataTable::Pagination should change the page position when using pagina
                 data-sort-id="1"
                 disabled=""
                 role="columnheader"
-                tabindex="0"
+                tabindex="-1"
               >
                 <div
                   class="c8"
@@ -1709,7 +1709,7 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -1905,7 +1905,7 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -2101,7 +2101,7 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -2297,7 +2297,7 @@ exports[`DataTable::Pagination should have the correct amount of rows when pagin
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -2721,7 +2721,7 @@ exports[`DataTable::Pagination should recalculate pagination position if there i
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -2917,7 +2917,7 @@ exports[`DataTable::Pagination should render correctly if pagination is enabled 
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -3132,7 +3132,7 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -3347,7 +3347,7 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -3562,7 +3562,7 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -3777,7 +3777,7 @@ exports[`DataTable::Pagination should render correctly when a paginationComponen
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -3992,7 +3992,7 @@ exports[`DataTable::Pagination should render correctly when paginationResetDefau
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -4184,7 +4184,7 @@ exports[`DataTable::Theming should render correctly when a custom style is appli
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -4396,7 +4396,7 @@ exports[`DataTable::ariaLabel should render correctly when ariaLabel 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -4607,7 +4607,7 @@ exports[`DataTable::ariaLabel should render correctly when not ariaLabel 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -4822,7 +4822,7 @@ exports[`DataTable::column.style should render correctly when a style is set on 
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -5034,7 +5034,7 @@ exports[`DataTable::columns should render correctly if column.center 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -5252,7 +5252,7 @@ exports[`DataTable::columns should render correctly if column.hide is an integer
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -5472,7 +5472,7 @@ exports[`DataTable::columns should render correctly if column.hide lg 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -5692,7 +5692,7 @@ exports[`DataTable::columns should render correctly if column.hide md 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -5912,7 +5912,7 @@ exports[`DataTable::columns should render correctly if column.hide sm 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -6126,7 +6126,7 @@ exports[`DataTable::columns should render correctly if column.maxWidth 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -6340,7 +6340,7 @@ exports[`DataTable::columns should render correctly if column.minWidth 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -6553,7 +6553,7 @@ exports[`DataTable::columns should render correctly if column.omit is true 1`] =
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -6765,7 +6765,7 @@ exports[`DataTable::columns should render correctly if column.right 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -6979,7 +6979,7 @@ exports[`DataTable::columns should render correctly if column.width 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -7192,7 +7192,7 @@ exports[`DataTable::columns should render correctly when column.allowOverflow = 
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -7409,7 +7409,7 @@ exports[`DataTable::columns should render correctly when column.button = true 1`
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c9"
@@ -7608,7 +7608,7 @@ exports[`DataTable::columns should render correctly when column.cell is set to a
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -7816,7 +7816,7 @@ exports[`DataTable::columns should render correctly when column.compact = true 1
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -8282,7 +8282,7 @@ exports[`DataTable::columns should render correctly when column.wrap = true 1`] 
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -8493,7 +8493,7 @@ exports[`DataTable::columns should render correctly when ignoreRowClick = true 1
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -8698,7 +8698,7 @@ exports[`DataTable::columns should render correctly with columns/data 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -8909,7 +8909,7 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -9121,7 +9121,7 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -9332,7 +9332,7 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -9544,7 +9544,7 @@ exports[`DataTable::conditionalCellStyles should render correctly when condition
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -9755,7 +9755,7 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -9991,7 +9991,7 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -10202,7 +10202,7 @@ exports[`DataTable::conditionalRowStyles should render correctly when conditiona
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -10415,7 +10415,7 @@ exports[`DataTable::dense should render correctly when dense 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -10630,7 +10630,7 @@ exports[`DataTable::direction should render correctly when direction is auto 1`]
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -10846,7 +10846,7 @@ exports[`DataTable::direction should render correctly when direction is ltr 1`] 
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -11062,7 +11062,7 @@ exports[`DataTable::direction should render correctly when direction is rtl 1`] 
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -11325,7 +11325,7 @@ exports[`DataTable::direction should render correctly when direction is rtl when
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c10"
@@ -11632,7 +11632,7 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c10"
@@ -11986,7 +11986,7 @@ exports[`DataTable::expandableRows should expand a row if expandableRows is true
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c10"
@@ -12352,7 +12352,7 @@ exports[`DataTable::expandableRows should not expand a row if the expander row i
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c10"
@@ -12620,7 +12620,7 @@ exports[`DataTable::expandableRows should not render expandableRows expandableRo
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -12882,7 +12882,7 @@ exports[`DataTable::expandableRows should render correctly when expandableRowExp
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c10"
@@ -13185,7 +13185,7 @@ exports[`DataTable::expandableRows should render correctly when expandableRowExp
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c10"
@@ -13528,7 +13528,7 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c10"
@@ -13867,7 +13867,7 @@ exports[`DataTable::expandableRows should render correctly when expandableRows i
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c10"
@@ -14145,7 +14145,7 @@ exports[`DataTable::expandableRows should render correctly when expandableRowsHi
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -14362,7 +14362,7 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -14579,7 +14579,7 @@ exports[`DataTable::fixedHeader should render correctly when fixedHeader and fix
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -14801,7 +14801,7 @@ exports[`DataTable::highlightOnHover should render correctly when highlightOnHov
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -15016,7 +15016,7 @@ exports[`DataTable::pointerOnHover should render correctly when pointerOnHover 1
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -15570,7 +15570,7 @@ exports[`DataTable::progress/nodata when persistTableHead should disable TableHe
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -15718,7 +15718,7 @@ exports[`DataTable::progress/nodata when persistTableHead should disable TableHe
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -15866,7 +15866,7 @@ exports[`DataTable::progress/nodata when persistTableHead should only Loading an
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -16043,7 +16043,7 @@ exports[`DataTable::responsive should render correctly responsive by default 1`]
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -16251,7 +16251,7 @@ exports[`DataTable::responsive should render correctly when responsive=false 1`]
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -16487,7 +16487,7 @@ exports[`DataTable::selectableRows should not render a select all checkbox when 
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c9"
@@ -16769,7 +16769,7 @@ exports[`DataTable::selectableRows should render correctly when selectableRows i
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c10"
@@ -17076,7 +17076,7 @@ exports[`DataTable::selectableRows should render correctly when selectableRowsHi
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c10"
@@ -18036,7 +18036,7 @@ exports[`DataTable::sorting should render correctly and not be sorted when a col
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -20264,7 +20264,7 @@ exports[`DataTable::striped should render correctly when striped 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -20590,7 +20590,7 @@ exports[`data prop changes should update state if the data prop changes 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -21083,7 +21083,7 @@ exports[`should render correctly when conditionalRowStyles is used with an expan
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c10"
@@ -21433,7 +21433,7 @@ exports[`should render correctly when conditionalRowStyles is used with an expan
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c10"
@@ -21711,7 +21711,7 @@ exports[`should render correctly when conditionalRowStyles with classNames is us
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -21925,7 +21925,7 @@ exports[`should render correctly when disabled 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -22136,7 +22136,7 @@ exports[`should render the correctly when using selector function 1`] = `
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"
@@ -22328,7 +22328,7 @@ exports[`should render the correctly when using selector function and a format f
               data-sort-id="1"
               disabled=""
               role="columnheader"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="c8"


### PR DESCRIPTION
The proposed fix sets the `tabindex="-1"` (unfocusable) wherever the "disabled" property is set on the column-sorting functionality.

This is an accessibility fix; currently, all column headers on DataTable have `tabindex="0"`, making them focusable. That's appropriate for interactive components like sortable column headers, but where sorting is disabled, it adds unnecessary keystrokes and disrupts the normal flow of selection on the page (violating [WCAG 2.4.3](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html))

I've updated the test snapshots for DataTable to reflect these change -- there are 77 cases where what used to have a `tabindex="0"` is now `tabindex="-1"`.

Note: This fixes an issue raised in the comments to #1159 but is not a fix for the overall issue the original poster discussed. (They wanted more direct user control over the tabindex for each column; this PR just obviates one potential use-case for that enhancement, and improves on it by enforcing WCAG compliance rather than relying on the component's installer to do so.)