### PR TITLE
feat: add sponsorship infrastructure and support page

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Sponsoring puts your company logo in front of ~200k developers a week — on the
 
 ## Need help?
 
-For complex integrations, performance issues, or major version upgrades, [get in touch](mailto:johnnyazee@gmail.com) to discuss one-off consulting.
+For complex integrations, performance issues, or major version upgrades, [get in touch](mailto:1385932+jbetancur@users.noreply.github.com) to discuss one-off consulting.
 
 ## Sponsors
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -15,7 +15,7 @@ Usage questions ("how do I...") are not answered through GitHub issues. Check th
 
 ## Consulting
 
-Need help with a complex integration, performance issue, or major version upgrade? Email [johnnyazee@gmail.com](mailto:johnnyazee@gmail.com).
+Need help with a complex integration, performance issue, or major version upgrade? Email [1385932+jbetancur@users.noreply.github.com](mailto:1385932+jbetancur@users.noreply.github.com).
 
 ## Sponsorship
 

--- a/apps/docs/src/pages/support.astro
+++ b/apps/docs/src/pages/support.astro
@@ -202,7 +202,7 @@ const OC_BASE = 'https://opencollective.com/react-data-table-component';
     <div class="mt-12 text-center">
       <p class="text-sm text-gray-500 mb-3">Questions about sponsorship or consulting?</p>
       <a
-        href="mailto:johnnyazee@gmail.com"
+        href="mailto:1385932+jbetancur@users.noreply.github.com"
         class="text-sm text-brand-600 hover:text-brand-700 font-medium"
       >
         Email me directly →


### PR DESCRIPTION
## Summary

- Enable GitHub Sponsors in `FUNDING.yml` alongside OpenCollective (GH Sponsors is now the primary CTA everywhere)
- Overhaul `README.md` with tiered sponsorship table (Supporter/Backer/Bronze/Silver/Gold), backers section, Apache 2.0 license fix, and noreply contact email
- Add `SUPPORT.md` to redirect usage questions away from GitHub issues
- Add `usage_question` issue template that steers "how do I" questions to docs/consulting instead of issues
- Overhaul support page with tiered sponsor cards, logo placement mockups, and GitHub Sponsors as primary CTA
- Update nav, docs sidebar, and homepage sponsor section to point to GitHub Sponsors
- Fix license references from MIT → Apache 2.0 throughout docs

## Motivation

The project has ~200k weekly downloads and was leaving money on the table with no clear sponsorship ask, inconsistent pricing, and the wrong license mentioned in several places.

## Test plan

- [ ] Verify sponsor button on repo header shows both GitHub Sponsors and OpenCollective
- [ ] Check `/support` page renders correctly with tier cards and logo placement section
- [ ] Confirm no personal email addresses are exposed anywhere
- [ ] Confirm all sponsor CTAs link to GitHub Sponsors, with OpenCollective as secondary