### PR TITLE
fix(resize): avoid null deref when resize update flushes after mouseup

### DIFF
--- a/src/hooks/useColumnResize.ts
+++ b/src/hooks/useColumnResize.ts
@@ -25,9 +25,10 @@ export default function useColumnResize({ initialColumnWidths, onColumnResize }:
 
 		function onMouseMove(mv: MouseEvent) {
 			if (!resizeRef.current) return;
+			const { columnId } = resizeRef.current;
 			const delta = mv.clientX - resizeRef.current.startX;
 			const newWidth = Math.max(40, resizeRef.current.startWidth + delta);
-			setColumnWidths(prev => ({ ...prev, [resizeRef.current!.columnId]: newWidth }));
+			setColumnWidths(prev => ({ ...prev, [columnId]: newWidth }));
 		}
 
 		function onMouseUp() {


### PR DESCRIPTION
## Summary

Dragging a column border to resize throws and tears down the table:

```
TypeError: Cannot read properties of null (reading 'columnId')
    at onMouseMove (useColumnResize.ts)
    at basicStateReducer (react-dom)
```

This reproduces reliably at the **end** of essentially every resize drag under React 18.

## Root cause

In `useColumnResize`, `onMouseMove` reads `resizeRef.current!.columnId` **lazily, inside the `setColumnWidths` updater**:

```ts
setColumnWidths((prev) => ({
  ...prev,
  [resizeRef.current!.columnId]: newWidth,
}));
```

The `if (!resizeRef.current) return;` guard runs when the event fires, but the `resizeRef.current!` deref happens later, when React executes the queued updater during render.

Under React 18 automatic batching, the final mousemove's state update isn't committed synchronously. `mouseup` fires first and runs `onMouseUp`, which sets `resizeRef.current = null`. React then flushes the still-queued mousemove updater, which now dereferences `null` → the crash. Since every drag ends in a `mouseup`, it fires on nearly every resize.

`onMouseUp` doesn't hit this because it already captures the id into a local (`const { columnId: id } = resizeRef.current;`) **before** calling `setColumnWidths`. `onMouseMove` is just missing the same treatment.

## Fix

Capture `columnId` before the updater, mirroring `onMouseUp`, and drop the non-null assertion:

```ts
function onMouseMove(mv: MouseEvent) {
  if (!resizeRef.current) return;
  const { columnId } = resizeRef.current;
  const delta = mv.clientX - resizeRef.current.startX;
  const newWidth = Math.max(40, resizeRef.current.startWidth + delta);
  setColumnWidths((prev) => ({ ...prev, [columnId]: newWidth }));
}
```

Two-line change, no behavior change. `startX`/`startWidth` are still read synchronously inside `onMouseMove` (not inside the deferred updater), so they remain safe.

## Testing

- `npm run typecheck`, `npm run lint`, and `npm test` (509 tests) all pass.

I didn't add a unit test: the bug is a scheduling/batching race, and `act()` in the test environment flushes the `setColumnWidths` updater synchronously (while `resizeRef.current` is still set), so it can't reproduce the deferred-past-`mouseup` ordering deterministically. Happy to add one if you have a preferred approach for simulating the batching gap.
