### PR TITLE
feat: add cellNavigation prop for ARIA grid keyboard navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # React Data Table Component
 
-[![GitHub release](https://img.shields.io/github/release/jbetancur/react-data-table-component.svg)](https://GitHub.com/jbetancur/react-data-table-component/releases/)
+[![GitHub release](https://img.shields.io/github/release/jbetancur/react-data-table-component.svg)](https://GitHub.com/jbetancur/react-data-table-component/releases/) [![npm downloads](https://img.shields.io/npm/dm/react-data-table-component.svg)](https://www.npmjs.com/package/react-data-table-component) [![GitHub stars](https://img.shields.io/github/stars/jbetancur/react-data-table-component.svg)](https://github.com/jbetancur/react-data-table-component/stargazers) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/jbetancur/react-data-table-component.svg)](https://github.com/jbetancur/react-data-table-component/commits/master) [![Dependents](https://img.shields.io/librariesio/dependent-repos/npm/react-data-table-component.svg)](https://github.com/jbetancur/react-data-table-component/network/dependents)
 
 **A simple but flexible React data table. Working table in 10 lines.** Sorting, selection, pagination, expandable rows, and theming are opt-in props. No atomic HTML table knowledge required.
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -61,7 +61,8 @@ const columns = [
 - [SSR](https://reactdatatable.com/docs/ssr): Next.js App Router, Remix, Astro
 - [Performance](https://reactdatatable.com/docs/performance): large datasets, memoization
 - [Headless Hooks](https://reactdatatable.com/docs/headless): use the logic without the UI
-- [Accessibility](https://reactdatatable.com/docs/accessibility): keyboard and screen reader support
+- [Accessibility](https://reactdatatable.com/docs/accessibility): ARIA roles and screen reader support
+- [Keyboard Navigation](https://reactdatatable.com/docs/keyboard-navigation): cellNavigation prop for spreadsheet-style ARIA grid keyboard navigation
 - [Localization](https://reactdatatable.com/docs/localization): translated labels and locales
 - [RTL Support](https://reactdatatable.com/docs/rtl): right-to-left layouts
 - [Mobile](https://reactdatatable.com/docs/mobile): responsive columns and layouts

--- a/apps/docs/src/components/demos/InlineEditingDemo.tsx
+++ b/apps/docs/src/components/demos/InlineEditingDemo.tsx
@@ -108,9 +108,10 @@ export default function InlineEditingDemo() {
 			<p className="text-xs text-gray-400">
 				Click any cell to edit. <strong>Name</strong> and <strong>Salary</strong> are text inputs;{' '}
 				<strong>Department</strong> and <strong>Status</strong> are dropdowns. <kbd>Enter</kbd> commits, <kbd>Esc</kbd>{' '}
-				cancels.
+				cancels. Keyboard navigation is enabled too: click or Tab into the table, move between cells and headers with
+				the arrow keys, and press <kbd>Enter</kbd> to edit or sort.
 			</p>
-			<DataTable columns={columns} data={data} highlightOnHover />
+			<DataTable columns={columns} data={data} highlightOnHover cellNavigation />
 			{lastEdit && <div className="text-xs text-emerald-600 font-mono">{lastEdit}</div>}
 		</div>
 	);

--- a/apps/docs/src/components/demos/KeyboardArrowNavDemo.tsx
+++ b/apps/docs/src/components/demos/KeyboardArrowNavDemo.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import DataTable from '../ThemedDataTable';
+import { type TableColumn } from 'react-data-table-component';
+
+interface Employee {
+	id: number;
+	name: string;
+	department: string;
+	salary: number;
+}
+
+const data: Employee[] = [
+	{ id: 1, name: 'Aria Chen', department: 'Engineering', salary: 155000 },
+	{ id: 2, name: 'Marcus Webb', department: 'Product', salary: 132000 },
+	{ id: 3, name: 'Priya Kapoor', department: 'Design', salary: 118000 },
+	{ id: 4, name: 'Jordan Ellis', department: 'Analytics', salary: 143000 },
+];
+
+const columns: TableColumn<Employee>[] = [
+	{ id: 'name', name: 'Name', selector: r => r.name },
+	{ id: 'department', name: 'Department', selector: r => r.department },
+	{ id: 'salary', name: 'Salary', selector: r => r.salary, format: r => `$${r.salary.toLocaleString()}`, right: true },
+];
+
+export default function KeyboardArrowNavDemo() {
+	return (
+		<div className="space-y-2">
+			<p className="text-xs text-gray-400">
+				A plain read-only table. Click a cell, then use <kbd>←</kbd> <kbd>→</kbd> <kbd>↑</kbd> <kbd>↓</kbd> to move,{' '}
+				<kbd>Home</kbd>/<kbd>End</kbd> to jump to the row edges, and <kbd>Ctrl</kbd>+<kbd>Home</kbd>/
+				<kbd>Ctrl</kbd>+<kbd>End</kbd> to jump to the grid corners. No editing, sorting, selection, or expansion
+				here — just movement, which works on any table.
+			</p>
+			<DataTable columns={columns} data={data} highlightOnHover cellNavigation />
+		</div>
+	);
+}

--- a/apps/docs/src/components/demos/KeyboardEditDemo.tsx
+++ b/apps/docs/src/components/demos/KeyboardEditDemo.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import DataTable from '../ThemedDataTable';
+import { type TableColumn } from 'react-data-table-component';
+
+interface Employee {
+	id: number;
+	name: string;
+	department: string;
+	salary: number;
+}
+
+const initialData: Employee[] = [
+	{ id: 1, name: 'Aria Chen', department: 'Engineering', salary: 155000 },
+	{ id: 2, name: 'Marcus Webb', department: 'Product', salary: 132000 },
+	{ id: 3, name: 'Priya Kapoor', department: 'Design', salary: 118000 },
+	{ id: 4, name: 'Jordan Ellis', department: 'Analytics', salary: 143000 },
+];
+
+export default function KeyboardEditDemo() {
+	const [data, setData] = React.useState<Employee[]>(initialData);
+
+	const handleCellEdit = (row: Employee, value: string, column: TableColumn<Employee>) => {
+		const field = column.id as keyof Employee;
+		setData(prev =>
+			prev.map(r => (r.id === row.id ? { ...r, [field]: field === 'salary' ? Number(value) || r.salary : value } : r)),
+		);
+	};
+
+	const columns: TableColumn<Employee>[] = [
+		{ id: 'name', name: 'Name', selector: r => r.name, editable: true, onCellEdit: handleCellEdit },
+		{ id: 'department', name: 'Department', selector: r => r.department },
+		{
+			id: 'salary',
+			name: 'Salary',
+			selector: r => r.salary,
+			format: r => `$${r.salary.toLocaleString()}`,
+			right: true,
+			editable: true,
+			onCellEdit: handleCellEdit,
+		},
+	];
+
+	return (
+		<div className="space-y-2">
+			<p className="text-xs text-gray-400">
+				Arrow to Name or Salary, then press <kbd>Enter</kbd> or <kbd>F2</kbd> to open the editor. <kbd>Enter</kbd>{' '}
+				commits and <kbd>Escape</kbd> cancels — either way, focus returns to the cell so arrow-key navigation
+				continues immediately. Department has no editor, so Enter/F2 do nothing there.
+			</p>
+			<DataTable columns={columns} data={data} highlightOnHover cellNavigation />
+		</div>
+	);
+}

--- a/apps/docs/src/components/demos/KeyboardNavigationDemo.tsx
+++ b/apps/docs/src/components/demos/KeyboardNavigationDemo.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import DataTable from '../ThemedDataTable';
+import { type TableColumn } from 'react-data-table-component';
+
+interface Employee {
+	id: number;
+	name: string;
+	department: string;
+	salary: number;
+}
+
+const data: Employee[] = [
+	{ id: 1, name: 'Aria Chen', department: 'Engineering', salary: 155000 },
+	{ id: 2, name: 'Marcus Webb', department: 'Product', salary: 132000 },
+	{ id: 3, name: 'Priya Kapoor', department: 'Design', salary: 118000 },
+	{ id: 4, name: 'Jordan Ellis', department: 'Analytics', salary: 143000 },
+];
+
+const columns: TableColumn<Employee>[] = [
+	{ id: 'name', name: 'Name', selector: r => r.name, sortable: true, editable: true },
+	{ id: 'department', name: 'Department', selector: r => r.department, sortable: true },
+	{
+		id: 'salary',
+		name: 'Salary',
+		selector: r => r.salary,
+		format: r => `$${r.salary.toLocaleString()}`,
+		sortable: true,
+		right: true,
+		editable: true,
+	},
+];
+
+export default function KeyboardNavigationDemo() {
+	return (
+		<div className="space-y-2">
+			<p className="text-xs text-gray-400">
+				Click or Tab into the table, then use only the keyboard: arrows to move, <kbd>Enter</kbd>/<kbd>Space</kbd> to
+				sort a header, <kbd>Space</kbd> to select a row, <kbd>Enter</kbd> to expand one, and <kbd>Enter</kbd>/
+				<kbd>F2</kbd> to edit Name or Salary.
+			</p>
+			<DataTable
+				columns={columns}
+				data={data}
+				highlightOnHover
+				cellNavigation
+				selectableRows
+				expandableRows
+				expandableRowsComponent={({ data: row }: { data: Employee }) => (
+					<div className="px-4 py-2 text-xs text-gray-500">
+						Full record for <strong>{row.name}</strong>: {row.department}, ${row.salary.toLocaleString()}
+					</div>
+				)}
+			/>
+		</div>
+	);
+}

--- a/apps/docs/src/components/demos/KeyboardSortDemo.tsx
+++ b/apps/docs/src/components/demos/KeyboardSortDemo.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import DataTable from '../ThemedDataTable';
+import { type TableColumn } from 'react-data-table-component';
+
+interface Employee {
+	id: number;
+	name: string;
+	department: string;
+	salary: number;
+}
+
+const data: Employee[] = [
+	{ id: 1, name: 'Aria Chen', department: 'Engineering', salary: 155000 },
+	{ id: 2, name: 'Marcus Webb', department: 'Product', salary: 132000 },
+	{ id: 3, name: 'Priya Kapoor', department: 'Design', salary: 118000 },
+	{ id: 4, name: 'Jordan Ellis', department: 'Analytics', salary: 143000 },
+];
+
+const columns: TableColumn<Employee>[] = [
+	{ id: 'name', name: 'Name', selector: r => r.name, sortable: true },
+	{ id: 'department', name: 'Department', selector: r => r.department, sortable: true },
+	{
+		id: 'salary',
+		name: 'Salary',
+		selector: r => r.salary,
+		format: r => `$${r.salary.toLocaleString()}`,
+		sortable: true,
+		right: true,
+	},
+];
+
+export default function KeyboardSortDemo() {
+	return (
+		<div className="space-y-2">
+			<p className="text-xs text-gray-400">
+				<kbd>↑</kbd> from the first body row moves into the header. <kbd>Enter</kbd> or <kbd>Space</kbd> on a
+				sortable header cycles ascending → descending → unsorted, same as a click. <kbd>↓</kbd> from the header
+				returns to the body in the same column.
+			</p>
+			<DataTable columns={columns} data={data} highlightOnHover cellNavigation />
+		</div>
+	);
+}

--- a/apps/docs/src/layouts/DocsLayout.astro
+++ b/apps/docs/src/layouts/DocsLayout.astro
@@ -61,6 +61,7 @@ const nav = [
     links: [
       { label: 'Animations', href: '/docs/animations' },
       { label: 'Accessibility', href: '/docs/accessibility' },
+      { label: 'Keyboard Navigation', href: '/docs/keyboard-navigation' },
       { label: 'Localization', href: '/docs/localization' },
       { label: 'RTL Support', href: '/docs/rtl' },
       { label: 'Mobile', href: '/docs/mobile' },

--- a/apps/docs/src/pages/docs/accessibility.md
+++ b/apps/docs/src/pages/docs/accessibility.md
@@ -27,17 +27,19 @@ Always provide `ariaLabel` so screen readers can identify `DataTable`. Without i
 
 ## Table structure
 
-`react-data-table-component` renders `div` elements with explicit ARIA roles, giving screen readers a full grid structure.
+`react-data-table-component` renders `div` elements with explicit ARIA roles, giving screen readers a full table structure.
 
 | Element | Role / attribute |
 | --- | --- |
-| Table wrapper | `role="table"`, `aria-label` (from `ariaLabel` prop), `aria-busy` during load |
+| Table wrapper | `role="table"` (or `role="grid"` with `cellNavigation` — see below), `aria-label` (from `ariaLabel` prop), `aria-busy` during load |
 | Header section | `role="rowgroup"` |
 | Body section | `role="rowgroup"` |
 | Header row | `role="row"` |
 | Data row | `role="row"`, `aria-selected` (when `selectableRows` is enabled) |
-| Data cell | `role="cell"` |
+| Data cell | `role="cell"` (or `role="gridcell"` with `cellNavigation`) |
 | Column header | `role="columnheader"` |
+
+By default this is a **static table**: nothing but sortable headers is focusable, which is the right shape for a screen reader's native table-reading commands. Passing `cellNavigation` turns it into an interactive **grid** (WAI-ARIA grid pattern) instead — every cell becomes focusable via a single roving tab stop, and arrow keys move between them. See [Keyboard navigation](/docs/keyboard-navigation) for the full key reference and the reasoning for making this opt-in rather than the default.
 
 ---
 
@@ -52,7 +54,7 @@ Sortable column headers expose `aria-sort` so screen readers announce the curren
 | Sorted Z → A / high → low | `"descending"` |
 | Column not sortable | attribute omitted |
 
-**Keyboard**: sortable headers receive `tabIndex={0}`. Press **Enter** to toggle the sort direction. Non-sortable headers are removed from the tab order. Keyboard focus is indicated with a visible `:focus-visible` outline in the theme's primary color.
+**Keyboard**: sortable headers receive `tabIndex={0}`. Press **Enter** or **Space** to toggle the sort direction. Non-sortable headers are removed from the tab order. Keyboard focus is indicated with a visible `:focus-visible` outline in the theme's primary color. With `cellNavigation` enabled, header cells instead participate in the grid's roving tabindex — see [Keyboard navigation](/docs/keyboard-navigation).
 
 ---
 
@@ -64,6 +66,7 @@ When `selectableRows` is enabled:
 - The select-all checkbox in the header has `aria-label="Select all rows"`.
 - Per-row checkboxes have `aria-label="Select row {id}"` where `{id}` is the row's key field value.
 - The indeterminate state (some-but-not-all rows selected) is set via the native `indeterminate` DOM property, which screen readers announce correctly.
+- With `cellNavigation` enabled, checkboxes are reachable by arrowing to their column and are toggled with **Space**. See [Keyboard navigation](/docs/keyboard-navigation).
 
 ---
 
@@ -112,7 +115,7 @@ Focus moves automatically to the first focusable element (the operator `<select>
 
 The expand toggle is a `<button>` with `aria-label="Expand Row"` or `"Collapse Row"`. Expanded content renders inline beneath the row and is read naturally by screen readers.
 
-**Keyboard**: press **Enter** or **Space** on the expander button to toggle. If `expandOnRowClicked` is set, pressing **Enter** on the row itself also toggles.
+**Keyboard**: press **Enter** or **Space** on the expander button to toggle. If `expandOnRowClicked` is set, pressing **Enter** on the row itself also toggles. With `cellNavigation` enabled, the expander button is reachable by arrowing to its column. See [Keyboard navigation](/docs/keyboard-navigation).
 
 ---
 

--- a/apps/docs/src/pages/docs/api.md
+++ b/apps/docs/src/pages/docs/api.md
@@ -156,6 +156,12 @@ Column-level footers live on each [`TableColumn<T>`](#tablecolumnt) as the `foot
 | `onRowMouseEnter` | `(row, event) => void` | Called when the pointer enters a row. |
 | `onRowMouseLeave` | `(row, event) => void` | Called when the pointer leaves a row. |
 
+### Keyboard navigation
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `cellNavigation` | `boolean` | `false` | Spreadsheet-style keyboard navigation using the WAI-ARIA grid pattern (`role="grid"`, single Tab stop, roving tabindex). Arrow keys move between cells, including header, selection, and expander cells; `Home`/`End` and `Ctrl+Home`/`Ctrl+End` jump to row and grid edges; `Enter`/`F2` open a cell editor; `Enter`/`Space` sort from a header. See [Keyboard navigation](/docs/keyboard-navigation). |
+
 ### Column features
 
 | Prop | Type | Default | Description |

--- a/apps/docs/src/pages/docs/conditional-styles.astro
+++ b/apps/docs/src/pages/docs/conditional-styles.astro
@@ -13,6 +13,53 @@ import ConditionalStylesDemo from '../../components/demos/ConditionalStylesDemo.
     <code>cell</code> renderer required.
   </p>
 
+  <Demo
+    title="Conditional row and cell styles — sales pipeline"
+    description="Won deals get a green left border; lost deals are dimmed. Value cells are bold-green for large deals, gray for small. Days Open cells turn amber then red as they age."
+    code={`import DataTable, { type ConditionalStyles, type TableColumn } from 'react-data-table-component';
+
+const conditionalRowStyles: ConditionalStyles<Deal>[] = [
+  {
+    when: r => r.stage === 'Closed Won',
+    style: { backgroundColor: '#f0fdf4', borderLeft: '3px solid #16a34a' },
+  },
+  {
+    when: r => r.stage === 'Closed Lost',
+    style: { backgroundColor: '#fef2f2', opacity: 0.75 },
+  },
+];
+
+const columns: TableColumn<Deal>[] = [
+  { name: 'Company', selector: r => r.company, sortable: true, grow: 2 },
+  { name: 'Rep',     selector: r => r.rep,     sortable: true },
+  {
+    name: 'Value',
+    selector: r => r.value,
+    format: r => fmt(r.value),
+    sortable: true,
+    right: true,
+    conditionalCellStyles: [
+      { when: r => r.value >= 200000, style: { fontWeight: 700, color: '#15803d' } },
+      { when: r => r.value < 20000,   style: { color: '#9ca3af' } },
+    ],
+  },
+  {
+    name: 'Days open',
+    selector: r => r.daysOpen,
+    sortable: true,
+    right: true,
+    conditionalCellStyles: [
+      { when: r => r.daysOpen > 90, style: { color: '#dc2626', fontWeight: 700 } },
+      { when: r => r.daysOpen > 60, style: { color: '#d97706' } },
+    ],
+  },
+];
+
+<DataTable columns={columns} data={data} conditionalRowStyles={conditionalRowStyles} highlightOnHover />`}
+  >
+    <ConditionalStylesDemo client:load />
+  </Demo>
+
   <h2>conditionalRowStyles</h2>
 
   <p>
@@ -108,51 +155,4 @@ const conditionalRowStyles: ConditionalStyles<Deal>[] = [
   <p>
     See it combined with other features in the <a href="/docs/recipes/live-updates">Live-updating data grid</a> recipe.
   </p>
-
-  <Demo
-    title="Conditional row and cell styles — sales pipeline"
-    description="Won deals get a green left border; lost deals are dimmed. Value cells are bold-green for large deals, gray for small. Days Open cells turn amber then red as they age."
-    code={`import DataTable, { type ConditionalStyles, type TableColumn } from 'react-data-table-component';
-
-const conditionalRowStyles: ConditionalStyles<Deal>[] = [
-  {
-    when: r => r.stage === 'Closed Won',
-    style: { backgroundColor: '#f0fdf4', borderLeft: '3px solid #16a34a' },
-  },
-  {
-    when: r => r.stage === 'Closed Lost',
-    style: { backgroundColor: '#fef2f2', opacity: 0.75 },
-  },
-];
-
-const columns: TableColumn<Deal>[] = [
-  { name: 'Company', selector: r => r.company, sortable: true, grow: 2 },
-  { name: 'Rep',     selector: r => r.rep,     sortable: true },
-  {
-    name: 'Value',
-    selector: r => r.value,
-    format: r => fmt(r.value),
-    sortable: true,
-    right: true,
-    conditionalCellStyles: [
-      { when: r => r.value >= 200000, style: { fontWeight: 700, color: '#15803d' } },
-      { when: r => r.value < 20000,   style: { color: '#9ca3af' } },
-    ],
-  },
-  {
-    name: 'Days open',
-    selector: r => r.daysOpen,
-    sortable: true,
-    right: true,
-    conditionalCellStyles: [
-      { when: r => r.daysOpen > 90, style: { color: '#dc2626', fontWeight: 700 } },
-      { when: r => r.daysOpen > 60, style: { color: '#d97706' } },
-    ],
-  },
-];
-
-<DataTable columns={columns} data={data} conditionalRowStyles={conditionalRowStyles} highlightOnHover />`}
-  >
-    <ConditionalStylesDemo client:load />
-  </Demo>
 </DocsLayout>

--- a/apps/docs/src/pages/docs/inline-editing.astro
+++ b/apps/docs/src/pages/docs/inline-editing.astro
@@ -398,6 +398,18 @@ const columns: TableColumn<Employee>[] = [
   box-shadow: inset 0 0 0 3px var(--rdt-color-primary);
 }`} lang="css" />
 
+  <h2>Keyboard cell navigation</h2>
+
+  <p>
+    Pass <code>cellNavigation</code> to navigate the whole table with the keyboard, spreadsheet-style —
+    arrow keys between cells, <kbd>Enter</kbd>/<kbd>F2</kbd> to open the focused cell's editor, and
+    <kbd>Escape</kbd> to cancel and return focus to the cell. See
+    <a href="/docs/keyboard-navigation">Keyboard navigation</a> for the full key reference; it also
+    covers header, selection, and expander cells, and works on read-only tables.
+  </p>
+
+  <CodeBlock code={`<DataTable columns={columns} data={data} cellNavigation />`} />
+
   <h2>Limitations</h2>
   <ul>
     <li>Built-in editors cover text, number, date, checkbox, and select. For autocomplete, multi-line text, rich pickers, etc. use the <code>custom</code> editor.</li>
@@ -418,6 +430,11 @@ const columns: TableColumn<Employee>[] = [
       ['<code>onCellEdit</code>', '<code>(row: T, value: string, column: TableColumn&lt;T&gt;) =&gt; void</code>', 'Called when the user commits an edit (<kbd>Enter</kbd>, blur, or selection change for dropdowns). Receives the original row, the new string value, and the column definition.'],
     ]}
   />
+
+  <p>
+    <code>cellNavigation</code> is a table-level prop covered on its own page — see
+    <a href="/docs/keyboard-navigation">Keyboard navigation</a>.
+  </p>
 
   <h3>CellEditor</h3>
 

--- a/apps/docs/src/pages/docs/keyboard-navigation.astro
+++ b/apps/docs/src/pages/docs/keyboard-navigation.astro
@@ -1,0 +1,170 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+import Demo from '../../components/Demo.astro';
+import CodeBlock from '../../components/CodeBlock.astro';
+import KeyboardArrowNavDemo from '../../components/demos/KeyboardArrowNavDemo.tsx';
+import KeyboardSortDemo from '../../components/demos/KeyboardSortDemo.tsx';
+import KeyboardEditDemo from '../../components/demos/KeyboardEditDemo.tsx';
+import KeyboardNavigationDemo from '../../components/demos/KeyboardNavigationDemo.tsx';
+import DocsTable from '../../components/DocsTable.astro';
+---
+
+<DocsLayout title="Keyboard navigation | react-data-table-component">
+  <h1>Keyboard navigation</h1>
+
+  <p>
+    Pass <code>cellNavigation</code> to navigate the whole table with the keyboard, spreadsheet-style.
+    The table renders with the WAI-ARIA grid pattern: <code>role="grid"</code>, a single Tab stop, and
+    a roving tabindex, so the table adds exactly one stop to the page's Tab order and all movement
+    inside it happens with the keys below. Navigation covers every cell, including the header row,
+    selection checkboxes, and expander buttons, so sorting, selecting, and expanding all work without
+    a mouse. It's independent of <a href="/docs/inline-editing">inline editing</a> and works on
+    read-only tables too.
+  </p>
+
+  <CodeBlock code={`<DataTable columns={columns} data={data} cellNavigation />`} />
+
+  <h2>All shortcuts</h2>
+
+  <DocsTable
+    headers={['Key', 'Action']}
+    rows={[
+      ['<kbd>←</kbd> <kbd>→</kbd> <kbd>↑</kbd> <kbd>↓</kbd>', 'Move between cells. <kbd>↑</kbd> from the first body row moves into the header row. Clamped at the edges, no wraparound.'],
+      ['<kbd>Home</kbd> / <kbd>End</kbd>', 'Jump to the first / last cell in the current row.'],
+      ['<kbd>Ctrl</kbd>+<kbd>Home</kbd> / <kbd>Ctrl</kbd>+<kbd>End</kbd>', 'Jump to the first / last cell of the grid.'],
+      ['<kbd>Enter</kbd> or <kbd>F2</kbd>', "Open the focused cell's editor, if it has one (<code>editable</code>/<code>editor</code> — see <a href=\"/docs/inline-editing\">Inline editing</a>)."],
+      ['<kbd>Escape</kbd>', 'Cancel an open editor and return focus to the cell so navigation can continue.'],
+      ['<kbd>Enter</kbd> or <kbd>Space</kbd> on a header', 'Sort by that column (sortable columns only).'],
+      ['<kbd>Space</kbd> on a checkbox / <kbd>Enter</kbd> on an expander', 'Toggle row selection / expand or collapse the row.'],
+    ]}
+  />
+
+  <p>
+    Arrow keys only navigate when the focused cell is not being edited. While an editor is open,
+    arrow keys behave normally (moving the text cursor, changing a native
+    <code>&lt;select&gt;</code>, etc.).
+  </p>
+
+  <h2>Movement: arrows, Home/End, Ctrl+Home/Ctrl+End</h2>
+
+  <p>
+    The base behavior works on any table, editable or not. Arrow keys move one cell at a time and
+    clamp at the edges — there's no wraparound from the last column back to the first. <kbd>Home</kbd>
+    and <kbd>End</kbd> jump to the first / last cell in the current row; add <kbd>Ctrl</kbd>
+    (<kbd>⌘</kbd> on macOS) to jump to the first / last cell of the whole grid instead.
+  </p>
+
+  <Demo
+    title="Arrow movement"
+    description="Click a cell, then move with the keyboard only. No editing, sorting, selection, or expansion — just movement."
+    code={`<DataTable columns={columns} data={data} cellNavigation />`}
+  >
+    <KeyboardArrowNavDemo client:load />
+  </Demo>
+
+  <h2>Sorting from the keyboard</h2>
+
+  <p>
+    Arrow <kbd>↑</kbd> out of the first body row to reach the header. On a sortable column,
+    <kbd>Enter</kbd> or <kbd>Space</kbd> cycles the sort exactly like a click would — ascending,
+    then descending, then back to unsorted. See <a href="/docs/sorting">Sorting</a> for the full
+    behavior, including multi-column sort.
+  </p>
+
+  <Demo
+    title="Sort with Enter / Space"
+    description="Arrow up to a header, then press Enter or Space to sort. Arrow down returns to the body."
+    code={`const columns: TableColumn<Employee>[] = [
+  { id: 'name', name: 'Name', selector: r => r.name, sortable: true },
+  { id: 'department', name: 'Department', selector: r => r.department, sortable: true },
+  { id: 'salary', name: 'Salary', selector: r => r.salary, sortable: true, right: true },
+];
+
+<DataTable columns={columns} data={data} cellNavigation />`}
+  >
+    <KeyboardSortDemo client:load />
+  </Demo>
+
+  <h2>Editing from the keyboard</h2>
+
+  <p>
+    <kbd>Enter</kbd> or <kbd>F2</kbd> opens the focused cell's editor if the column has one
+    (<code>editable</code> or <code>editor</code>). <kbd>Enter</kbd> inside the editor commits;
+    <kbd>Escape</kbd> cancels. Either way, focus lands back on the cell wrapper so arrow-key
+    navigation continues without an extra click. See <a href="/docs/inline-editing">Inline editing</a>
+    for the full set of editor types.
+  </p>
+
+  <Demo
+    title="Edit with Enter / F2, cancel with Escape"
+    description="Arrow to Name or Salary, press Enter or F2 to edit, Enter to commit or Escape to cancel."
+    code={`const columns: TableColumn<Employee>[] = [
+  { id: 'name', name: 'Name', selector: r => r.name, editable: true, onCellEdit: handleCellEdit },
+  { id: 'department', name: 'Department', selector: r => r.department }, // no editor
+  { id: 'salary', name: 'Salary', selector: r => r.salary, right: true,
+    editable: true, onCellEdit: handleCellEdit },
+];
+
+<DataTable columns={columns} data={data} cellNavigation />`}
+  >
+    <KeyboardEditDemo client:load />
+  </Demo>
+
+  <h2>Selection and expansion from the keyboard</h2>
+
+  <p>
+    Selection checkboxes and expander buttons sit in the nav grid like any other cell. Arrow onto
+    a row's checkbox and press <kbd>Space</kbd> to select it — arrow up far enough and you reach the
+    header's select-all checkbox, which works the same way. Arrow onto an expander button and press
+    <kbd>Enter</kbd> to expand or collapse that row.
+  </p>
+
+  <Demo
+    title="Select and expand without a mouse"
+    description="Everything together: arrows, Home/End, sorting, editing, row selection, and row expansion, all from the keyboard."
+    code={`<DataTable
+  columns={columns}
+  data={data}
+  cellNavigation
+  selectableRows
+  expandableRows
+  expandableRowsComponent={RowDetail}
+/>`}
+  >
+    <KeyboardNavigationDemo client:load />
+  </Demo>
+
+  <h2>The grid pattern</h2>
+
+  <p>
+    Without <code>cellNavigation</code>, the table renders <code>role="table"</code> with plain
+    <code>role="cell"</code> cells — the right shape for a screen reader's native table-reading
+    commands, since nothing in the table is meant to hold focus. Turning on <code>cellNavigation</code>
+    switches every region to the <a href="https://www.w3.org/WAI/ARIA/apg/patterns/grid/">WAI-ARIA grid
+    pattern</a>: <code>role="grid"</code>, <code>role="gridcell"</code> for body cells, and a single
+    roving <code>tabIndex={'{0}'}</code> that follows the last-focused cell. This is why it's an opt-in
+    prop rather than always-on — it's the right choice for tables you expect people to operate, not a
+    strict upgrade over the default.
+  </p>
+
+  <p>
+    See <a href="/docs/accessibility">Accessibility</a> for the full ARIA role reference, including how
+    roles differ with and without <code>cellNavigation</code>.
+  </p>
+
+  <h2>Limitations</h2>
+  <ul>
+    <li>Clamps at row/column edges rather than wrapping.</li>
+    <li>Doesn't cross page boundaries — arrowing past the last row does not auto-paginate.</li>
+    <li>Key bindings are fixed. There's no prop to remap them.</li>
+  </ul>
+
+  <h2>Prop reference</h2>
+
+  <DocsTable
+    headers={['Table prop', 'Type', 'Description']}
+    rows={[
+      ['<code>cellNavigation</code>', '<code>boolean</code>', "Enable spreadsheet-style keyboard navigation (WAI-ARIA grid pattern: <code>role='grid'</code>, single Tab stop, roving tabindex). Defaults to <code>false</code>."],
+    ]}
+  />
+</DocsLayout>

--- a/src/DataTable.css
+++ b/src/DataTable.css
@@ -751,6 +751,17 @@
 	position: relative;
 }
 
+/* ─── Cell navigation: focus outline ───────────────────────────────────────── */
+/* Focus ring for keyboard cell navigation (`cellNavigation`). :focus-within also
+   covers cells whose real focus target is an inner widget (row checkbox, expander
+   button) or an open inline editor. Uses outline rather than box-shadow so it
+   doesn't fight with `.rdt_cellEditing`'s inset box-shadow while editing. */
+.rdt_table[role='grid'] [data-nav-row]:focus-within {
+	outline: 2px solid var(--rdt-color-primary, #1976d2);
+	outline-offset: -2px;
+	z-index: 2;
+}
+
 
 /* ─── Column pinning ────────────────────────────────────────────────────────── */
 

--- a/src/__tests__/DataTable.test.tsx
+++ b/src/__tests__/DataTable.test.tsx
@@ -1078,7 +1078,9 @@ describe('DataTable::expandableRows', () => {
 			/>,
 		);
 
-		fireEvent.keyDown(container.querySelector(`div[data-tag="${STOP_PROP_TAG}"]`) as HTMLElement, { key: 'Enter' });
+		// Key events only count when the row itself is focused — bubbled keys from
+		// focused descendants (editors, cell navigation) must not toggle the row.
+		fireEvent.keyDown(container.querySelector('div[id^="row-"]') as HTMLElement, { key: 'Enter' });
 
 		expect(onRowExpandToggledMock).toHaveBeenCalled();
 	});

--- a/src/__tests__/cellNavigation.test.tsx
+++ b/src/__tests__/cellNavigation.test.tsx
@@ -1,0 +1,338 @@
+import * as React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import DataTable from '../components/DataTable';
+import type { TableColumn } from '../types';
+
+interface Row {
+	id: number;
+	name: string;
+	age: number;
+}
+
+const rows: Row[] = [
+	{ id: 1, name: 'Alice', age: 30 },
+	{ id: 2, name: 'Bob', age: 40 },
+	{ id: 3, name: 'Carol', age: 50 },
+];
+
+const columns: TableColumn<Row>[] = [
+	{ id: 'name', name: 'Name', selector: r => r.name, editable: true },
+	{ id: 'age', name: 'Age', selector: r => r.age },
+];
+
+function getCells(container: HTMLElement): HTMLElement[] {
+	return Array.from(container.querySelectorAll<HTMLElement>('[role="gridcell"]'));
+}
+
+function getHeaders(container: HTMLElement): HTMLElement[] {
+	return Array.from(container.querySelectorAll<HTMLElement>('[role="columnheader"]'));
+}
+
+describe('cellNavigation', () => {
+	test('is off by default — table role and no roving tabindex', () => {
+		const { container } = render(<DataTable columns={columns} data={rows} />);
+		expect(container.querySelector('[role="table"]')).toBeInTheDocument();
+		expect(container.querySelector('[role="grid"]')).not.toBeInTheDocument();
+		expect(container.querySelector('[role="gridcell"]')).not.toBeInTheDocument();
+		const cells = Array.from(container.querySelectorAll('[role="cell"]'));
+		expect(cells.every(c => c.getAttribute('tabindex') === null)).toBe(true);
+	});
+
+	test('renders the WAI-ARIA grid pattern when enabled', () => {
+		const { container } = render(<DataTable columns={columns} data={rows} cellNavigation />);
+		expect(container.querySelector('[role="grid"]')).toBeInTheDocument();
+		expect(container.querySelector('[role="table"]')).not.toBeInTheDocument();
+		expect(getCells(container)).toHaveLength(6);
+	});
+
+	test('first body cell is the only Tab stop before any interaction', () => {
+		const { container } = render(<DataTable columns={columns} data={rows} cellNavigation />);
+		const cells = getCells(container);
+		expect(cells[0].getAttribute('tabindex')).toBe('0');
+		expect(cells.slice(1).every(c => c.getAttribute('tabindex') === '-1')).toBe(true);
+		expect(getHeaders(container).every(h => h.getAttribute('tabindex') === '-1')).toBe(true);
+	});
+
+	test('focusing a cell makes it the active (tabIndex 0) cell', () => {
+		const { container } = render(<DataTable columns={columns} data={rows} cellNavigation />);
+		const cells = getCells(container);
+
+		fireEvent.focus(cells[2]); // row 1, "name" column
+		expect(cells[2].getAttribute('tabindex')).toBe('0');
+		expect(cells[0].getAttribute('tabindex')).toBe('-1');
+	});
+
+	test('ArrowRight/ArrowLeft move focus within the row, clamped at the edges', () => {
+		const { container } = render(<DataTable columns={columns} data={rows} cellNavigation />);
+		const cells = getCells(container);
+
+		fireEvent.keyDown(cells[0], { key: 'ArrowRight' });
+		expect(document.activeElement).toBe(cells[1]);
+		expect(cells[1].getAttribute('tabindex')).toBe('0');
+
+		// At the last column, ArrowRight is a no-op.
+		fireEvent.keyDown(cells[1], { key: 'ArrowRight' });
+		expect(document.activeElement).toBe(cells[1]);
+
+		fireEvent.keyDown(cells[1], { key: 'ArrowLeft' });
+		expect(document.activeElement).toBe(cells[0]);
+
+		// At the first column, ArrowLeft is a no-op.
+		fireEvent.keyDown(cells[0], { key: 'ArrowLeft' });
+		expect(document.activeElement).toBe(cells[0]);
+	});
+
+	test('ArrowDown/ArrowUp move focus within the column, clamped at the last row', () => {
+		const { container } = render(<DataTable columns={columns} data={rows} cellNavigation />);
+		const cells = getCells(container);
+
+		fireEvent.keyDown(cells[0], { key: 'ArrowDown' });
+		expect(document.activeElement).toBe(cells[2]); // row 1, "name"
+
+		fireEvent.keyDown(cells[2], { key: 'ArrowDown' });
+		expect(document.activeElement).toBe(cells[4]); // row 2, "name"
+
+		// Last row — ArrowDown is a no-op.
+		fireEvent.keyDown(cells[4], { key: 'ArrowDown' });
+		expect(document.activeElement).toBe(cells[4]);
+
+		fireEvent.keyDown(cells[4], { key: 'ArrowUp' });
+		expect(document.activeElement).toBe(cells[2]);
+	});
+
+	test('ArrowUp from the first body row moves into the header row', () => {
+		const { container } = render(<DataTable columns={columns} data={rows} cellNavigation />);
+		const cells = getCells(container);
+
+		fireEvent.keyDown(cells[1], { key: 'ArrowUp' }); // row 0, "age"
+		const headers = getHeaders(container);
+		expect(document.activeElement).toBe(headers[1]);
+		expect(headers[1].getAttribute('tabindex')).toBe('0');
+
+		// Header is the top edge — ArrowUp is a no-op.
+		fireEvent.keyDown(headers[1], { key: 'ArrowUp' });
+		expect(document.activeElement).toBe(headers[1]);
+
+		// ArrowDown returns to the first body row in the same column.
+		fireEvent.keyDown(headers[1], { key: 'ArrowDown' });
+		expect(document.activeElement).toBe(getCells(container)[1]);
+	});
+
+	test('Enter and Space sort from a focused sortable header', () => {
+		const sortableColumns: TableColumn<Row>[] = [
+			{ id: 'name', name: 'Name', selector: r => r.name, sortable: true },
+			{ id: 'age', name: 'Age', selector: r => r.age },
+		];
+		const { container } = render(<DataTable columns={sortableColumns} data={rows} cellNavigation />);
+
+		fireEvent.keyDown(getCells(container)[0], { key: 'ArrowUp' });
+		const header = getHeaders(container)[0];
+		expect(document.activeElement).toBe(header);
+
+		fireEvent.keyDown(header, { key: 'Enter' }); // sort asc (already ascending)
+		fireEvent.keyDown(header, { key: 'Enter' }); // sort desc
+		expect(getCells(container)[0].textContent).toBe('Carol');
+
+		fireEvent.keyDown(header, { key: ' ' }); // back to asc
+		expect(getCells(container)[0].textContent).toBe('Alice');
+	});
+
+	test('selection checkbox and expander cells are navigable, focusing their widget', () => {
+		const { container } = render(
+			<DataTable
+				columns={columns}
+				data={rows}
+				cellNavigation
+				selectableRows
+				expandableRows
+				expandableRowsComponent={() => <div>expanded</div>}
+			/>,
+		);
+
+		const firstDataCell = container.querySelector<HTMLElement>('[data-nav-row="0"][data-nav-col="2"]')!;
+		fireEvent.keyDown(firstDataCell, { key: 'ArrowLeft' });
+		const expander = document.activeElement as HTMLElement;
+		expect(expander.tagName).toBe('BUTTON');
+		expect(expander.getAttribute('tabindex')).toBe('0');
+
+		fireEvent.keyDown(expander, { key: 'ArrowLeft' });
+		const checkbox = document.activeElement as HTMLInputElement;
+		expect(checkbox.tagName).toBe('INPUT');
+		expect(checkbox.type).toBe('checkbox');
+		expect(checkbox.getAttribute('tabindex')).toBe('0');
+
+		// ArrowUp from the row checkbox reaches the select-all header checkbox.
+		fireEvent.keyDown(checkbox, { key: 'ArrowUp' });
+		const selectAll = document.activeElement as HTMLInputElement;
+		expect(selectAll.getAttribute('aria-label')).toBe('Select all rows');
+	});
+
+	test('the expander header slot is skipped by keyboard nav (no bulk expand/collapse)', () => {
+		const { container } = render(
+			<DataTable
+				columns={columns}
+				data={rows}
+				cellNavigation
+				selectableRows
+				expandableRows
+				expandableRowsComponent={() => <div>expanded</div>}
+			/>,
+		);
+
+		// The expander header cell has no data-nav-row/col at all — it never appears in the grid.
+		expect(container.querySelector('[data-nav-row="-1"][data-nav-col="1"]')).not.toBeInTheDocument();
+
+		const expanderCell = container.querySelector<HTMLElement>('[data-nav-row="0"][data-nav-col="1"]')!;
+		fireEvent.keyDown(expanderCell, { key: 'ArrowUp' });
+		// Falls back to the nearest header cell instead of landing nowhere.
+		const landed = document.activeElement as HTMLElement;
+		expect(landed).not.toBe(document.body);
+		expect(landed.closest('[data-nav-row]')?.getAttribute('data-nav-row')).toBe('-1');
+	});
+
+	test('focus ring spans the full header cell width, not just the inner sortable label', () => {
+		const sortableColumns: TableColumn<Row>[] = [
+			{ id: 'name', name: 'Name', selector: r => r.name, sortable: true },
+			{ id: 'age', name: 'Age', selector: r => r.age },
+		];
+		const { container } = render(<DataTable columns={sortableColumns} data={rows} cellNavigation />);
+
+		fireEvent.keyDown(getCells(container)[0], { key: 'ArrowUp' });
+		const outerHeaderCell = document.activeElement!.closest('[data-nav-row="-1"][data-nav-col="0"]') as HTMLElement;
+		expect(outerHeaderCell).not.toBeNull();
+		expect(outerHeaderCell.className).toContain('rdt_TableCol');
+		// The focusable element is the inner sortable div, a descendant of the outer cell
+		// that data-nav-row/col (and therefore the :focus-within ring) is attached to.
+		expect(outerHeaderCell).not.toBe(document.activeElement);
+		expect(outerHeaderCell.contains(document.activeElement)).toBe(true);
+	});
+
+	test('Home/End jump to row edges; Ctrl+Home/Ctrl+End jump to grid corners', () => {
+		const { container } = render(<DataTable columns={columns} data={rows} cellNavigation />);
+		const cells = getCells(container);
+
+		fireEvent.keyDown(cells[2], { key: 'End' }); // row 1
+		expect(document.activeElement).toBe(cells[3]);
+
+		fireEvent.keyDown(cells[3], { key: 'Home' });
+		expect(document.activeElement).toBe(cells[2]);
+
+		fireEvent.keyDown(cells[2], { key: 'End', ctrlKey: true });
+		expect(document.activeElement).toBe(cells[5]); // last row, last column
+
+		fireEvent.keyDown(cells[5], { key: 'Home', ctrlKey: true });
+		expect(document.activeElement).toBe(cells[0]);
+	});
+
+	test('Enter and F2 open the editor on the focused editable cell', async () => {
+		const { container, unmount } = render(<DataTable columns={columns} data={rows} cellNavigation />);
+		fireEvent.keyDown(getCells(container)[0], { key: 'Enter' });
+		expect(await screen.findByDisplayValue('Alice')).toBeInTheDocument();
+		unmount();
+
+		const second = render(<DataTable columns={columns} data={rows} cellNavigation />);
+		fireEvent.keyDown(getCells(second.container)[0], { key: 'F2' });
+		expect(await second.findByDisplayValue('Alice')).toBeInTheDocument();
+	});
+
+	test('Enter on a cell does not trigger row click handlers', () => {
+		const onRowClicked = vi.fn();
+		const { container } = render(
+			<DataTable columns={columns} data={rows} cellNavigation onRowClicked={onRowClicked} />,
+		);
+		fireEvent.keyDown(getCells(container)[1], { key: 'Enter' }); // non-editable cell
+		expect(onRowClicked).not.toHaveBeenCalled();
+	});
+
+	test('arrow keys do not navigate cells while the focused cell is being edited', async () => {
+		const { container } = render(<DataTable columns={columns} data={rows} cellNavigation />);
+		const cells = getCells(container);
+
+		fireEvent.focus(cells[0]);
+		fireEvent.keyDown(cells[0], { key: 'Enter' });
+		const input = await screen.findByDisplayValue('Alice');
+
+		fireEvent.keyDown(input, { key: 'ArrowRight' });
+		// Still editing "name" on row 0 — focus has not been moved to another cell.
+		expect(screen.getByDisplayValue('Alice')).toBeInTheDocument();
+	});
+
+	test('Escape cancels editing and returns focus to the cell for further navigation', async () => {
+		const { container } = render(<DataTable columns={columns} data={rows} cellNavigation />);
+		const cells = getCells(container);
+
+		fireEvent.focus(cells[0]);
+		fireEvent.keyDown(cells[0], { key: 'Enter' });
+		const input = await screen.findByDisplayValue('Alice');
+		fireEvent.keyDown(input, { key: 'Escape' });
+
+		expect(screen.queryByDisplayValue('Alice')).not.toBeInTheDocument();
+		expect(document.activeElement).toBe(cells[0]);
+
+		// Navigation resumes normally after cancelling.
+		fireEvent.keyDown(cells[0], { key: 'ArrowRight' });
+		expect(document.activeElement).toBe(getCells(container)[1]);
+	});
+
+	test('keeps a Tab stop when the active row disappears from the page', () => {
+		const { container, rerender } = render(<DataTable columns={columns} data={rows} cellNavigation />);
+		const cells = getCells(container);
+
+		fireEvent.focus(cells[5]); // row 2, "age"
+		expect(cells[5].getAttribute('tabindex')).toBe('0');
+
+		rerender(<DataTable columns={columns} data={[rows[0]]} cellNavigation />);
+		const remaining = getCells(container);
+		expect(remaining).toHaveLength(2);
+		// Active cell clamps to the last row; the "age" column stays active.
+		expect(remaining[1].getAttribute('tabindex')).toBe('0');
+	});
+
+	test('omitted columns are excluded from the nav grid', () => {
+		const withOmit: TableColumn<Row>[] = [
+			{ id: 'name', name: 'Name', selector: r => r.name },
+			{ id: 'hidden', name: 'Hidden', selector: r => r.id, omit: true },
+			{ id: 'age', name: 'Age', selector: r => r.age },
+		];
+		const { container } = render(<DataTable columns={withOmit} data={rows} cellNavigation />);
+		const cells = getCells(container);
+		expect(cells).toHaveLength(6);
+
+		fireEvent.keyDown(cells[0], { key: 'ArrowRight' });
+		expect(document.activeElement).toBe(cells[1]); // "age", not the omitted column
+		expect(cells[1].getAttribute('data-nav-col')).toBe('1');
+	});
+
+	test('two tables with identical column ids and row keys do not steal focus from each other after editing', async () => {
+		// Each cell's `id` prop is `column.id` + row keyField with no per-table prefix, so
+		// two tables with the same columns/data produce identical DOM ids. Refocus-after-edit
+		// is ref-based (not an id lookup), so it stays scoped to the cell it belongs to.
+		function TwoTables() {
+			return (
+				<div>
+					<div data-testid="table-a">
+						<DataTable columns={columns} data={rows} cellNavigation />
+					</div>
+					<div data-testid="table-b">
+						<DataTable columns={columns} data={rows} cellNavigation />
+					</div>
+				</div>
+			);
+		}
+		render(<TwoTables />);
+
+		const tableA = screen.getByTestId('table-a');
+		const tableB = screen.getByTestId('table-b');
+		const cellsA = getCells(tableA);
+		const cellsB = getCells(tableB);
+
+		fireEvent.focus(cellsA[0]);
+		fireEvent.keyDown(cellsA[0], { key: 'Enter' });
+		const input = await screen.findAllByDisplayValue('Alice').then(inputs => inputs[0]);
+		fireEvent.keyDown(input, { key: 'Escape' });
+
+		expect(document.activeElement).toBe(cellsA[0]);
+		expect(tableB.contains(document.activeElement)).toBe(false);
+		expect(cellsB[0].getAttribute('tabindex')).toBe('0');
+	});
+});

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -58,25 +58,28 @@ type CellExtendedProps = React.HTMLAttributes<HTMLDivElement> &
 		cellStyle?: React.CSSProperties;
 	};
 
-export function CellExtended({
-	button,
-	grow,
-	maxWidth,
-	minWidth,
-	width,
-	right,
-	center,
-	compact,
-	hide,
-	allowOverflow,
-	$headCell,
-	$noPadding,
-	headStyle,
-	cellStyle,
-	className,
-	style,
-	...rest
-}: CellExtendedProps): JSX.Element {
+export const CellExtended = React.forwardRef<HTMLDivElement, CellExtendedProps>(function CellExtended(
+	{
+		button,
+		grow,
+		maxWidth,
+		minWidth,
+		width,
+		right,
+		center,
+		compact,
+		hide,
+		allowOverflow,
+		$headCell,
+		$noPadding,
+		headStyle,
+		cellStyle,
+		className,
+		style,
+		...rest
+	},
+	ref,
+) {
 	const cellProps: CellProps = { button, grow, maxWidth, minWidth, width, right, center, compact, hide, allowOverflow };
 	const computedStyle = buildCellStyle(cellProps);
 	const hideClass = buildHideClass(hide);
@@ -91,9 +94,10 @@ export function CellExtended({
 		.join(' ');
 	return (
 		<div
+			ref={ref}
 			className={baseClass}
 			style={{ ...($headCell ? headStyle : cellStyle), ...computedStyle, ...style }}
 			{...rest}
 		/>
 	);
-}
+});

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -11,6 +11,8 @@ interface CheckboxProps {
 	checked?: boolean;
 	disabled?: boolean;
 	onClick?: (e: React.MouseEvent) => void;
+	/** Roving tabindex when cell navigation is enabled */
+	tabIndex?: number;
 }
 
 function Checkbox({
@@ -21,6 +23,7 @@ function Checkbox({
 	checked = false,
 	disabled = false,
 	onClick = noop,
+	tabIndex,
 }: CheckboxProps): JSX.Element {
 	const setCheckboxRef = (checkbox: HTMLInputElement) => {
 		if (checkbox) {
@@ -48,6 +51,7 @@ function Checkbox({
 				checked={checked}
 				disabled={disabled}
 				{...resolvedComponentOptions}
+				{...(tabIndex !== undefined && { tabIndex })}
 				onChange={noop}
 			/>
 		);
@@ -73,6 +77,7 @@ function Checkbox({
 				aria-label={name}
 				checked={checked}
 				disabled={disabled}
+				tabIndex={tabIndex}
 				onChange={noop}
 			/>
 		</span>

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -27,6 +27,7 @@ import useRowContextValue from '../hooks/useRowContextValue';
 import useHeadContextValue from '../hooks/useHeadContextValue';
 import useIsomorphicLayoutEffect from '../hooks/useIsomorphicLayoutEffect';
 import { useColorMode } from '../hooks/useColorMode';
+import useCellNavigation from '../hooks/useCellNavigation';
 
 function DataTableInner<T>(props: TableProps<T>, ref: React.ForwardedRef<DataTableHandle>): JSX.Element {
 	const {
@@ -117,6 +118,7 @@ function DataTableInner<T>(props: TableProps<T>, ref: React.ForwardedRef<DataTab
 		initialColumnWidths,
 		onColumnResize,
 		animateRows = false,
+		cellNavigation = false,
 		columnSeparator,
 		headerSeparator,
 		footerComponent,
@@ -340,6 +342,21 @@ function DataTableInner<T>(props: TableProps<T>, ref: React.ForwardedRef<DataTab
 	const showTableHead = !noTableHead && (persistTableHead || progressPending || filteredSortedData.length > 0);
 	const showHeader = !noHeader && !!(title || actions);
 
+	// ── Cell navigation ────────────────────────────────────────────────────────
+	const {
+		activeCell: effectiveActiveCell,
+		handleNavFocus,
+		handleNavKeyDown,
+	} = useCellNavigation({
+		cellNavigation,
+		selectableRows,
+		expandableRows,
+		expandableRowsHideExpander,
+		effectiveColumns,
+		filteredTableRowCount: filteredTableRows.length,
+		showTableHead,
+	});
+
 	// Footer renders when explicitly enabled, when a footerComponent is provided,
 	// or when at least one visible column declares a `footer`. `showFooter={false}`
 	// suppresses the row entirely (overrides both column footers and footerComponent).
@@ -408,6 +425,8 @@ function DataTableInner<T>(props: TableProps<T>, ref: React.ForwardedRef<DataTab
 		columnWidths,
 		pinnedOffsets,
 		animateRows,
+		cellNavigation,
+		activeCell: effectiveActiveCell,
 	});
 
 	const headContextValue = useHeadContextValue<T>({
@@ -440,6 +459,8 @@ function DataTableInner<T>(props: TableProps<T>, ref: React.ForwardedRef<DataTab
 		selectableRowsComponentProps,
 		selectableRowDisabled,
 		showSelectAll,
+		cellNavigation,
+		activeCell: effectiveActiveCell,
 		progressPending,
 		sortedData: filteredSortedData,
 		onSelectAllRows: handleSelectAllRows,
@@ -518,8 +539,10 @@ function DataTableInner<T>(props: TableProps<T>, ref: React.ForwardedRef<DataTab
 									id={tableId}
 									disabled={disabled}
 									className="rdt_Table"
-									role="table"
+									role={cellNavigation ? 'grid' : 'table'}
 									aria-busy={isBusy}
+									onKeyDown={cellNavigation ? handleNavKeyDown : undefined}
+									onFocus={cellNavigation ? handleNavFocus : undefined}
 									{...(ariaLabel && { 'aria-label': ariaLabel })}
 								>
 									{showTableHead && (

--- a/src/components/DataTableHead.tsx
+++ b/src/components/DataTableHead.tsx
@@ -51,6 +51,8 @@ function DataTableHead<T>({
 		columnWidths,
 		pinnedOffsets,
 		resizable,
+		cellNavigation,
+		activeCell,
 		onSort,
 		onFilterChange,
 		onResizeStart,
@@ -163,6 +165,9 @@ function DataTableHead<T>({
 		onDragEnter,
 		onDragLeave,
 		draggingColumnId,
+		cellNavigation,
+		activeCell,
+		navCol: prefixColCount + visibleColumns.indexOf(column),
 	});
 
 	const firstRightPinnedId = React.useMemo(() => getFirstRightPinnedId(columns), [columns]);

--- a/src/components/ExpanderButton.tsx
+++ b/src/components/ExpanderButton.tsx
@@ -13,6 +13,7 @@ type ExpanderButtonProps<T> = {
 	id: string | number;
 	row: T;
 	onToggled?: (row: T) => void;
+	tabIndex?: number;
 };
 
 function ExpanderButton<T>({
@@ -23,6 +24,7 @@ function ExpanderButton<T>({
 	id,
 	row,
 	onToggled,
+	tabIndex,
 }: ExpanderButtonProps<T>): JSX.Element {
 	const customStyles = useStyles();
 	const icon = expanded ? expandableIcon.expanded : expandableIcon.collapsed;
@@ -36,6 +38,7 @@ function ExpanderButton<T>({
 			onClick={handleToggle}
 			data-testid={`expander-button-${id}`}
 			disabled={disabled}
+			tabIndex={tabIndex}
 			aria-label={
 				expanded
 					? (expandableRowsOptions?.collapseRowAriaLabel ?? 'Collapse Row')

--- a/src/components/TableCell.tsx
+++ b/src/components/TableCell.tsx
@@ -11,13 +11,23 @@ interface CellProps<T> {
 	column: TableColumn<T>;
 	row: T;
 	rowIndex: number;
+	navCol: number;
 	isDragging: boolean;
 }
 
-function Cell<T>({ id, column, row, rowIndex, dataTag, isDragging }: CellProps<T>): JSX.Element {
+function Cell<T>({ id, column, row, rowIndex, navCol, dataTag, isDragging }: CellProps<T>): JSX.Element {
 	const customStyles = useStyles();
-	const { onDragStart, onDragOver, onDragEnd, onDragEnter, onDragLeave, columnWidths, pinnedOffsets } =
-		useRowContext<T>();
+	const {
+		onDragStart,
+		onDragOver,
+		onDragEnd,
+		onDragEnter,
+		onDragLeave,
+		columnWidths,
+		pinnedOffsets,
+		cellNavigation,
+		activeCell,
+	} = useRowContext<T>();
 	const resizedWidth = column.id != null ? columnWidths[column.id] : undefined;
 	const { conditionalStyle, classNames } = getConditionalStyle(row, column.conditionalCellStyles, ['rdt_TableCell']);
 
@@ -83,13 +93,6 @@ function Cell<T>({ id, column, row, rowIndex, dataTag, isDragging }: CellProps<T
 		if (e.key === 'Escape') cancelEdit();
 	};
 
-	// ── Column pinning ─────────────────────────────────────────────────────────
-	const pinMeta = getPinnedCellMeta(column, pinnedOffsets, 1);
-
-	const editableClass = editor && !editing ? 'rdt_cellEditable' : '';
-	const editingClass = editing ? 'rdt_cellEditing' : '';
-	const errorClass = editError ? 'rdt_cellEditError' : '';
-
 	// Checkbox editor commits instantly on click — no extra state.
 	const handleCheckboxCommit = (e: React.MouseEvent<HTMLDivElement> | React.ChangeEvent<HTMLInputElement>) => {
 		e.stopPropagation();
@@ -97,11 +100,58 @@ function Cell<T>({ id, column, row, rowIndex, dataTag, isDragging }: CellProps<T
 		commitEdit(current ? 'false' : 'true');
 	};
 
+	// ── Cell navigation ────────────────────────────────────────────────────────
+	// Roving tabindex: exactly one cell in the grid is a Tab stop. Arrow-key movement
+	// and focus placement are handled centrally on the table element (see
+	// handleNavKeyDown in DataTable); this cell only renders its coordinates, its
+	// tabindex, and the editing keys.
+	const isActive = cellNavigation && activeCell != null && activeCell.row === rowIndex && activeCell.col === navCol;
+
+	// Return focus to the cell wrapper when editing ends (Enter/Escape/blur unmounts the
+	// input, which would otherwise drop focus to <body> and out of the grid entirely).
+	// `id` (the cell's DOM id, `column.id` + row keyField) is not unique across tables,
+	// so this holds a ref to the cell's own node rather than looking it up by id.
+	// The wasEditing guard stops re-renders that merely make this cell the clamped
+	// active cell (sort, filter, page change) from stealing focus from elsewhere.
+	const cellRef = React.useRef<HTMLDivElement>(null);
+	const wasEditingRef = React.useRef(false);
+	React.useEffect(() => {
+		if (cellNavigation && isActive && wasEditingRef.current && !editing) {
+			const el = cellRef.current;
+			if (el && (document.activeElement === document.body || el.contains(document.activeElement))) el.focus();
+		}
+		wasEditingRef.current = editing;
+	}, [cellNavigation, isActive, editing]);
+
+	const handleCellKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+		// While editing, keys belong to the editor input.
+		if (editing) return;
+
+		if ((e.key === 'Enter' || e.key === 'F2') && editor && editor.type !== 'checkbox') {
+			e.preventDefault();
+			startEdit();
+			return;
+		}
+
+		if (e.key === ' ' && editor?.type === 'checkbox') {
+			e.preventDefault();
+			handleCheckboxCommit(e as unknown as React.MouseEvent<HTMLDivElement>);
+		}
+	};
+
+	// ── Column pinning ─────────────────────────────────────────────────────────
+	const pinMeta = getPinnedCellMeta(column, pinnedOffsets, 1);
+
+	const editableClass = editor && !editing ? 'rdt_cellEditable' : '';
+	const editingClass = editing ? 'rdt_cellEditing' : '';
+	const errorClass = editError ? 'rdt_cellEditError' : '';
+
 	return (
 		<CellExtended
+			ref={cellRef}
 			id={id}
 			data-column-id={column.id}
-			role="cell"
+			role={cellNavigation ? 'gridcell' : 'cell'}
 			className={[classNames, pinMeta.className, editableClass, editingClass, errorClass].filter(Boolean).join(' ')}
 			data-tag={dataTag}
 			button={column.button}
@@ -123,6 +173,10 @@ function Cell<T>({ id, column, row, rowIndex, dataTag, isDragging }: CellProps<T
 			onDragEnd={column.reorder ? onDragEnd : undefined}
 			onDragEnter={column.reorder ? onDragEnter : undefined}
 			onDragLeave={column.reorder ? onDragLeave : undefined}
+			tabIndex={cellNavigation ? (isActive ? 0 : -1) : undefined}
+			data-nav-row={cellNavigation ? rowIndex : undefined}
+			data-nav-col={cellNavigation ? navCol : undefined}
+			onKeyDown={cellNavigation ? handleCellKeyDown : undefined}
 			onClick={editor && !editing && editor.type !== 'checkbox' ? startEdit : undefined}
 		>
 			{editing && (editor?.type === 'text' || editor?.type === 'number' || editor?.type === 'date') && (
@@ -159,6 +213,7 @@ function Cell<T>({ id, column, row, rowIndex, dataTag, isDragging }: CellProps<T
 						className="rdt_editCheckbox"
 						aria-checked={seedValue() === 'true'}
 						checked={seedValue() === 'true'}
+						tabIndex={cellNavigation ? -1 : undefined}
 						onChange={handleCheckboxCommit}
 						onClick={e => e.stopPropagation()}
 					/>

--- a/src/components/TableCellCheckbox.tsx
+++ b/src/components/TableCellCheckbox.tsx
@@ -4,6 +4,7 @@ import { CellBase } from './Cell';
 import Checkbox from './Checkbox';
 import { prop, isEmpty } from '../util';
 import type { RowState, SingleRowAction, RangeRowAction, ComponentProps, TableRow } from '../types';
+import type { NavCellProps } from '../context/RowContext';
 
 type TableCellCheckboxProps<T> = {
 	name: string;
@@ -20,6 +21,7 @@ type TableCellCheckboxProps<T> = {
 	visibleRowsRef: React.MutableRefObject<T[]>;
 	lastSelectedKeyRef: React.MutableRefObject<string | number | null>;
 	selectableRowsRange: boolean;
+	nav?: NavCellProps;
 };
 
 function TableCellCheckbox<T>({
@@ -37,6 +39,7 @@ function TableCellCheckbox<T>({
 	visibleRowsRef,
 	lastSelectedKeyRef,
 	selectableRowsRange,
+	nav,
 }: TableCellCheckboxProps<T>): JSX.Element {
 	const disabled = !!(selectableRowDisabled && selectableRowDisabled(row));
 	const rowKey = prop(row as TableRow, keyField) as string | number | undefined;
@@ -94,8 +97,12 @@ function TableCellCheckbox<T>({
 		<CellBase
 			onClick={(e: React.MouseEvent) => e.stopPropagation()}
 			className={['rdt_TableCell', 'rdt_cellCheckbox'].join(' ')}
-			role="cell"
+			role={nav ? 'gridcell' : 'cell'}
 			$noPadding
+			tabIndex={nav ? -1 : undefined}
+			data-nav-row={nav?.row}
+			data-nav-col={nav?.col}
+			data-nav-widget={nav ? 'true' : undefined}
 		>
 			<Checkbox
 				name={name}
@@ -105,6 +112,7 @@ function TableCellCheckbox<T>({
 				aria-checked={selected}
 				onClick={handleOnRowSelected}
 				disabled={disabled}
+				tabIndex={nav ? (nav.active ? 0 : -1) : undefined}
 			/>
 		</CellBase>
 	);

--- a/src/components/TableCellExpander.tsx
+++ b/src/components/TableCellExpander.tsx
@@ -4,6 +4,7 @@ import { useStyles } from '../context/StylesContext';
 import { CellBase } from './Cell';
 import ExpanderButton from './ExpanderButton';
 import type { ExpandableIcon, Localization } from '../types';
+import type { NavCellProps } from '../context/RowContext';
 
 type ExpandableRowsOptions = NonNullable<Localization['expandable']>;
 
@@ -15,6 +16,7 @@ type CellExpanderProps<T> = {
 	id: string | number;
 	row: T;
 	onToggled: (row: T) => void;
+	nav?: NavCellProps;
 };
 
 function CellExpander<T>({
@@ -25,6 +27,7 @@ function CellExpander<T>({
 	id,
 	onToggled,
 	disabled = false,
+	nav,
 }: CellExpanderProps<T>): JSX.Element {
 	const customStyles = useStyles();
 
@@ -34,6 +37,11 @@ function CellExpander<T>({
 			className="rdt_cellExpander"
 			$noPadding
 			style={customStyles.expanderCell?.style as React.CSSProperties}
+			role={nav ? 'gridcell' : undefined}
+			tabIndex={nav ? -1 : undefined}
+			data-nav-row={nav?.row}
+			data-nav-col={nav?.col}
+			data-nav-widget={nav ? 'true' : undefined}
 		>
 			<ExpanderButton
 				id={id}
@@ -43,6 +51,7 @@ function CellExpander<T>({
 				expandableRowsOptions={expandableRowsOptions}
 				disabled={disabled}
 				onToggled={onToggled}
+				tabIndex={nav ? (nav.active ? 0 : -1) : undefined}
 			/>
 		</CellBase>
 	);

--- a/src/components/TableCol.tsx
+++ b/src/components/TableCol.tsx
@@ -8,6 +8,7 @@ import { equalizeId, getPinnedCellMeta } from '../util';
 import type { PinnedOffsets } from '../util';
 import { SortOrder } from '../types';
 import type { TableColumn, SortAction, SortColumn, FilterState, Localization } from '../types';
+import type { ActiveCell } from '../context/RowContext';
 
 type FilterLocalization = NonNullable<Localization['filter']>;
 
@@ -40,6 +41,10 @@ type TableColProps<T> = {
 	pinnedOffsets?: PinnedOffsets;
 	/** CSS grid placement styles — injected by DataTableHead when rendering in grouped-header grid mode */
 	gridStyle?: React.CSSProperties;
+	// Cell navigation: this header cell's column in the nav grid (header row is -1)
+	cellNavigation?: boolean;
+	activeCell?: ActiveCell | null;
+	navCol?: number;
 };
 
 function TableCol<T>({
@@ -69,6 +74,9 @@ function TableCol<T>({
 	onResizeStart,
 	pinnedOffsets,
 	gridStyle,
+	cellNavigation,
+	activeCell,
+	navCol,
 }: TableColProps<T>): JSX.Element | null {
 	const customStyles = useStyles();
 
@@ -105,7 +113,8 @@ function TableCol<T>({
 	};
 
 	const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-		if (event.key === 'Enter') {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
 			handleSortChange(event.ctrlKey || event.metaKey);
 		}
 	};
@@ -142,7 +151,14 @@ function TableCol<T>({
 
 	const sortActive = !!(column.sortable && sortIndex !== -1);
 	const disableSort = !column.sortable || disabled;
-	const tabIndex = disableSort ? -1 : 0;
+	const isNavActive = !!cellNavigation && activeCell?.row === -1 && activeCell?.col === navCol;
+	// With cellNavigation the whole grid is one Tab stop (roving tabindex); otherwise
+	// only sortable headers are tabbable.
+	const tabIndex = cellNavigation ? (isNavActive ? 0 : -1) : disableSort ? -1 : 0;
+	// data-nav-row/col live on the outer cell (full column width) so the :focus-within
+	// ring spans the whole header, matching body gridcells — not just the inner sortable
+	// div, which is inset by header padding and would otherwise draw a narrower ring.
+	const outerNavAttributes = cellNavigation ? { 'data-nav-row': -1, 'data-nav-col': navCol } : undefined;
 	const nativeSortIconLeft = column.sortable && !sortIcon && !column.right;
 	const nativeSortIconRight = column.sortable && !sortIcon && column.right;
 	const customSortIconLeft = column.sortable && sortIcon && !column.right;
@@ -206,6 +222,9 @@ function TableCol<T>({
 			onDragEnd={onDragEnd}
 			onDragEnter={onDragEnter}
 			onDragLeave={onDragLeave}
+			{...outerNavAttributes}
+			data-nav-widget={cellNavigation && column.name ? 'true' : undefined}
+			{...(cellNavigation && !column.name ? { role: 'columnheader', tabIndex } : undefined)}
 		>
 			{column.name && (
 				<div
@@ -323,6 +342,14 @@ function areColPropsEqual<T>(prevProps: TableColProps<T>, nextProps: TableColPro
 		if (!pg || !ng) return false;
 		if (pg.gridColumn !== ng.gridColumn || pg.gridRow !== ng.gridRow) return false;
 	}
+	if (prevProps.cellNavigation !== nextProps.cellNavigation) return false;
+	if (prevProps.navCol !== nextProps.navCol) return false;
+	// Only re-render for active-cell changes that flip this header's Tab-stop state.
+	const prevNavActive =
+		!!prevProps.cellNavigation && prevProps.activeCell?.row === -1 && prevProps.activeCell?.col === prevProps.navCol;
+	const nextNavActive =
+		!!nextProps.cellNavigation && nextProps.activeCell?.row === -1 && nextProps.activeCell?.col === nextProps.navCol;
+	if (prevNavActive !== nextNavActive) return false;
 	return true;
 }
 

--- a/src/components/TableColCheckbox.tsx
+++ b/src/components/TableColCheckbox.tsx
@@ -14,6 +14,8 @@ function ColumnCheckbox<T>(): JSX.Element {
 		selectableRowDisabled,
 		keyField,
 		mergeSelections,
+		cellNavigation,
+		activeCell,
 		onSelectAllRows,
 	} = useHeadContext<T>();
 
@@ -32,8 +34,19 @@ function ColumnCheckbox<T>(): JSX.Element {
 		});
 	};
 
+	const navActive = cellNavigation && activeCell?.row === -1 && activeCell?.col === 0;
+
 	return (
-		<CellBase className={['rdt_TableCol', 'rdt_columnCheckbox'].join(' ')} role="columnheader" $headCell $noPadding>
+		<CellBase
+			className={['rdt_TableCol', 'rdt_columnCheckbox'].join(' ')}
+			role="columnheader"
+			$headCell
+			$noPadding
+			tabIndex={cellNavigation ? -1 : undefined}
+			data-nav-row={cellNavigation ? -1 : undefined}
+			data-nav-col={cellNavigation ? 0 : undefined}
+			data-nav-widget={cellNavigation ? 'true' : undefined}
+		>
 			<Checkbox
 				name="Select all rows"
 				component={selectableRowsComponent}
@@ -42,6 +55,7 @@ function ColumnCheckbox<T>(): JSX.Element {
 				checked={allSelected}
 				indeterminate={indeterminate}
 				disabled={isDisabled}
+				tabIndex={cellNavigation ? (navActive ? 0 : -1) : undefined}
 			/>
 		</CellBase>
 	);

--- a/src/components/TableFooter.tsx
+++ b/src/components/TableFooter.tsx
@@ -31,7 +31,7 @@ function TableFooter<T>({
 	footerComponent: FooterComponentProp,
 }: TableFooterProps<T>): JSX.Element {
 	const customStyles = useStyles();
-	const { columnWidths, pinnedOffsets } = useRowContext<T>();
+	const { columnWidths, pinnedOffsets, cellNavigation } = useRowContext<T>();
 
 	const firstRightPinnedId = React.useMemo(() => getFirstRightPinnedId(columns), [columns]);
 
@@ -64,7 +64,7 @@ function TableFooter<T>({
 						<React.Fragment key={`footer-${column.id}`}>
 							{firstRightPinnedId != null && column.id === firstRightPinnedId && <RightPinSpacer />}
 							<CellExtended
-								role="cell"
+								role={cellNavigation ? 'gridcell' : 'cell'}
 								data-column-id={column.id}
 								className={['rdt_footerCell', pinMeta.className].filter(Boolean).join(' ')}
 								button={column.button}

--- a/src/components/TableRow.tsx
+++ b/src/components/TableRow.tsx
@@ -9,7 +9,7 @@ import ExpanderRow from './ExpanderRow';
 import RightPinSpacer from './RightPinSpacer';
 import { prop, equalizeId, getConditionalStyle, getFirstRightPinnedId, isEven } from '../util';
 import { STOP_PROP_TAG } from '../constants';
-import type { TableRow } from '../types';
+import type { TableRow, TableColumn } from '../types';
 
 function isRowTarget(e: React.MouseEvent<HTMLDivElement>): boolean {
 	return (e.target as HTMLDivElement).getAttribute('data-tag') === STOP_PROP_TAG;
@@ -76,6 +76,8 @@ function Row<T>({
 		selectableRowsHighlight,
 		selectableRowsSingle,
 		striped,
+		cellNavigation,
+		activeCell,
 	} = useRowContext<T>();
 
 	type ExpanderState = { expanded: boolean; mounted: boolean; closing: boolean };
@@ -151,6 +153,9 @@ function Row<T>({
 
 	const handleKeyDown = React.useCallback(
 		(e: React.KeyboardEvent<HTMLDivElement>) => {
+			// Only act on keys pressed while the row itself is focused — with cellNavigation
+			// (or an open editor) key events bubble up from focused descendants.
+			if (e.target !== e.currentTarget) return;
 			if (e.key === 'Enter') {
 				if (!defaultExpanderDisabled && expandableRows && expandOnRowClicked) {
 					handleExpanded();
@@ -194,6 +199,17 @@ function Row<T>({
 
 	const rowKeyField = prop(row as TableRow, keyField) ?? rowIndex;
 
+	// Cell navigation: selection/expander cells occupy the first nav columns, then each
+	// non-omitted data column gets the next index.
+	const navPrefixCount = (selectableRows ? 1 : 0) + (expandableRows && !expandableRowsHideExpander ? 1 : 0);
+	const columnIndexMap = React.useMemo(() => {
+		const map = new Map<TableColumn<T>, number>();
+		let i = 0;
+		for (const c of columns) if (!c.omit) map.set(c, i++);
+		return map;
+	}, [columns]);
+	const navRowActive = cellNavigation && activeCell?.row === rowIndex;
+
 	const firstRightPinnedId = React.useMemo(() => getFirstRightPinnedId(columns), [columns]);
 	const { conditionalStyle, classNames } = React.useMemo(
 		() => getConditionalStyle(row, conditionalRowStyles, ['rdt_TableRow']),
@@ -235,7 +251,7 @@ function Row<T>({
 				id={`row-${id}`}
 				role="row"
 				aria-selected={selectableRows ? selected : undefined}
-				tabIndex={!defaultExpanderDisabled && showPointer ? 0 : -1}
+				tabIndex={cellNavigation ? -1 : !defaultExpanderDisabled && showPointer ? 0 : -1}
 				className={className}
 				style={style}
 				onClick={handleRowClick}
@@ -261,6 +277,7 @@ function Row<T>({
 						visibleRowsRef={visibleRowsRef}
 						lastSelectedKeyRef={lastSelectedKeyRef}
 						selectableRowsRange={selectableRowsRange}
+						nav={cellNavigation ? { row: rowIndex, col: 0, active: navRowActive && activeCell?.col === 0 } : undefined}
 					/>
 				)}
 
@@ -273,6 +290,15 @@ function Row<T>({
 						row={row}
 						onToggled={handleExpanded}
 						disabled={defaultExpanderDisabled}
+						nav={
+							cellNavigation
+								? {
+										row: rowIndex,
+										col: selectableRows ? 1 : 0,
+										active: navRowActive && activeCell?.col === (selectableRows ? 1 : 0),
+									}
+								: undefined
+						}
 					/>
 				)}
 
@@ -290,6 +316,7 @@ function Row<T>({
 								column={column}
 								row={row}
 								rowIndex={rowIndex}
+								navCol={navPrefixCount + (columnIndexMap.get(column) ?? 0)}
 								isDragging={equalizeId(draggingColumnId, column.id)}
 							/>
 						</React.Fragment>

--- a/src/context/HeadContext.tsx
+++ b/src/context/HeadContext.tsx
@@ -11,6 +11,7 @@ import type {
 	Localization,
 } from '../types';
 import type { PinnedOffsets } from '../util';
+import type { ActiveCell } from './RowContext';
 
 export interface HeadContextValue<T> {
 	// Sort state
@@ -44,6 +45,9 @@ export interface HeadContextValue<T> {
 	columnWidths: Record<string | number, number>;
 	pinnedOffsets: PinnedOffsets;
 	resizable: boolean;
+	// Cell navigation (row -1 of the nav grid is the header row)
+	cellNavigation: boolean;
+	activeCell: ActiveCell | null;
 	// Table state
 	progressPending: boolean;
 	sortedData: T[];

--- a/src/context/RowContext.tsx
+++ b/src/context/RowContext.tsx
@@ -61,6 +61,26 @@ export interface RowContextValue<T> {
 	pinnedOffsets: PinnedOffsets;
 	/** Whether to animate rows on mount */
 	animateRows: boolean;
+	/** Enable spreadsheet-style keyboard navigation between cells. */
+	cellNavigation: boolean;
+	/**
+	 * The roving-tabindex target when `cellNavigation` is on, clamped by DataTable to the
+	 * current page and column set so exactly one cell is always a Tab stop. Row `-1` is
+	 * the header row; columns count selection/expander cells before data columns.
+	 */
+	activeCell: ActiveCell | null;
+}
+
+export interface ActiveCell {
+	row: number;
+	col: number;
+}
+
+/** Position + Tab-stop state a row passes to its selection/expander cells. */
+export interface NavCellProps {
+	row: number;
+	col: number;
+	active: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/hooks/useCellNavigation.ts
+++ b/src/hooks/useCellNavigation.ts
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import type { ActiveCell } from '../context/RowContext';
+import type { TableColumn } from '../types';
+
+const NAV_KEYS = ['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown', 'Home', 'End'];
+
+// Focus the navigable cell at (row, col). Falls back to the nearest column in the same
+// row when the exact coordinate has no cell (e.g. a header slot with no bulk action, like
+// the expander column). Cells flagged data-nav-widget hand focus to their single
+// interactive child — an input/button (row checkbox, expander button) or, for sortable
+// headers, the inner columnheader div — so Space/Enter activate it natively and the
+// visible focus ring (drawn on the outer cell via :focus-within) still spans the full
+// column width instead of just the inner element. A disabled widget falls back to the cell.
+function focusNavCell(root: HTMLElement, row: number, col: number): void {
+	let cell = root.querySelector<HTMLElement>(`[data-nav-row="${row}"][data-nav-col="${col}"]`);
+	if (!cell) {
+		let best = Number.POSITIVE_INFINITY;
+		root.querySelectorAll<HTMLElement>(`[data-nav-row="${row}"]`).forEach(candidate => {
+			const dist = Math.abs(Number(candidate.dataset.navCol) - col);
+			if (dist < best) {
+				best = dist;
+				cell = candidate;
+			}
+		});
+	}
+	if (!cell) return;
+	const widget = cell.dataset.navWidget
+		? cell.querySelector<HTMLElement>('input:not(:disabled), button:not(:disabled), [role="columnheader"]')
+		: null;
+	(widget ?? cell).focus();
+}
+
+type Options<T> = {
+	cellNavigation: boolean;
+	selectableRows: boolean;
+	expandableRows: boolean;
+	expandableRowsHideExpander: boolean;
+	effectiveColumns: TableColumn<T>[];
+	filteredTableRowCount: number;
+	showTableHead: boolean;
+};
+
+// The nav grid counts selection/expander cells before data columns; row -1 is the
+// header row. The stored active cell is clamped into the current page/column bounds
+// so the grid always keeps exactly one Tab stop even when the active row is sorted,
+// filtered, or paginated away.
+export default function useCellNavigation<T>({
+	cellNavigation,
+	selectableRows,
+	expandableRows,
+	expandableRowsHideExpander,
+	effectiveColumns,
+	filteredTableRowCount,
+	showTableHead,
+}: Options<T>) {
+	const [activeCell, setActiveCell] = React.useState<ActiveCell | null>(null);
+
+	const navPrefixCols = (selectableRows ? 1 : 0) + (expandableRows && !expandableRowsHideExpander ? 1 : 0);
+	const totalNavCols = navPrefixCols + effectiveColumns.filter(c => !c.omit).length;
+	const navMinRow = showTableHead ? -1 : 0;
+	const navMaxRow = filteredTableRowCount - 1;
+
+	const effectiveActiveCell = React.useMemo((): ActiveCell | null => {
+		if (!cellNavigation || totalNavCols === 0 || navMaxRow < navMinRow) return null;
+		const base = activeCell ?? { row: navMaxRow >= 0 ? 0 : navMinRow, col: 0 };
+		return {
+			row: Math.min(Math.max(base.row, navMinRow), navMaxRow),
+			col: Math.min(Math.max(base.col, 0), totalNavCols - 1),
+		};
+	}, [cellNavigation, activeCell, navMinRow, navMaxRow, totalNavCols]);
+
+	const handleNavFocus = React.useCallback((e: React.FocusEvent<HTMLDivElement>) => {
+		const cell = (e.target as HTMLElement).closest<HTMLElement>('[data-nav-row]');
+		if (!cell) return;
+		const row = Number(cell.dataset.navRow);
+		const col = Number(cell.dataset.navCol);
+		setActiveCell(prev => (prev && prev.row === row && prev.col === col ? prev : { row, col }));
+	}, []);
+
+	const handleNavKeyDown = React.useCallback(
+		(e: React.KeyboardEvent<HTMLDivElement>) => {
+			if (e.defaultPrevented) return;
+			if (!NAV_KEYS.includes(e.key) && e.key !== ' ') return;
+			const target = e.target as HTMLElement;
+			const cell = target.closest<HTMLElement>('[data-nav-row]');
+			if (!cell) return;
+
+			// Space on a focused cell wrapper would scroll the page; swallow it. Widgets and
+			// editors handle Space themselves and preventDefault before it bubbles here.
+			if (e.key === ' ') {
+				if (target === cell) e.preventDefault();
+				return;
+			}
+
+			// Don't hijack arrows from text-entry widgets (open editors, custom cell content).
+			const tag = target.tagName;
+			if (target.isContentEditable || tag === 'TEXTAREA' || tag === 'SELECT') return;
+			if (tag === 'INPUT' && !['checkbox', 'radio', 'button'].includes((target as HTMLInputElement).type)) return;
+			if (target.closest('.rdt_editCustomWrap')) return;
+
+			const rtl = getComputedStyle(e.currentTarget).direction === 'rtl';
+			const row = Number(cell.dataset.navRow);
+			const col = Number(cell.dataset.navCol);
+			let nextRow = row;
+			let nextCol = col;
+
+			switch (e.key) {
+				case 'ArrowRight':
+					nextCol += rtl ? -1 : 1;
+					break;
+				case 'ArrowLeft':
+					nextCol += rtl ? 1 : -1;
+					break;
+				case 'ArrowDown':
+					nextRow += 1;
+					break;
+				case 'ArrowUp':
+					nextRow -= 1;
+					break;
+				case 'Home':
+					nextCol = 0;
+					if (e.ctrlKey || e.metaKey) nextRow = navMaxRow >= 0 ? 0 : navMinRow;
+					break;
+				case 'End':
+					nextCol = totalNavCols - 1;
+					if (e.ctrlKey || e.metaKey) nextRow = navMaxRow >= 0 ? navMaxRow : navMinRow;
+					break;
+			}
+
+			nextRow = Math.min(Math.max(nextRow, navMinRow), Math.max(navMaxRow, navMinRow));
+			nextCol = Math.min(Math.max(nextCol, 0), Math.max(totalNavCols - 1, 0));
+			e.preventDefault();
+			if (nextRow === row && nextCol === col) return;
+			focusNavCell(e.currentTarget, nextRow, nextCol);
+		},
+		[navMinRow, navMaxRow, totalNavCols],
+	);
+
+	return { activeCell: effectiveActiveCell, handleNavFocus, handleNavKeyDown };
+}

--- a/src/hooks/useHeadContextValue.ts
+++ b/src/hooks/useHeadContextValue.ts
@@ -40,6 +40,8 @@ export default function useHeadContextValue<T>(options: HeadContextValue<T>): He
 			options.selectableRowsComponentProps,
 			options.selectableRowDisabled,
 			options.showSelectAll,
+			options.cellNavigation,
+			options.activeCell,
 			options.progressPending,
 			options.sortedData,
 			options.onSelectAllRows,

--- a/src/hooks/useRowContextValue.ts
+++ b/src/hooks/useRowContextValue.ts
@@ -52,6 +52,8 @@ export default function useRowContextValue<T>(options: RowContextValue<T>): RowC
 			options.pinnedOffsets,
 			options.animateRows,
 			options.localization,
+			options.cellNavigation,
+			options.activeCell,
 		],
 	);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,6 +238,16 @@ type BaseTableProps<T> = {
 	 * so you can persist to localStorage, a database, or anywhere else.
 	 */
 	onColumnResize?: (columnId: string | number, width: number, allWidths: Record<string | number, number>) => void;
+	/**
+	 * Enable spreadsheet-style keyboard navigation between cells. The table renders as a
+	 * WAI-ARIA grid (`role="grid"`, single Tab stop, roving tabindex): arrow keys move
+	 * between cells — including selection checkboxes, expander buttons, and the header
+	 * row — Home/End jump to the row edges, and Ctrl+Home/Ctrl+End jump to the grid
+	 * corners. Enter or F2 opens the focused cell's editor if it has one
+	 * (`editable`/`editor`) and Escape cancels it; Enter or Space on a header sorts the
+	 * column. Navigation is clamped to the current page. Defaults to `false`.
+	 */
+	cellNavigation?: boolean;
 	/** Animate rows on mount and expander rows on expand (respects prefers-reduced-motion) */
 	animateRows?: boolean;
 	/**


### PR DESCRIPTION
Adds an opt-in `cellNavigation` prop that turns the table into a WAI-ARIA grid (role="grid"/"gridcell", single Tab stop, roving tabindex). Arrow keys move between cells including the header row, selection checkboxes, and expander buttons; Home/End and Ctrl+Home/Ctrl+End jump row/grid edges; Enter/F2 open a cell's editor and Escape cancels it; Enter/Space sort from a header. Non-interactive header slots (e.g. the expander column) are excluded from the nav grid rather than given a bulk action.

Refocus-after-edit now targets a ref to the cell's own DOM node instead of `document.getElementById`, since cell ids aren't unique across multiple DataTable instances on the same page.

Adds a dedicated Keyboard Navigation docs page with per-shortcut demos, and updates Accessibility's ARIA role tables to cover grid mode.
