### PR TITLE
fix: preserve row hover background with inline styles

### DIFF
--- a/src/DataTable.css
+++ b/src/DataTable.css
@@ -167,7 +167,7 @@
 
 .rdt_rowHighlight:hover {
 	color: var(--rdt-color-highlight-text, rgba(0, 0, 0, 0.87));
-	background-color: var(--rdt-color-highlight, #eee);
+	background-color: var(--rdt-color-highlight, #eee) !important;
 	outline: 1px solid var(--rdt-color-bg, #fff);
 	transition-duration: 0.15s;
 	transition-property: background-color;


### PR DESCRIPTION
## Summary

Fixes the row hover background when a row already has an inline
`background-color` applied through `customStyles`.

## Problem

When `highlightOnHover` is enabled, the row receives the
`rdt_rowHighlight` class and the configured `--rdt-color-highlight`
value is available.

However, row background styles from `customStyles.rows.style` are
applied inline. The inline `background-color` takes precedence over
the normal declaration in `.rdt_rowHighlight:hover`, so the hover
background is not visible.

## Change

Adds `!important` to the active hover background declaration:

```css
.rdt_rowHighlight:hover {
    background-color: var(--rdt-color-highlight, #eee) !important;
}