### PR TITLE
Add ctx.error and ctx.inputRef to custom cell editors, live validation server-save demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 A summary of notable changes per release. For the full commit history see the [repository on GitHub](https://github.com/jbetancur/react-data-table-component/commits/master).
 
+## 8.7.0
+
+### New features
+
+- **`ctx.error` for custom editors** — the custom editor render context now includes the current validation error (`string | null`), so custom editors can style their own invalid state when `validate` rejects a commit. → [Inline editing](/docs/inline-editing) ([#1355](https://github.com/jbetancur/react-data-table-component/issues/1355))
+- **`ctx.inputRef` for custom editors** — attach it as the `ref` of your focusable element to get auto-focus when the editor opens and refocus after a rejected commit, matching the built-in editors. → [Inline editing](/docs/inline-editing) ([#1355](https://github.com/jbetancur/react-data-table-component/issues/1355))
+
+---
+
 ## 8.6.2
 
 ### Bug fixes

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -49,7 +49,7 @@ const columns = [
 - [Fixed Header](https://reactdatatable.com/docs/fixed-header): sticky header with scrollable body; when to disable the responsive scroll container
 - [Footer](https://reactdatatable.com/docs/footer): summary and pagination footers
 - [Loading State](https://reactdatatable.com/docs/loading): progress and skeleton states
-- [Inline Editing](https://reactdatatable.com/docs/inline-editing): edit cells in place
+- [Inline Editing](https://reactdatatable.com/docs/inline-editing): edit cells in place with built-in editor types, per-column validation, and optimistic server-save patterns
 
 ## Styling
 

--- a/apps/docs/src/components/demos/InlineEditingDemo.tsx
+++ b/apps/docs/src/components/demos/InlineEditingDemo.tsx
@@ -34,7 +34,7 @@ export default function InlineEditingDemo() {
 
 	const handleCellEdit = (row: Employee, value: string, column: TableColumn<Employee>) => {
 		const field = column.id as keyof Employee;
-		const parsed = field === 'salary' ? Number(value) || row.salary : field === 'remote' ? value === 'true' : value;
+		const parsed = field === 'salary' ? Number(value) : field === 'remote' ? value === 'true' : value;
 		setData(prev => prev.map(r => (r.id === row.id ? { ...r, [field]: parsed } : r)));
 		setLastEdit(`Updated ${row.name} → ${String(column.name)}: "${value}"`);
 	};
@@ -46,6 +46,7 @@ export default function InlineEditingDemo() {
 			selector: r => r.name,
 			sortable: true,
 			editable: true,
+			validate: value => (value.trim() === '' ? 'Name is required' : true),
 			onCellEdit: handleCellEdit,
 		},
 		{
@@ -99,6 +100,10 @@ export default function InlineEditingDemo() {
 			sortable: true,
 			right: true,
 			editable: true,
+			validate: value => {
+				const n = Number(value);
+				return Number.isFinite(n) && n > 0 ? true : 'Enter a positive number';
+			},
 			onCellEdit: handleCellEdit,
 		},
 		{
@@ -117,8 +122,10 @@ export default function InlineEditingDemo() {
 			<p className="text-xs text-gray-400">
 				Click any cell to edit. <strong>Name</strong> and <strong>Salary</strong> are text inputs;{' '}
 				<strong>Department</strong> and <strong>Status</strong> are dropdowns; <strong>Remote</strong> is a checkbox.{' '}
-				<kbd>Enter</kbd> commits, <kbd>Esc</kbd> cancels. Keyboard navigation is enabled too: click or Tab into the
-				table, move between cells and headers with the arrow keys, and press <kbd>Enter</kbd> to edit or sort.
+				<kbd>Enter</kbd> commits, <kbd>Esc</kbd> cancels. <strong>Name</strong> and <strong>Salary</strong> are
+				validated: try committing an empty name or a negative salary to see the inline error. Keyboard navigation is
+				enabled too: click or Tab into the table, move between cells and headers with the arrow keys, and press{' '}
+				<kbd>Enter</kbd> to edit or sort.
 			</p>
 			<DataTable columns={columns} data={data} highlightOnHover cellNavigation />
 			{lastEdit && <div className="text-xs text-emerald-600 font-mono">{lastEdit}</div>}

--- a/apps/docs/src/components/demos/ServerSideEditDemo.tsx
+++ b/apps/docs/src/components/demos/ServerSideEditDemo.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import DataTable from '../ThemedDataTable';
+import { type TableColumn } from 'react-data-table-component';
+
+interface Product {
+	id: number;
+	sku: string;
+	name: string;
+	stock: number;
+	price: number;
+}
+
+const initialData: Product[] = [
+	{ id: 1, sku: 'CH-114', name: 'Aeron Chair', stock: 12, price: 745 },
+	{ id: 2, sku: 'DK-208', name: 'Standing Desk', stock: 7, price: 890 },
+	{ id: 3, sku: 'MN-330', name: '32" Monitor', stock: 24, price: 429 },
+	{ id: 4, sku: 'KB-501', name: 'Mech Keyboard', stock: 41, price: 159 },
+	{ id: 5, sku: 'LM-612', name: 'Desk Lamp', stock: 63, price: 49 },
+];
+
+function saveToServer(field: keyof Product, value: string | number): Promise<void> {
+	return new Promise((resolve, reject) =>
+		setTimeout(() => {
+			if (field === 'price' && Number(value) > 1000) reject(new Error('Price exceeds the $1,000 cap'));
+			else resolve();
+		}, 900),
+	);
+}
+
+export default function ServerSideEditDemo() {
+	const [data, setData] = React.useState<Product[]>(initialData);
+	const [savingId, setSavingId] = React.useState<number | null>(null);
+	const [status, setStatus] = React.useState<{ ok: boolean; message: string } | null>(null);
+
+	const handleCellEdit = async (row: Product, value: string, column: TableColumn<Product>) => {
+		const field = column.id as keyof Product;
+		const parsed = field === 'name' ? value : Number(value);
+		setData(prev => prev.map(r => (r.id === row.id ? { ...r, [field]: parsed } : r)));
+		setSavingId(row.id);
+		setStatus({ ok: true, message: `Saving ${row.sku}…` });
+		try {
+			await saveToServer(field, parsed);
+			setStatus({ ok: true, message: `Saved ${row.sku} → ${String(column.name)}: "${value}"` });
+		} catch (err) {
+			setData(prev => prev.map(r => (r.id === row.id ? { ...r, [field]: row[field] } : r)));
+			setStatus({ ok: false, message: `${(err as Error).message} — rolled back ${row.sku}` });
+		} finally {
+			setSavingId(null);
+		}
+	};
+
+	const columns: TableColumn<Product>[] = [
+		{ id: 'sku', name: 'SKU', selector: r => r.sku, width: '90px' },
+		{ id: 'name', name: 'Product', selector: r => r.name, editable: true, onCellEdit: handleCellEdit },
+		{
+			id: 'stock',
+			name: 'Stock',
+			selector: r => r.stock,
+			right: true,
+			editor: { type: 'number', min: 0, step: 1 },
+			validate: value => (Number.isInteger(Number(value)) && Number(value) >= 0 ? true : 'Enter a whole number'),
+			onCellEdit: handleCellEdit,
+		},
+		{
+			id: 'price',
+			name: 'Price',
+			selector: r => r.price,
+			format: r => `$${r.price.toLocaleString()}`,
+			right: true,
+			editor: { type: 'number', min: 0, step: 1 },
+			validate: value => (Number(value) > 0 ? true : 'Enter a positive number'),
+			onCellEdit: handleCellEdit,
+		},
+	];
+
+	return (
+		<div className="space-y-2">
+			<p className="text-xs text-gray-400">
+				Edits apply optimistically, then save to a simulated server with ~1s latency. The row dims while the save is in
+				flight. The server rejects any <strong>Price</strong> over $1,000 — try it to watch the edit roll back.
+			</p>
+			<DataTable
+				columns={columns}
+				data={data}
+				highlightOnHover
+				conditionalRowStyles={[{ when: r => r.id === savingId, style: { opacity: 0.45 } }]}
+			/>
+			{status && (
+				<div className={`text-xs font-mono ${status.ok ? 'text-emerald-600' : 'text-red-600'}`}>{status.message}</div>
+			)}
+		</div>
+	);
+}

--- a/apps/docs/src/pages/docs/api.astro
+++ b/apps/docs/src/pages/docs/api.astro
@@ -195,6 +195,8 @@ interface CustomCellEditorContext<T> {
   commit: (value?: string) => void;
   cancel: () => void;
   column: TableColumn<T>;
+  error: string | null;
+  inputRef: React.RefCallback<HTMLElement>;
 }`} lang="ts" />
 
   <DocsTable

--- a/apps/docs/src/pages/docs/inline-editing.astro
+++ b/apps/docs/src/pages/docs/inline-editing.astro
@@ -3,6 +3,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
 import Demo from '../../components/Demo.astro';
 import CodeBlock from '../../components/CodeBlock.astro';
 import InlineEditingDemo from '../../components/demos/InlineEditingDemo.tsx';
+import ServerSideEditDemo from '../../components/demos/ServerSideEditDemo.tsx';
 import DocsTable from '../../components/DocsTable.astro';
 ---
 
@@ -30,7 +31,7 @@ import DocsTable from '../../components/DocsTable.astro';
 
   <Demo
     title="Editable cells — text + dropdown"
-    description="Name and Salary use text inputs. Department and Status use dropdowns. Click any cell to edit."
+    description="Name and Salary use text inputs with validation. Department and Status use dropdowns. Click any cell to edit."
     code={`import { useState } from 'react';
 import DataTable, { type TableColumn } from 'react-data-table-component';
 
@@ -48,13 +49,20 @@ export default function App() {
   const handleCellEdit = (row: Employee, value: string, column: TableColumn<Employee>) => {
     const field = column.id as keyof Employee;
     setData(prev =>
-      prev.map(r => (r.id === row.id ? { ...r, [field]: field === 'salary' ? Number(value) || r.salary : value } : r)),
+      prev.map(r => (r.id === row.id ? { ...r, [field]: field === 'salary' ? Number(value) : value } : r)),
     );
   };
 
   const columns: TableColumn<Employee>[] = [
     // Text editor — editable: true is shorthand for { editor: { type: 'text' } }
-    { id: 'name', name: 'Name', selector: r => r.name, editable: true, onCellEdit: handleCellEdit },
+    {
+      id: 'name',
+      name: 'Name',
+      selector: r => r.name,
+      editable: true,
+      validate: value => (value.trim() === '' ? 'Name is required' : true),
+      onCellEdit: handleCellEdit,
+    },
 
     // Dropdown editor
     {
@@ -96,6 +104,10 @@ export default function App() {
       format: r => \`$\${r.salary.toLocaleString()}\`,
       right: true,
       editable: true,
+      validate: value => {
+        const n = Number(value);
+        return Number.isFinite(n) && n > 0 ? true : 'Enter a positive number';
+      },
       onCellEdit: handleCellEdit,
     },
   ];
@@ -216,9 +228,9 @@ export default function App() {
   id: 'role', name: 'Role', selector: r => r.role,
   editor: {
     type: 'custom',
-    render: ({ value, setValue, commit, cancel, row }) => (
+    render: ({ value, setValue, commit, cancel, row, inputRef }) => (
       <Autocomplete
-        autoFocus
+        ref={inputRef}
         value={value}
         onChange={setValue}
         onSelect={v => commit(v)}
@@ -234,6 +246,17 @@ export default function App() {
     The <code>ctx.row</code> field gives you the row data for context-aware editors
     (dependent dropdowns, etc.). The cell wrapper still owns padding and the focus ring —
     your custom editor only needs to render the input.
+  </p>
+
+  <p>
+    Validation works the same as for built-in editors: <code>ctx.commit</code> runs the
+    column's <code>validate</code> first, and a string result keeps the editor open with the
+    inline error tooltip. Since 8.7.0 the render context also carries the current error as
+    <code>ctx.error</code> (<code>string | null</code>), so your editor can style its own
+    invalid state, e.g. <code>aria-invalid=&#123;!!ctx.error&#125;</code>. Attach
+    <code>ctx.inputRef</code> as the <code>ref</code> of your focusable element to get the
+    same focus handling as the built-in editors: auto-focus when the editor opens and
+    refocus after a rejected commit.
   </p>
 
   <h2>The cell becomes the editor</h2>
@@ -292,6 +315,60 @@ export default function App() {
     console.error('Save failed:', err);
   }
 };`} />
+
+  <Demo
+    title="Server-side saves — optimistic update with rollback"
+    description="Edits apply immediately and save to a simulated server. Failed saves roll back. The server rejects prices over $1,000."
+    code={`import { useState } from 'react';
+import DataTable, { type TableColumn } from 'react-data-table-component';
+
+export default function App() {
+  const [data, setData] = useState<Product[]>(initialData);
+  const [savingId, setSavingId] = useState<number | null>(null);
+
+  const handleCellEdit = async (row: Product, value: string, column: TableColumn<Product>) => {
+    const field = column.id as keyof Product;
+    const parsed = field === 'name' ? value : Number(value);
+
+    // Optimistic update
+    setData(prev => prev.map(r => (r.id === row.id ? { ...r, [field]: parsed } : r)));
+    setSavingId(row.id);
+
+    try {
+      await api.updateProduct(row.id, { [field]: parsed });
+    } catch (err) {
+      // Roll back the field to its pre-edit value
+      setData(prev => prev.map(r => (r.id === row.id ? { ...r, [field]: row[field] } : r)));
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  const columns: TableColumn<Product>[] = [
+    { id: 'sku', name: 'SKU', selector: r => r.sku },
+    { id: 'name', name: 'Product', selector: r => r.name, editable: true, onCellEdit: handleCellEdit },
+    {
+      id: 'price',
+      name: 'Price',
+      selector: r => r.price,
+      right: true,
+      editor: { type: 'number', min: 0 },
+      validate: value => (Number(value) > 0 ? true : 'Enter a positive number'),
+      onCellEdit: handleCellEdit,
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      data={data}
+      conditionalRowStyles={[{ when: r => r.id === savingId, style: { opacity: 0.45 } }]}
+    />
+  );
+}`}
+  >
+    <ServerSideEditDemo client:load />
+  </Demo>
 
   <h2>Validation</h2>
   <p>

--- a/src/__tests__/inlineEditing.test.tsx
+++ b/src/__tests__/inlineEditing.test.tsx
@@ -224,4 +224,78 @@ describe('inline editing: custom editor', () => {
 		await waitFor(() => expect(onCellEdit).toHaveBeenCalled());
 		expect(onCellEdit.mock.calls[0][1]).toBe('Zara');
 	});
+
+	test('receives the validation error via ctx.error after a rejected commit', async () => {
+		const onCellEdit = vi.fn();
+		const columns: TableColumn<Row>[] = [
+			{
+				id: 'name',
+				name: 'Name',
+				selector: r => r.name,
+				editor: {
+					type: 'custom',
+					render: ctx => (
+						<button data-testid="custom-commit" data-error={ctx.error ?? ''} onClick={() => ctx.commit('')}>
+							save
+						</button>
+					),
+				},
+				validate: value => (value === '' ? 'Must not be empty' : true),
+				onCellEdit,
+			},
+		];
+
+		const { getByText } = render(<DataTable columns={columns} data={rows} />);
+		clickCell(getByText, 'Alice');
+
+		const btn = await screen.findByTestId('custom-commit');
+		expect(btn).toHaveAttribute('data-error', '');
+		fireEvent.click(btn);
+
+		await waitFor(() => expect(screen.getByTestId('custom-commit')).toHaveAttribute('data-error', 'Must not be empty'));
+		expect(onCellEdit).not.toHaveBeenCalled();
+	});
+
+	test('focuses the element attached to ctx.inputRef on open and after a rejected commit', async () => {
+		const onCellEdit = vi.fn();
+		const columns: TableColumn<Row>[] = [
+			{
+				id: 'name',
+				name: 'Name',
+				selector: r => r.name,
+				editor: {
+					type: 'custom',
+					render: ctx => (
+						<>
+							<input
+								data-testid="custom-input"
+								ref={ctx.inputRef}
+								value={ctx.value}
+								onChange={e => ctx.setValue(e.target.value)}
+							/>
+							<button data-testid="custom-save" onClick={() => ctx.commit('')}>
+								save
+							</button>
+						</>
+					),
+				},
+				validate: value => (value === '' ? 'Must not be empty' : true),
+				onCellEdit,
+			},
+		];
+
+		const { getByText } = render(<DataTable columns={columns} data={rows} />);
+		clickCell(getByText, 'Alice');
+
+		const input = await screen.findByTestId('custom-input');
+		await waitFor(() => expect(input).toHaveFocus());
+
+		const saveBtn = screen.getByTestId('custom-save');
+		saveBtn.focus();
+		expect(input).not.toHaveFocus();
+		fireEvent.click(saveBtn);
+
+		await waitFor(() => expect(input).toHaveFocus());
+		expect(onCellEdit).not.toHaveBeenCalled();
+	});
 });

--- a/src/components/CellEditor.tsx
+++ b/src/components/CellEditor.tsx
@@ -17,6 +17,7 @@ function CellEditor<T>({ edit, row, column, cellNavigation }: CellEditorProps<T>
 		setEditValue,
 		editError,
 		inputRef,
+		customInputRef,
 		seedValue,
 		cancelEdit,
 		commitEdit,
@@ -102,6 +103,8 @@ function CellEditor<T>({ edit, row, column, cellNavigation }: CellEditorProps<T>
 						commit: commitEdit,
 						cancel: cancelEdit,
 						column,
+						error: editError,
+						inputRef: customInputRef,
 					})}
 				</div>
 			)}

--- a/src/hooks/useCellEdit.ts
+++ b/src/hooks/useCellEdit.ts
@@ -7,7 +7,8 @@ export interface CellEditApi<T> {
 	editValue: string;
 	setEditValue: React.Dispatch<React.SetStateAction<string>>;
 	editError: string | null;
-	inputRef: React.RefObject<HTMLInputElement | HTMLSelectElement>;
+	inputRef: React.MutableRefObject<HTMLElement | null>;
+	customInputRef: React.RefCallback<HTMLElement>;
 	seedValue: () => string;
 	startEdit: () => void;
 	cancelEdit: () => void;
@@ -26,7 +27,10 @@ export default function useCellEdit<T>(column: TableColumn<T>, row: T, rowIndex:
 	const [editing, setEditing] = React.useState(false);
 	const [editValue, setEditValue] = React.useState('');
 	const [editError, setEditError] = React.useState<string | null>(null);
-	const inputRef = React.useRef<HTMLInputElement | HTMLSelectElement>(null);
+	const inputRef = React.useRef<HTMLElement | null>(null);
+	const customInputRef = React.useCallback<React.RefCallback<HTMLElement>>(el => {
+		inputRef.current = el;
+	}, []);
 
 	const seedValue = React.useCallback((): string => {
 		const raw = column.selector ? column.selector(row, rowIndex) : undefined;
@@ -92,6 +96,7 @@ export default function useCellEdit<T>(column: TableColumn<T>, row: T, rowIndex:
 		setEditValue,
 		editError,
 		inputRef,
+		customInputRef,
 		seedValue,
 		startEdit,
 		cancelEdit,

--- a/src/types.ts
+++ b/src/types.ts
@@ -418,6 +418,10 @@ export interface CustomCellEditorContext<T = unknown> {
 	cancel: () => void;
 	/** The column definition. */
 	column: TableColumn<T>;
+	/** Current validation error from `validate`, or `null`. Set when a commit was rejected with a message. */
+	error: string | null;
+	/** Attach as `ref` on your focusable element to opt in to auto-focus on open and refocus after a rejected commit. */
+	inputRef: React.RefCallback<HTMLElement>;
 }
 
 /** Options for inline cell editors. */


### PR DESCRIPTION
Custom editors couldn't see validation errors or get the same focus handling as built-in editors. Also adds live demos for validate and optimistic server-side saves with rollback to the inline editing docs.

Closes #1355