### PR TITLE
add datetime/time filter types, fix filter pagination and id-less filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 A summary of notable changes per release. For the full commit history see the [repository on GitHub](https://github.com/jbetancur/react-data-table-component/commits/master).
 
+## 8.8.0
+
+### New features
+
+- **`filterType: 'datetime'`** — filter columns down to a specific date and time via a `datetime-local` input, reusing the date operators. `Equals` matches the exact instant rather than the whole calendar day. → [Filtering](/docs/filtering) ([#1362](https://github.com/jbetancur/react-data-table-component/issues/1362))
+- **`filterType: 'time'`** — filter by time of day, ignoring the date, so a filter matches across every date at once (e.g. "errors between 02:00 and 04:00"). Accepts seconds precision, reads the time portion of full timestamps, and a `Between` whose start is later than its end wraps past midnight. → [Filtering](/docs/filtering)
+
+### Bug fixes
+
+- With client-side pagination, column filtering only matched rows on the current page — filtering ran after the page was sliced, so matches on other pages never appeared and the result count disagreed with the rows shown. Filtering now runs on the full sorted set before pagination. → [Filtering](/docs/filtering) ([#1364](https://github.com/jbetancur/react-data-table-component/issues/1364))
+- A `filterable` column without an explicit `id` showed the filter UI but never actually filtered, because the filter matched against undecorated columns whose ids had not yet been auto-assigned. → [Filtering](/docs/filtering) ([#1363](https://github.com/jbetancur/react-data-table-component/issues/1363))
+
+---
+
 ## 8.7.1
 
 ### Bug fixes

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -35,7 +35,7 @@ const columns = [
 - [Column Resizing](https://reactdatatable.com/docs/resizable): drag column edges by mouse or touch, persist widths
 - [Column Pinning](https://reactdatatable.com/docs/column-pinning): pin columns left or right
 - [Column Separators](https://reactdatatable.com/docs/column-separators): vertical divider lines between header and body columns
-- [Column Filtering](https://reactdatatable.com/docs/filtering): per-column text, number, and select filters
+- [Column Filtering](https://reactdatatable.com/docs/filtering): per-column text, number, date, datetime, and time-of-day filters with operator selection and two-condition AND/OR logic
 - [Sorting](https://reactdatatable.com/docs/sorting): client-side and server-side sorting
 
 ## Rows

--- a/apps/docs/src/components/demos/FilteringDemo.tsx
+++ b/apps/docs/src/components/demos/FilteringDemo.tsx
@@ -21,6 +21,24 @@ const data: Employee[] = [
 	{ id: 8, name: 'Casey Park', department: 'Design', salary: 109000, hired: '2022-11-19' },
 	{ id: 9, name: 'Drew Santos', department: 'Product', salary: 138000, hired: '2020-03-30' },
 	{ id: 10, name: 'Avery Johnson', department: 'Sales', salary: 104000, hired: '2021-08-14' },
+	{ id: 11, name: 'Riley Nguyen', department: 'Engineering', salary: 149000, hired: '2019-06-24' },
+	{ id: 12, name: 'Jamie Foster', department: 'Analytics', salary: 121000, hired: '2021-10-03' },
+	{ id: 13, name: 'Quinn Alvarez', department: 'Product', salary: 145000, hired: '2018-05-17' },
+	{ id: 14, name: 'Reese Kim', department: 'Design', salary: 112000, hired: '2023-01-09' },
+	{ id: 15, name: 'Devon Wright', department: 'Engineering', salary: 158000, hired: '2016-12-01' },
+	{ id: 16, name: 'Harper Diaz', department: 'Sales', salary: 99000, hired: '2022-06-28' },
+	{ id: 17, name: 'Emerson Cole', department: 'Analytics', salary: 136000, hired: '2020-09-11' },
+	{ id: 18, name: 'Sasha Petrov', department: 'Engineering', salary: 141000, hired: '2021-03-19' },
+	{ id: 19, name: 'Blake Turner', department: 'Product', salary: 127000, hired: '2019-11-25' },
+	{ id: 20, name: 'Rowan Mitchell', department: 'Design', salary: 115000, hired: '2022-08-02' },
+	{ id: 21, name: 'Kai Nakamura', department: 'Engineering', salary: 167000, hired: '2017-04-14' },
+	{ id: 22, name: 'Logan Reyes', department: 'Sales', salary: 102000, hired: '2023-05-30' },
+	{ id: 23, name: 'Skyler Bennett', department: 'Analytics', salary: 139000, hired: '2018-08-21' },
+	{ id: 24, name: 'Parker Hughes', department: 'Product', salary: 133000, hired: '2020-02-06' },
+	{ id: 25, name: 'Elliot Ramos', department: 'Design', salary: 121000, hired: '2021-12-13' },
+	{ id: 26, name: 'Dakota Silva', department: 'Engineering', salary: 152000, hired: '2019-07-08' },
+	{ id: 27, name: 'Micah Owens', department: 'Sales', salary: 96000, hired: '2022-10-17' },
+	{ id: 28, name: 'Finley Grant', department: 'Analytics', salary: 147000, hired: '2017-11-29' },
 ];
 
 const columns: TableColumn<Employee>[] = [
@@ -60,5 +78,14 @@ const columns: TableColumn<Employee>[] = [
 ];
 
 export default function FilteringDemo() {
-	return <DataTable columns={columns} data={data} highlightOnHover defaultSortFieldId="name" />;
+	return (
+		<DataTable
+			columns={columns}
+			data={data}
+			highlightOnHover
+			defaultSortFieldId="name"
+			pagination
+			paginationPerPage={10}
+		/>
+	);
 }

--- a/apps/docs/src/components/demos/TimeFilterDemo.tsx
+++ b/apps/docs/src/components/demos/TimeFilterDemo.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import DataTable from '../ThemedDataTable';
+import { type TableColumn } from 'react-data-table-component';
+
+interface LogEntry {
+	id: number;
+	service: string;
+	level: 'info' | 'warn' | 'error';
+	message: string;
+	// Full ISO timestamps spanning several days — the time filter reads the
+	// time-of-day and ignores the date, so a window matches across all of them.
+	at: string;
+}
+
+const data: LogEntry[] = [
+	{ id: 1, service: 'auth', level: 'info', message: 'session started', at: '2024-03-01T08:12:04' },
+	{ id: 2, service: 'billing', level: 'warn', message: 'retry scheduled', at: '2024-03-01T23:41:19' },
+	{ id: 3, service: 'cron', level: 'error', message: 'nightly job failed', at: '2024-03-02T02:15:00' },
+	{ id: 4, service: 'api', level: 'info', message: 'request handled', at: '2024-03-02T13:05:47' },
+	{ id: 5, service: 'cron', level: 'error', message: 'nightly job failed', at: '2024-03-03T02:47:31' },
+	{ id: 6, service: 'auth', level: 'info', message: 'session started', at: '2024-03-03T09:30:12' },
+	{ id: 7, service: 'billing', level: 'warn', message: 'card declined', at: '2024-03-03T17:58:00' },
+	{ id: 8, service: 'cron', level: 'error', message: 'nightly job failed', at: '2024-03-04T03:22:09' },
+	{ id: 9, service: 'api', level: 'info', message: 'request handled', at: '2024-03-04T21:14:55' },
+	{ id: 10, service: 'auth', level: 'warn', message: 'rate limited', at: '2024-03-05T00:38:41' },
+];
+
+const levelColor: Record<LogEntry['level'], string> = {
+	info: 'var(--rdt-color-text-muted, #64748b)',
+	warn: '#b45309',
+	error: '#dc2626',
+};
+
+const columns: TableColumn<LogEntry>[] = [
+	{
+		id: 'at',
+		name: 'Time',
+		selector: r => r.at,
+		format: r => r.at.slice(11),
+		sortable: true,
+		filterable: true,
+		filterType: 'time',
+	},
+	{ id: 'service', name: 'Service', selector: r => r.service, sortable: true, filterable: true },
+	{
+		id: 'level',
+		name: 'Level',
+		selector: r => r.level,
+		cell: r => <span style={{ color: levelColor[r.level], fontWeight: 600 }}>{r.level}</span>,
+		sortable: true,
+		filterable: true,
+	},
+	{ id: 'message', name: 'Message', selector: r => r.message, grow: 2 },
+];
+
+export default function TimeFilterDemo() {
+	return <DataTable columns={columns} data={data} highlightOnHover defaultSortFieldId="at" dense />;
+}

--- a/apps/docs/src/pages/docs/api.astro
+++ b/apps/docs/src/pages/docs/api.astro
@@ -132,7 +132,7 @@ const columns: TableColumn<MyRow>[] = [
       ['<code>sortFunction</code>', '<code>(a: T, b: T) =&gt; number</code>', 'Custom comparator for this column.'],
       ['<code>sortField</code>', '<code>string</code>', 'Field key passed to <code>onSort</code> for server-side sort identification.'],
       ['<code>filterable</code>', '<code>boolean</code>', 'Show a filter popup for this column.'],
-      ['<code>filterType</code>', '<code>"text" | "number" | "date"</code>', 'Filter operator set and input widget. Defaults to <code>"text"</code>. See <a href="/docs/filtering">Filtering</a>.'],
+      ['<code>filterType</code>', '<code>"text" | "number" | "date" | "datetime" | "time"</code>', 'Filter operator set and input widget. Defaults to <code>"text"</code>. See <a href="/docs/filtering">Filtering</a>.'],
       ['<code>filterFunction</code>', '<code>(row, filter: FilterState) =&gt; boolean</code>', 'Custom filter predicate. Overrides built-in operator logic. Receives the full <code>FilterState</code> including both conditions.'],
       ['<code>width</code>', '<code>string</code>', 'Fixed column width, e.g. <code>"120px"</code>.'],
       ['<code>minWidth</code>', '<code>string</code>', 'Minimum width.'],

--- a/apps/docs/src/pages/docs/filtering.astro
+++ b/apps/docs/src/pages/docs/filtering.astro
@@ -3,6 +3,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
 import Demo from '../../components/Demo.astro';
 import CodeBlock from '../../components/CodeBlock.astro';
 import FilteringDemo from '../../components/demos/FilteringDemo.tsx';
+import TimeFilterDemo from '../../components/demos/TimeFilterDemo.tsx';
 import DocsTable from '../../components/DocsTable.astro';
 import PropsTable from '../../components/PropsTable.astro';
 ---
@@ -58,11 +59,18 @@ const columns: TableColumn<Employee>[] = [
 ];
 
 export default function App() {
-  return <DataTable columns={columns} data={data} highlightOnHover />;
+  return <DataTable columns={columns} data={data} highlightOnHover pagination paginationPerPage={10} />;
 }`}
   >
     <FilteringDemo client:load />
   </Demo>
+
+  <p>
+    Filtering runs on the full dataset before pagination, so a filter matches rows on every
+    page, not just the one you are viewing. The result count and page navigation update to the
+    filtered set. This applies to client-side pagination; see the
+    <a href="/docs/recipes/server-side">server-side recipe</a> for the server case.
+  </p>
 
   <h2>Quick start</h2>
   <p>
@@ -84,6 +92,8 @@ export default function App() {
   { id: 'name', name: 'Name', selector: r => r.name, filterable: true },
   { id: 'score', name: 'Score', selector: r => r.score, filterable: true, filterType: 'number' },
   { id: 'dob', name: 'Birth date', selector: r => r.dob, filterable: true, filterType: 'date' },
+  { id: 'seen', name: 'Last seen', selector: r => r.seen, filterable: true, filterType: 'datetime' },
+  { id: 'ranAt', name: 'Ran at', selector: r => r.ranAt, filterable: true, filterType: 'time' },
 ];`} />
 
   <DocsTable
@@ -92,14 +102,47 @@ export default function App() {
       ['<code>"text"</code> (default)', 'Contains', 'Text', 'Contains, Does not contain, Equals, Does not equal, Begins with, Ends with, Blank, Not blank'],
       ['<code>"number"</code>', 'Equals', 'Number', 'Equals, Does not equal, Greater than, ≥, Less than, ≤, Between, Blank, Not blank'],
       ['<code>"date"</code>', 'Equals', 'Date', 'Equals, Before, After, Between, Blank, Not blank'],
+      ['<code>"datetime"</code>', 'Equals', 'Date &amp; time', 'Equals, Before, After, Between, Blank, Not blank'],
+      ['<code>"time"</code>', 'Equals', 'Time', 'Equals, Before, After, Between, Blank, Not blank'],
     ]}
   />
 
   <p>
     <strong>Blank / Not blank</strong> match on empty cells and need no value input.
-    <strong>Between</strong> (number and date) shows two value inputs for inclusive bounds.
-    For <code>"date"</code> columns, <code>selector</code> should return an ISO string (<code>"2024-03-15"</code>) or any value parseable by <code>new Date()</code>.
+    <strong>Between</strong> (number, date, datetime, and time) shows two value inputs for inclusive bounds.
+    For <code>"date"</code> and <code>"datetime"</code> columns, <code>selector</code> should return an ISO string (<code>"2024-03-15"</code> or <code>"2024-03-15T14:30"</code>) or any value parseable by <code>new Date()</code>.
   </p>
+  <p>
+    <code>"date"</code> compares by calendar day, so <strong>Equals</strong> matches any time on that day.
+    <code>"datetime"</code> compares the exact instant, so <strong>Equals</strong> matches a specific minute. Because
+    <code>datetime-local</code> inputs are timezone-naive, filtering is exact only when your cell values are also local
+    time (no <code>Z</code> / offset); otherwise supply a <code>filterFunction</code>.
+  </p>
+  <p>
+    <code>"time"</code> compares the <em>time of day</em> and ignores the date, so it filters across every date at once
+    — useful for logs (&ldquo;anything after 17:00&rdquo;, &ldquo;errors between 02:00 and 04:00&rdquo;). The input
+    accepts seconds, and the cell value may be a bare time (<code>"17:30"</code>) or any timestamp whose time portion
+    is read (<code>"2024-03-15T17:30:45"</code>). A <strong>Between</strong> whose start is later than its end wraps
+    past midnight, so <code>22:00</code>–<code>06:00</code> matches an overnight window.
+  </p>
+
+  <Demo
+    title="Time-of-day filter"
+    description="Log rows across several days. Open the Time filter, choose Between, and enter 02:00 and 04:00 to surface the nightly cron failures regardless of date. Try 22:00 to 06:00 for an overnight window that wraps past midnight."
+    code={`const columns: TableColumn<LogEntry>[] = [
+  {
+    id: 'at',
+    name: 'Time',
+    selector: r => r.at,               // full ISO timestamp
+    format: r => r.at.slice(11),       // show just the time
+    filterable: true,
+    filterType: 'time',                // filters by time of day, ignoring the date
+  },
+  // ...
+];`}
+  >
+    <TimeFilterDemo client:load />
+  </Demo>
 
   <h2>Two conditions per column</h2>
   <p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-data-table-component",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-data-table-component",
-      "version": "8.7.0",
+      "version": "8.7.1",
       "funding": [
         {
           "type": "github",
@@ -35,7 +35,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "jsdom": "^29.1.1",
-        "prettier": "^3.9.5",
+        "prettier": "^3.9.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "tsup": "^8.5.1",
@@ -2652,16 +2652,13 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -2922,9 +2919,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.43",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
-      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.0.tgz",
+      "integrity": "sha512-oCu2wfipvX3AePSgmOuKkIywOu+8n9psz7hXYmk56ghpu3+7KzNIBopaOs4c9BrtdnTtW30unG9GTfHo7EwERQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2958,9 +2955,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
-      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -2978,9 +2975,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.42",
-        "caniuse-lite": "^1.0.30001803",
-        "electron-to-chromium": "^1.5.389",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
         "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
@@ -3078,9 +3075,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001805",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
-      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -3109,33 +3106,16 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -3229,19 +3209,6 @@
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-      }
-    },
-    "node_modules/concurrently/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/confbox": {
@@ -3510,9 +3477,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.391",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.391.tgz",
-      "integrity": "sha512-YmCu4856jkgKT1Nh6fwRdeVrM6Ydf/fBnq51tpmSfX+jOcUMTxh31yH6hjKScRenhB2oDSvA9oooxcpjogPeig==",
+      "version": "1.5.395",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.395.tgz",
+      "integrity": "sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4109,6 +4076,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/eslint/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4125,6 +4108,23 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -4161,6 +4161,19 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/eslint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/espree": {
@@ -5481,9 +5494,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -5497,23 +5510,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -5532,9 +5545,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -5553,9 +5566,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -5574,9 +5587,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -5595,9 +5608,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -5616,9 +5629,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -5640,9 +5653,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -5664,9 +5677,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -5688,9 +5701,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -5712,9 +5725,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -5733,9 +5746,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -6126,9 +6139,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -6158,13 +6171,14 @@
       }
     },
     "node_modules/own-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.6",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "object-keys": "^1.1.1",
         "safe-push-apply": "^1.0.0"
       },
@@ -6320,9 +6334,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
+      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
       "dev": true,
       "funding": [
         {
@@ -6340,7 +6354,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6402,9 +6416,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
-      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6443,19 +6457,6 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/prop-types": {
@@ -7364,22 +7365,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.4.8",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
-      "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.8"
+        "tldts-core": "^7.4.9"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.8",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
-      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7692,16 +7693,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "jsdom": "^29.1.1",
-    "prettier": "^3.9.5",
+    "prettier": "^3.9.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tsup": "^8.5.1",

--- a/src/__tests__/ColumnFilter.test.tsx
+++ b/src/__tests__/ColumnFilter.test.tsx
@@ -286,6 +286,47 @@ describe('ColumnFilter:date filter type', () => {
 	});
 });
 
+describe('ColumnFilter:datetime filter type', () => {
+	test('renders datetime-local inputs and the date operator set', () => {
+		const { container } = setup({ filterType: 'datetime', filterValue: emptyFilterState('datetime') });
+		openPanel(container);
+
+		const input = container.querySelector('input[aria-label="Filter value"]') as HTMLInputElement;
+		expect(input.type).toBe('datetime-local');
+
+		const opts = Array.from(container.querySelectorAll('select[aria-label="Filter operator"] option')).map(
+			o => o.textContent,
+		);
+		expect(opts).toEqual(['Equals', 'Before', 'After', 'Between', 'Blank', 'Not blank']);
+	});
+});
+
+describe('ColumnFilter:time filter type', () => {
+	test('renders a time input with seconds precision and the date operator set', () => {
+		const { container } = setup({ filterType: 'time', filterValue: emptyFilterState('time') });
+		openPanel(container);
+
+		const input = container.querySelector('input[aria-label="Filter value"]') as HTMLInputElement;
+		expect(input.type).toBe('time');
+		expect(input.step).toBe('1');
+
+		const opts = Array.from(container.querySelectorAll('select[aria-label="Filter operator"] option')).map(
+			o => o.textContent,
+		);
+		expect(opts).toEqual(['Equals', 'Before', 'After', 'Between', 'Blank', 'Not blank']);
+	});
+
+	test('between shows two time inputs', () => {
+		const { container } = setup({ filterType: 'time', filterValue: emptyFilterState('time') });
+		openPanel(container);
+		fireEvent.change(container.querySelector('select[aria-label="Filter operator"]') as HTMLSelectElement, {
+			target: { value: 'between' },
+		});
+		const inputs = container.querySelectorAll('input[type="time"]');
+		expect(inputs).toHaveLength(2);
+	});
+});
+
 describe('ColumnFilter:localization (options prop)', () => {
 	const options = {
 		filterColumnAriaLabel: 'test-filter-col',

--- a/src/__tests__/DataTable.test.tsx
+++ b/src/__tests__/DataTable.test.tsx
@@ -2789,6 +2789,18 @@ describe('DataTable::columnFilter', () => {
 		});
 	});
 
+	test('filters a filterable column that has no explicit id', () => {
+		const data = [{ name: 'Apple' }, { name: 'Banana' }];
+		const columns = [{ name: 'Name', selector: (row: (typeof data)[0]) => row.name, filterable: true }];
+		const { container } = render(<DataTable data={data} columns={columns} keyField="name" />);
+
+		fireEvent.click(container.querySelector('.rdt_filterIcon') as HTMLButtonElement);
+		fireEvent.change(container.querySelector('.rdt_filterInput') as HTMLInputElement, { target: { value: 'ban' } });
+		fireEvent.click(container.querySelector('.rdt_filterBtnPrimary') as HTMLButtonElement);
+
+		expect(container.querySelectorAll('.rdt_TableBody [role="row"]').length).toBe(1);
+	});
+
 	test('keeps table head visible when a filter matches no rows', () => {
 		const data = [
 			{ id: 1, some: { name: 'Apple' } },
@@ -2811,6 +2823,46 @@ describe('DataTable::columnFilter', () => {
 		// The head must persist so the filter can be cleared
 		expect(container.querySelector('.rdt_TableHead')).not.toBeNull();
 		expect(container.querySelector('.rdt_filterIcon')).not.toBeNull();
+	});
+
+	test('with client pagination, a filter matches across all pages, not just the current one', () => {
+		const data = Array.from({ length: 20 }, (_, i) => ({
+			id: i + 1,
+			name: i % 2 === 0 ? 'match' : 'other',
+		}));
+		const columns = [{ name: 'Name', id: 'name', selector: (row: (typeof data)[0]) => row.name, filterable: true }];
+		const { container } = render(<DataTable data={data} columns={columns} pagination paginationPerPage={10} />);
+
+		fireEvent.click(container.querySelector('.rdt_filterIcon') as HTMLButtonElement);
+		fireEvent.change(container.querySelector('.rdt_filterInput') as HTMLInputElement, {
+			target: { value: 'match' },
+		});
+		fireEvent.click(container.querySelector('.rdt_filterBtnPrimary') as HTMLButtonElement);
+
+		// 10 rows match across the whole set; all fit on the first filtered page.
+		expect(container.querySelectorAll('.rdt_TableBody [role="row"]').length).toBe(10);
+	});
+
+	test('filtering on a later page clamps back to a page with results', () => {
+		const data = Array.from({ length: 30 }, (_, i) => ({
+			id: i + 1,
+			// only rows 1-3 match; they live on page 1
+			name: i < 3 ? 'apple' : 'other',
+		}));
+		const columns = [{ name: 'Name', id: 'name', selector: (row: (typeof data)[0]) => row.name, filterable: true }];
+		const { container } = render(<DataTable data={data} columns={columns} pagination paginationPerPage={10} />);
+
+		// Go to the last page, then filter — the matches only exist on page 1
+		fireEvent.click(container.querySelector('#pagination-last-page') as HTMLButtonElement);
+
+		fireEvent.click(container.querySelector('.rdt_filterIcon') as HTMLButtonElement);
+		fireEvent.change(container.querySelector('.rdt_filterInput') as HTMLInputElement, {
+			target: { value: 'apple' },
+		});
+		fireEvent.click(container.querySelector('.rdt_filterBtnPrimary') as HTMLButtonElement);
+
+		// Page clamps back so the 3 matches render rather than an empty page
+		expect(container.querySelectorAll('.rdt_TableBody [role="row"]').length).toBe(3);
 	});
 
 	test('clears filter when Clear button is clicked', () => {

--- a/src/__tests__/useColumnFilter.test.ts
+++ b/src/__tests__/useColumnFilter.test.ts
@@ -211,6 +211,90 @@ describe('useColumnFilter:date operators', () => {
 	});
 });
 
+describe('useColumnFilter:datetime operators', () => {
+	type Event = { id: number; at: string };
+	const events: Event[] = [
+		{ id: 1, at: '2024-01-01T09:00' },
+		{ id: 2, at: '2024-01-01T15:30' },
+		{ id: 3, at: '2024-01-01T15:30:45' },
+		{ id: 4, at: '2024-01-02T08:00' },
+	];
+	const cols: TableColumn<Event>[] = [
+		{ id: 'at', name: 'At', selector: r => r.at, filterable: true, filterType: 'datetime' },
+	];
+	const setFilter = (filter: FilterState) => {
+		const { result } = renderHook(() => useColumnFilter<Event>(cols, { at: filter }));
+		return result.current.filteredData(events);
+	};
+
+	test('equals matches the exact instant, not the whole day', () => {
+		expect(setFilter({ condition1: { operator: 'equals', value: '2024-01-01T15:30' } }).map(r => r.id)).toEqual([2]);
+	});
+
+	test('before / after compare on time of day', () => {
+		expect(setFilter({ condition1: { operator: 'before', value: '2024-01-01T12:00' } }).map(r => r.id)).toEqual([1]);
+		expect(setFilter({ condition1: { operator: 'after', value: '2024-01-01T12:00' } }).map(r => r.id)).toEqual([
+			2, 3, 4,
+		]);
+	});
+
+	test('between bounds a time window across days', () => {
+		expect(
+			setFilter({
+				condition1: { operator: 'between', value: '2024-01-01T15:00', value2: '2024-01-02T09:00' },
+			}).map(r => r.id),
+		).toEqual([2, 3, 4]);
+	});
+});
+
+describe('useColumnFilter:time operators', () => {
+	// Same clock times spread across different days — the date must be ignored.
+	type Log = { id: number; ts: string };
+	const logs: Log[] = [
+		{ id: 1, ts: '2024-01-01T03:15:00' },
+		{ id: 2, ts: '2024-02-14T09:30:00' },
+		{ id: 3, ts: '2024-03-20T17:45:30' },
+		{ id: 4, ts: '2024-04-01T23:10:00' },
+		{ id: 5, ts: '2024-05-05T00:20:00' },
+	];
+	const cols: TableColumn<Log>[] = [
+		{ id: 'ts', name: 'Timestamp', selector: r => r.ts, filterable: true, filterType: 'time' },
+	];
+	const setFilter = (filter: FilterState) => {
+		const { result } = renderHook(() => useColumnFilter<Log>(cols, { ts: filter }));
+		return result.current.filteredData(logs).map(r => r.id);
+	};
+
+	test('after matches a time of day on every date', () => {
+		expect(setFilter({ condition1: { operator: 'after', value: '17:00' } })).toEqual([3, 4]);
+	});
+
+	test('before ignores the date component', () => {
+		expect(setFilter({ condition1: { operator: 'before', value: '09:30' } })).toEqual([1, 5]);
+	});
+
+	test('equals matches to the second', () => {
+		expect(setFilter({ condition1: { operator: 'equals', value: '17:45:30' } })).toEqual([3]);
+		expect(setFilter({ condition1: { operator: 'equals', value: '17:45' } })).toEqual([]);
+	});
+
+	test('between bounds a normal daytime window', () => {
+		expect(setFilter({ condition1: { operator: 'between', value: '09:00', value2: '18:00' } })).toEqual([2, 3]);
+	});
+
+	test('between wraps past midnight when start is later than end', () => {
+		// Overnight window 22:00–06:00 matches late-night and early-morning rows
+		expect(setFilter({ condition1: { operator: 'between', value: '22:00', value2: '06:00' } })).toEqual([1, 4, 5]);
+	});
+
+	test('non-time cell values do not match', () => {
+		const { result } = renderHook(() =>
+			useColumnFilter<Log>(cols, { ts: { condition1: { operator: 'after', value: '00:00' } } }),
+		);
+		expect(result.current.filteredData([{ id: 9, ts: 'not a time' }])).toEqual([]);
+	});
+});
+
 describe('useColumnFilter:condition combinators', () => {
 	const setFilter = (filter: FilterState) => {
 		const { result } = renderHook(() => useColumnFilter<Row>(columns, { name: filter }));

--- a/src/components/ColumnFilter.tsx
+++ b/src/components/ColumnFilter.tsx
@@ -43,7 +43,7 @@ function operatorsFor(filterType: FilterType, overrides?: ColumnFilterOptions['o
 	const base =
 		filterType === 'number'
 			? DEFAULT_NUMBER_OPERATORS
-			: filterType === 'date'
+			: filterType === 'date' || filterType === 'datetime' || filterType === 'time'
 				? DEFAULT_DATE_OPERATORS
 				: DEFAULT_TEXT_OPERATORS;
 	if (!overrides) return base;
@@ -75,7 +75,19 @@ type ConditionRowProps = {
 function ConditionRow({ condition, filterType, options, onChange, onRemove }: ConditionRowProps): JSX.Element {
 	const operators = operatorsFor(filterType, options.operators);
 	const selected = operators.find(o => o.value === condition.operator) ?? operators[0];
-	const inputType = filterType === 'number' ? 'number' : filterType === 'date' ? 'date' : 'text';
+	const inputType =
+		filterType === 'number'
+			? 'number'
+			: filterType === 'date'
+				? 'date'
+				: filterType === 'datetime'
+					? 'datetime-local'
+					: filterType === 'time'
+						? 'time'
+						: 'text';
+	// Time inputs default to minute precision; step=1 exposes a seconds field so
+	// logs can be filtered to the second.
+	const inputStep = filterType === 'time' ? 1 : undefined;
 
 	return (
 		<div className="rdt_filterConditionRow">
@@ -96,6 +108,7 @@ function ConditionRow({ condition, filterType, options, onChange, onRemove }: Co
 				<input
 					className="rdt_filterInput"
 					type={inputType}
+					step={inputStep}
 					value={condition.value ?? ''}
 					placeholder={options.valuePlaceholder ?? 'Value'}
 					onChange={e => onChange({ ...condition, value: e.target.value })}
@@ -110,6 +123,7 @@ function ConditionRow({ condition, filterType, options, onChange, onRemove }: Co
 					<input
 						className="rdt_filterInput"
 						type={inputType}
+						step={inputStep}
 						value={condition.value2 ?? ''}
 						placeholder={options.value2Placeholder ?? 'Value'}
 						onChange={e => onChange({ ...condition, value2: e.target.value })}

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -187,12 +187,6 @@ function DataTableInner<T>(props: TableProps<T>, ref: React.ForwardedRef<DataTab
 	}, []);
 
 	const tableId = React.useId();
-	const { filterValues, handleFilterChange, filteredData, filtering } = useColumnFilter(
-		columns,
-		controlledFilterValues,
-		onFilterChangeProp,
-		localization.filter,
-	);
 
 	// ── Column resize state ────────────────────────────────────────────────────
 	const isRTL = useRTL(direction);
@@ -217,6 +211,16 @@ function DataTableInner<T>(props: TableProps<T>, ref: React.ForwardedRef<DataTab
 		columnGroups,
 		defaultSortFieldId,
 		defaultSortAsc,
+	);
+
+	// Filter against the decorated columns (ids auto-assigned by useColumns) so the
+	// head, matcher, and context-menu keying all agree — a column with no explicit
+	// id still filters. Passing raw `columns` here would leave them id-less.
+	const { filterValues, handleFilterChange, filteredData, filtering } = useColumnFilter(
+		tableColumns,
+		controlledFilterValues,
+		onFilterChangeProp,
+		localization.filter,
 	);
 
 	const { effectiveColumns, pinnedOffsets, pinnedTotalWidths, hasPinnedColumns } = useColumnPinning({
@@ -296,8 +300,18 @@ function DataTableInner<T>(props: TableProps<T>, ref: React.ForwardedRef<DataTab
 	});
 
 	// ── Client-side column filtering ───────────────────────────────────────────
+	// Filtering must run on the full sorted set *before* pagination slices it,
+	// otherwise a filter only ever matches rows on the current page. For client
+	// pagination we therefore slice filteredSortedData ourselves; server pagination
+	// and the no-pagination case pass tableRows (already the full set) through.
 	const filteredSortedData = React.useMemo(() => filteredData(sortedData), [filteredData, sortedData]);
-	const filteredTableRows = React.useMemo(() => filteredData(tableRows), [filteredData, tableRows]);
+	const filteredTableRows = React.useMemo(() => {
+		if (pagination && !paginationServer) {
+			const lastIndex = currentPage * rowsPerPage;
+			return filteredSortedData.slice(lastIndex - rowsPerPage, lastIndex);
+		}
+		return filteredData(tableRows);
+	}, [pagination, paginationServer, currentPage, rowsPerPage, filteredSortedData, filteredData, tableRows]);
 
 	const { persistSelectedOnSort = false, persistSelectedOnPageChange = false } = paginationServerOptions;
 	const mergeSelections = !!(paginationServer && (persistSelectedOnPageChange || persistSelectedOnSort));

--- a/src/hooks/useColumnFilter.ts
+++ b/src/hooks/useColumnFilter.ts
@@ -35,11 +35,48 @@ export function isFilterActive(filter: FilterState): boolean {
 	return isConditionActive(filter.condition1) || (!!filter.condition2 && isConditionActive(filter.condition2));
 }
 
+// Seconds since midnight for a clock time, ignoring any date component.
+// Accepts a bare time ("17:30", "17:30:45") or a full timestamp whose time
+// portion is extracted ("2024-01-01T17:30:00", "2024-01-01 17:30"). Returns
+// null when no HH:MM can be found.
+function timeOfDaySeconds(raw: string): number | null {
+	const match = raw.match(/(\d{1,2}):(\d{2})(?::(\d{2}))?/);
+	if (!match) return null;
+	const h = Number(match[1]);
+	const m = Number(match[2]);
+	const s = match[3] ? Number(match[3]) : 0;
+	if (h > 23 || m > 59 || s > 59) return null;
+	return h * 3600 + m * 60 + s;
+}
+
 function applyCondition(condition: FilterCondition, cellValue: string, filterType: FilterType): boolean {
 	const { operator, value = '', value2 = '' } = condition;
 
 	if (operator === 'blank') return cellValue.trim() === '';
 	if (operator === 'notBlank') return cellValue.trim() !== '';
+
+	if (filterType === 'time') {
+		const t = timeOfDaySeconds(cellValue);
+		if (t === null) return false;
+		const t1 = timeOfDaySeconds(value);
+		const t2 = timeOfDaySeconds(value2);
+		switch (operator) {
+			case 'equals':
+				return t1 !== null && t === t1;
+			case 'before':
+				return t1 !== null && t < t1;
+			case 'after':
+				return t1 !== null && t > t1;
+			case 'between':
+				if (t1 === null) return t2 === null || t <= t2;
+				if (t2 === null) return t >= t1;
+				// A start later than the end is a window that wraps past midnight
+				// (e.g. 22:00–06:00), so match times outside the [t2, t1] gap.
+				return t1 <= t2 ? t >= t1 && t <= t2 : t >= t1 || t <= t2;
+			default:
+				return true;
+		}
+	}
 
 	if (filterType === 'number') {
 		const num = parseFloat(cellValue);
@@ -67,14 +104,15 @@ function applyCondition(condition: FilterCondition, cellValue: string, filterTyp
 		}
 	}
 
-	if (filterType === 'date') {
+	if (filterType === 'date' || filterType === 'datetime') {
 		const d = new Date(cellValue);
 		if (isNaN(d.getTime())) return false;
 		const d1 = new Date(value);
 		const d2 = new Date(value2);
 		switch (operator) {
 			case 'equals':
-				return d.toDateString() === d1.toDateString();
+				// date matches the whole calendar day; datetime matches the exact instant
+				return filterType === 'datetime' ? d.getTime() === d1.getTime() : d.toDateString() === d1.toDateString();
 			case 'before':
 				return d < d1;
 			case 'after':

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export type CSSObject = React.CSSProperties;
 
 // ── Column filter types ────────────────────────────────────────────────────────
 
-export type FilterType = 'text' | 'number' | 'date';
+export type FilterType = 'text' | 'number' | 'date' | 'datetime' | 'time';
 
 export type FilterOperator =
 	| 'contains'


### PR DESCRIPTION

- filterType 'datetime' (#1362) and 'time' with wrap-around between
- filter across all pages, not just current, with client pagination (#1364)
- filter columns without an explicit id (#1363)

Closes #1362 #1363 #1364 #1366 
