### PR TITLE
fix(selection): use the controlled selectedRows prop as the delta base

### DIFF
--- a/src/__tests__/DataTable.test.tsx
+++ b/src/__tests__/DataTable.test.tsx
@@ -255,6 +255,42 @@ describe('DataTable::onSelectedRowsChange', () => {
 	});
 });
 
+describe('DataTable::controlled selectedRows', () => {
+	test('should call onSelectedRowsChange with the correct values when a row is toggled while another is selected via the controlled selectedRows prop', () => {
+		const mock = dataMock();
+		const onSelectedRowsChange = vi.fn();
+
+		const { container, rerender } = render(
+			<DataTable
+				data={mock.data}
+				columns={mock.columns}
+				keyField="id"
+				selectableRows
+				selectedRows={[]}
+				onSelectedRowsChange={onSelectedRowsChange}
+			/>,
+		);
+
+		rerender(
+			<DataTable
+				data={mock.data}
+				columns={mock.columns}
+				keyField="id"
+				selectableRows
+				selectedRows={[mock.data[0]]}
+				onSelectedRowsChange={onSelectedRowsChange}
+			/>,
+		);
+
+		fireEvent.click(container.querySelector('input[name="Select row 2"]') as HTMLInputElement);
+
+		const calls = onSelectedRowsChange.mock.calls;
+		const lastCall = calls[calls.length - 1][0];
+		expect(lastCall.selectedCount).toBe(2);
+		expect(lastCall.selectedRows.map((row: { id: number }) => row.id).sort()).toEqual([1, 2]);
+	});
+});
+
 describe('data prop changes', () => {
 	test('should update state if the data prop changes', () => {
 		const mock = dataMock();

--- a/src/hooks/useTableState.ts
+++ b/src/hooks/useTableState.ts
@@ -93,7 +93,17 @@ export default function useTableState<T>(props: UseTableStateProps<T>): UseTable
 
 	const hasDefaultSort = defaultSortColumn.id != null || !!defaultSortColumn.selector;
 
-	const [tableState, dispatch] = React.useReducer<React.Reducer<TableState<T>, Action<T>>>(tableReducer, {
+	const reducer = React.useCallback(
+		(state: TableState<T>, action: Action<T>): TableState<T> => {
+			const calculatedState =
+				controlledSelectedRows !== undefined ? { ...state, selectedRows: controlledSelectedRows } : state;
+
+			return tableReducer(calculatedState, action);
+		},
+		[controlledSelectedRows],
+	);
+
+	const [tableState, dispatch] = React.useReducer(reducer, {
 		allSelected: false,
 		selectedCount: 0,
 		selectedRows: [],


### PR DESCRIPTION
## Summary

Controlled selection deltas are computed from internal reducer state, which is never reconciled with the `selectedRows` prop — so an externally-set selection is dropped on the next in-table toggle and `onSelectedRowsChange` emits the wrong set. This wraps the reducer so that, when controlled, it computes against the prop instead of stale internal state. Uncontrolled behavior is unchanged.

Fixes #1374

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation / example update
- [ ] Refactor / internal cleanup

## Checklist

- [x] I read CONTRIBUTING.md
- [x] I agree to the Code of Conduct
- [x] Tests pass (`npm test`)
- [x] No TypeScript errors (`npm run typecheck`)
- [x] I have updated docs or examples if needed (no doc change required — behavior of the existing `selectedRows` prop)

## How to test

1. Render a `DataTable` with `selectableRows`, a controlled `selectedRows`, and `onSelectedRowsChange` writing back to that state.
2. Set `selectedRows` to `[rowA]` from outside the table.
3. Toggle `rowB`'s checkbox → selection should be `[rowA, rowB]` (was `[rowB]` before this fix).
4. Or run the added regression test under `DataTable::controlled selectedRows`.
