### PR TITLE
fix: keep column filter popup within the viewport

### DIFF
--- a/src/DataTable.css
+++ b/src/DataTable.css
@@ -452,8 +452,10 @@
 	border-radius: var(--rdt-border-radius, 6px);
 	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14);
 	padding: 10px;
-	min-width: 260px;
-	max-width: calc(100vw - 24px);
+	min-width: min(260px, calc(100vw - 16px));
+	max-width: calc(100vw - 16px);
+	max-height: calc(100vh - 16px);
+	overflow: auto;
 	box-sizing: border-box;
 }
 

--- a/src/__tests__/ColumnFilter.position.test.tsx
+++ b/src/__tests__/ColumnFilter.position.test.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import ColumnFilter from '../components/ColumnFilter';
+import { emptyFilterState } from '../hooks/useColumnFilter';
+
+describe('ColumnFilter:viewport positioning', () => {
+	let anchor: DOMRect;
+	let panelWidth: number;
+	let panelHeight: number;
+
+	beforeEach(() => {
+		vi.stubGlobal('innerWidth', 800);
+		vi.stubGlobal('innerHeight', 600);
+		anchor = new DOMRect(40, 40, 22, 22);
+		panelWidth = 340;
+		panelHeight = 160;
+		vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+			if (this.classList.contains('rdt_filterIcon')) {
+				return anchor;
+			}
+			return new DOMRect(0, 0, panelWidth, panelHeight);
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+	});
+
+	function openPanel() {
+		const result = render(
+			<ColumnFilter columnId="name" filterValue={emptyFilterState('text')} onFilterChange={vi.fn()} />,
+		);
+		fireEvent.click(result.getByRole('button', { name: 'Filter column' }));
+		return { ...result, panel: result.getByRole('dialog') };
+	}
+
+	test('keeps the below-anchor position when it fits', () => {
+		const { panel } = openPanel();
+		expect(panel.style.left).toBe('40px');
+		expect(panel.style.top).toBe('66px');
+	});
+
+	test('uses the measured width at the right viewport edge', () => {
+		anchor = new DOMRect(760, 40, 22, 22);
+		const { panel } = openPanel();
+		expect(panel.style.left).toBe('452px');
+	});
+
+	test('keeps a left-scrolled anchor inside the viewport', () => {
+		anchor = new DOMRect(-100, 40, 22, 22);
+		const { panel } = openPanel();
+		expect(panel.style.left).toBe('8px');
+	});
+
+	test('flips above an anchor near the bottom edge', () => {
+		anchor = new DOMRect(40, 560, 22, 22);
+		const { panel } = openPanel();
+		expect(panel.style.top).toBe('396px');
+	});
+
+	test('fits within the viewport when neither side of the anchor has enough room', () => {
+		anchor = new DOMRect(40, 280, 22, 22);
+		panelHeight = 400;
+		const { panel } = openPanel();
+		expect(panel.style.top).toBe('192px');
+	});
+
+	test('repositions when adding a condition makes the panel taller and wider', () => {
+		anchor = new DOMRect(450, 380, 22, 22);
+		const { panel, getByRole } = openPanel();
+		expect(panel.style.top).toBe('406px');
+		panelWidth = 450;
+		panelHeight = 260;
+		fireEvent.click(getByRole('button', { name: 'Add a second filter condition' }));
+		expect(panel.style.left).toBe('342px');
+		expect(panel.style.top).toBe('116px');
+	});
+});

--- a/src/components/ColumnFilter.tsx
+++ b/src/components/ColumnFilter.tsx
@@ -4,6 +4,7 @@ import type { FilterState, FilterCondition, FilterOperator, FilterType, Localiza
 import { emptyFilterState, isFilterActive, isValueSelected } from '../hooks/useColumnFilter';
 import { emptyCondition, inputTypeFor, operatorsFor } from './filterOperators';
 import FilterIcon from '../icons/FilterIcon';
+import useIsomorphicLayoutEffect from '../hooks/useIsomorphicLayoutEffect';
 
 type ColumnFilterOptions = NonNullable<Localization['filter']>;
 
@@ -297,6 +298,28 @@ export default function ColumnFilter({
 
 	const panelRef = React.useRef<HTMLDivElement>(null);
 
+	// Measure after every render: adding a condition or changing filter content can
+	// resize an open panel. Position before paint without moving focus or remounting.
+	useIsomorphicLayoutEffect(() => {
+		const panel = panelRef.current;
+		const button = buttonRef.current;
+		if (!open || !panel || !button || !panelPos) {
+			return;
+		}
+		const rect = panel.getBoundingClientRect();
+		const anchor = button.getBoundingClientRect();
+		const margin = 8;
+		const left = Math.max(margin, Math.min(anchor.left, window.innerWidth - rect.width - margin));
+		let top = anchor.bottom + 4;
+		if (top + rect.height > window.innerHeight - margin) {
+			const flipped = anchor.top - rect.height - 4;
+			top = flipped >= margin ? flipped : Math.max(margin, window.innerHeight - rect.height - margin);
+		}
+		panel.style.left = `${left}px`;
+		panel.style.top = `${Math.max(margin, top)}px`;
+		panel.style.visibility = 'visible';
+	});
+
 	React.useEffect(() => {
 		if (!open) {
 			return;
@@ -408,15 +431,7 @@ export default function ColumnFilter({
 				setDistinctValues(getDistinctValues(columnId));
 			}
 			const rect = buttonRef.current.getBoundingClientRect();
-			const panelMinWidth = 260;
-			const margin = 8;
-			// Clamp the panel within the viewport on both axes. Anchoring purely to the
-			// button's left/right pushes the panel off-screen for columns near either edge
-			// (common on mobile once the header is horizontally scrolled), which reads as
-			// the menu "not coming up".
-			const maxLeft = window.innerWidth - panelMinWidth - margin;
-			const left = Math.min(Math.max(margin, rect.left), Math.max(margin, maxLeft));
-			setPanelPos({ top: rect.bottom + 4, left });
+			setPanelPos({ top: rect.bottom + 4, left: rect.left });
 		}
 		setOpen(v => !v);
 	}
@@ -448,7 +463,7 @@ export default function ColumnFilter({
 					className="rdt_filterPanel"
 					role="dialog"
 					aria-label={options.filterPanelAriaLabel ?? 'Column filter'}
-					style={{ position: 'fixed', top: panelPos.top, left: panelPos.left }}
+					style={{ position: 'fixed', top: panelPos.top, left: panelPos.left, visibility: 'hidden' }}
 				>
 					{isSet ? (
 						<SetFilterPanel


### PR DESCRIPTION
## Summary

Fixes #1386.

The filter popup is positioned using a hardcoded 260px width and always opens below its button. Its rendered width can be larger (for example, datetime inputs), and a button near the bottom of the viewport leaves the controls off screen.

Measure the rendered panel before paint, using the existing isomorphic layout-effect pattern from ContextMenu. Clamp it with an 8px viewport margin, prefer opening below the button, then flip above or fit within the viewport when necessary. Cap its dimensions and allow internal scrolling in very small viewports. Remeasure after parent renders so adding a condition stays within the viewport.

No public API or dependency changes. Existing dismissal and focus behavior is preserved.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation / example update
- [ ] Refactor / internal cleanup

## Checklist

- [x] I read [CONTRIBUTING.md](https://github.com/jbetancur/react-data-table-component/blob/master/CONTRIBUTING.md)
- [x] I agree to the [Code of Conduct](https://github.com/jbetancur/react-data-table-component/blob/master/CODE-OF-CONDUCT.md)
- [x] Tests pass (`npm test`)
- [x] No TypeScript errors (`npm run typecheck`)
- [x] I have updated docs or examples if needed (not needed: existing behavior is restored; no API changes)

## How to test

- `npm run lint`, `npm run typecheck`, `npm test`: pass, including six new positioning regressions (692 tests total). Four of the new tests fail against the original implementation.
- `npm run build` and `npm run docs:build`: pass. On Windows the existing Git-for-Windows `rm.exe` was made available on the process PATH for the library build.
- Render a filter button near the bottom-right viewport edge, open its popup, and add a second condition. It should stay visible. Repeat with text, number, date, datetime, time, and set filters in a short/narrow viewport; overflowing content should scroll inside the panel.

Additional local headless Edge 152 checks used the actual component and stylesheet, with no browser tooling added to this repository. Across 800x600, 320x240, and 220x120 viewports, all six filter types remained within the 8px boundary, including condition growth and set-list search/reset. Apply, Escape, initial focus, focus return, and resize dismissal passed. At 800x600 the original datetime popup bounds were `(532, 576, 288, 103)` (clipped right/bottom); the fix produced `(504, 443, 288, 103)`.

The reported Firefox/macOS environment was not available locally; the browser reproduction above is Edge on Windows with the repository's React 18 dependency.
